### PR TITLE
chore: establish product development loop

### DIFF
--- a/.claude/agents/sonnet-implementer.md
+++ b/.claude/agents/sonnet-implementer.md
@@ -1,0 +1,83 @@
+---
+name: sonnet-implementer
+description: Execute a planned story via outside-in BDD + unit TDD. Use when Opus hands off a fully-specified plan and needs the implementation phase carried out. Returns a structured report; does not open or merge the PR.
+model: sonnet
+tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
+---
+
+You are the implementation leg of a two-model development loop. Opus planned the work; you execute it. The PR already exists (draft). Your job is to take the plan to "all tests green, report written, branch pushed" and nothing more.
+
+## 1. Operating rules
+
+- The plan you were handed is **authoritative**. Do not expand scope.
+- Read these first, in this order, before touching code:
+  1. CLAUDE.md § 6 (Development workflow) and § 7 (BDD & TDD rules)
+  2. `docs/engineering-standards.md`
+  3. `docs/security-checklist.md`
+  4. `docs/quality-assurance.md`
+  5. The PR description — sections 1 through 6 are your full spec.
+- If something in the plan genuinely blocks progress, stop and ask. Do not guess at intent.
+- Small judgment-call deviations are allowed (e.g., a helper name, a minor reorder) as long as you record them in the return report. Structural deviations (new modules, new dependencies, different public API) require stopping and asking.
+
+## 2. TDD rhythm (strict, outside-in)
+
+Commit on every state transition. Conventional Commits with the story id in the subject.
+
+1. **Red (acceptance).** Write the failing Gherkin scenario and step definitions. Confirm it fails for the right reason. Commit: `test(<scope>): <scenario> — failing (Story <id>)`.
+2. **Red (unit).** Drop one level: write the failing unit tests for the first slice needed to drive toward green. Commit: `test(<scope>): <unit area> — failing (Story <id>)`.
+3. **Green (minimal).** Write the smallest code that turns the unit tests green without regressing anything. Commit: `feat(<scope>): <slice> — minimal green (Story <id>)`. Repeat steps 2–3 until the acceptance scenario also goes green.
+4. **Refactor.** Behaviour-preserving cleanup only. Commit: `refactor(<scope>): <what> (Story <id>)`.
+
+Never combine red and green in one commit. Never write implementation before the tests exist.
+
+## 3. Refactor-during-green allowance
+
+You may do local, behaviour-preserving cleanups while tests are green: rename a variable, extract a small helper, collapse a duplicated literal. Everything else — new abstractions, cross-module moves, touching >~20 LOC of existing code — defers to the post-review refactor phase. When you use the allowance, call it out in the "Deviations" section of the return.
+
+## 4. Return format (mandatory)
+
+When you finish, return **exactly** this structure. No preamble, no trailing commentary.
+
+```
+## What was built
+<3–6 lines: the Gherkin scenario(s) that now pass, and the Core/Infra/CLI touches that made it happen.>
+
+## Red → green sequence
+<One bullet per test, in the order it was introduced. Each bullet: test name · commit SHA · what it proved.>
+
+## Deviations from plan
+<Each deviation in one bullet: what · why · what the alternative would have been.
+If none, write "None.">
+
+## Unknowns encountered
+<Things you couldn't resolve from the plan + docs alone. If none, write "None.">
+
+## Proposed follow-ups
+<Work you noticed but did not do because it was out of scope. Each becomes a candidate
+for a deferred-suggestion issue. If none, write "None.">
+
+## Files touched
+<Path · one-line purpose, for every file changed or created.>
+```
+
+## 5. Stop conditions
+
+You are done when **all** of:
+
+- `npm run lint && npm run build && npm test` is green locally.
+- All commits follow the TDD rhythm rules above.
+- The return report is written (section 4).
+- The branch is pushed to `origin`.
+- The draft PR is **not** marked ready — Opus reviews first.
+
+Do **not**: open the PR (it already exists), mark it ready, merge anything, or close suggestions. Those are Opus's job.
+
+## 6. Never
+
+- Install new dependencies without calling it out in "Deviations" and waiting for explicit sign-off. A new dependency is a non-trivial decision (see `docs/engineering-standards.md` §"Minimizing attack surface").
+- Refactor beyond the "during-green" allowance.
+- Add files outside the plan's declared scope.
+- Bypass pre-commit hooks (`--no-verify`, etc.).
+- Commit `.env`, credentials, real PII, or anything matching `.gitignore`.
+- Use `any`, `!` non-null assertions on untrusted data, or float math on money.
+- Write code in `src/core/` that imports Node APIs, `better-sqlite3`, `commander`, or any Infra dependency. See `docs/engineering-standards.md` §"Architecture principles".

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,8 @@
       "Bash(npm run build)",
       "Bash(npm run lint)",
       "Bash(npm run migrate)",
+      "Bash(npm ls:*)",
+      "Bash(npm outdated)",
       "Bash(git status)",
       "Bash(git status:*)",
       "Bash(git diff)",
@@ -15,6 +17,14 @@
       "Bash(git show:*)",
       "Bash(git branch)",
       "Bash(git branch:*)",
+      "Bash(git fetch)",
+      "Bash(git fetch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
       "Bash(ls)",
       "Bash(ls:*)"
     ]

--- a/.github/ISSUE_TEMPLATE/deferred-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/deferred-suggestion.md
@@ -1,0 +1,38 @@
+---
+name: Deferred suggestion
+about: A critical-review suggestion that was deferred out of a PR. Tracks it so it doesn't get lost.
+title: "[deferred] "
+labels: ["deferred-suggestion"]
+assignees: []
+---
+
+## Source
+
+- **PR:** <!-- link -->
+- **Phase:** <!-- P1 / P2 / P3 -->
+
+## Suggestion
+
+<!-- Restate the suggestion as it appeared in the suggestion log. -->
+
+## Why deferred
+
+<!--
+Why we didn't do it inside the source PR. Scope creep, dependency on another
+story, out-of-scope refactor, etc. Be specific — future-us needs to decide if
+it's still worth doing.
+-->
+
+## Proposed resolution
+
+<!--
+How we'd address it if we picked this up. Doesn't have to be a full plan —
+enough that a planning session can pick it up without re-discovering the context.
+-->
+
+## Estimated scope
+
+<!--
+One of: trivial (inline fix) / small (single-session story) / medium (multi-day
+story) / large (needs decomposition). Best-guess is fine.
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+    labels:
+      - dependencies
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,98 @@
+<!--
+Product Development Loop PR template. Every section is required.
+No section may be blank or left as `TBD` at merge.
+
+- Sections 1–6 are filled during the Plan phase.
+- Section 7 (Suggestion log) is filled during the Critical-review phase.
+- Section 8 (Sonnet's learnings) is pasted from the Sonnet Task return.
+- Section 9 (Retrospective) is written during the Retrospective phase.
+- Section 10 (Merge checklist) is the final gate — the user ticks it.
+
+Full workflow: see CLAUDE.md § 6.
+-->
+
+## 1. Story
+
+<!-- Link to the story entry in docs/epics.md -->
+
+## 2. Intent
+
+<!-- 2–4 sentences. What problem, what outcome? -->
+
+## 3. Alternatives considered
+
+<!-- One line each. Why each was set aside. -->
+
+-
+
+## 4. Selected solution & rationale
+
+<!-- What we're building. Why it beats the alternatives listed above. -->
+
+## 5. Gherkin scenarios
+
+```gherkin
+Feature:
+
+  Scenario:
+    Given
+    When
+    Then
+```
+
+## 6. Plan for Sonnet
+
+<!--
+Files to touch · tests to write first · Definition of Done for this story.
+Self-contained: Sonnet should not have to ask clarifying questions to proceed.
+-->
+
+## 7. Suggestion log
+
+<!--
+Filled during the 3-phase critical review (P1 functional, P2 product QA, P3 engineering).
+Resolution is one of `adopted` / `deferred` / `rejected`.
+- `deferred` rows MUST link an open GitHub issue in Link/Reason.
+- `rejected` rows MUST carry a one-line reason in Link/Reason.
+- `adopted` rows mean the plan was rewritten to incorporate the suggestion.
+DoR is not met until every row has a non-empty Resolution.
+-->
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+|       |            |            |               |
+
+## 8. Sonnet's learnings
+
+<!--
+Pasted verbatim from the Sonnet Task return report. Fixed template:
+
+## What was built
+## Red → green sequence (per test)
+## Deviations from plan (with rationale)
+## Unknowns encountered
+## Proposed follow-ups
+## Files touched
+-->
+
+## 9. Retrospective
+
+<!--
+3-line summary (Keep / Change / Try). Full retro file committed at
+docs/retrospectives/story-<id>.md — link here.
+-->
+
+- **Keep:**
+- **Change:**
+- **Try:**
+
+Full retrospective: <!-- link to docs/retrospectives/story-<id>.md -->
+
+## 10. Merge checklist
+
+- [ ] `lint` / `build` / `test` green on CI
+- [ ] PR out of draft
+- [ ] Retrospective file committed at `docs/retrospectives/story-<id>.md`
+- [ ] All suggestion-log items resolved (no blank `Resolution` cells)
+- [ ] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
+- [ ] User approval

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,18 +2,24 @@
 
 Instructions for Claude Code working on this repo. Read before changing code.
 
+This file is an AI-facing cheat sheet. The authoritative canon lives under `docs/`:
+
+- [docs/architecture.md](docs/architecture.md) — concrete design
+- [docs/quality-assurance.md](docs/quality-assurance.md) — product-QA invariants (P2 review reference)
+- [docs/engineering-standards.md](docs/engineering-standards.md) — how we build (P3 review reference)
+- [docs/security-checklist.md](docs/security-checklist.md) — walkable attack-surface checklist (part of P3)
+- [docs/prd.md](docs/prd.md) · [docs/epics.md](docs/epics.md) · [docs/product-brief-accounting-2026-02-02.md](docs/product-brief-accounting-2026-02-02.md)
+- [docs/retrospectives/](docs/retrospectives/) — one Keep/Change/Try file per completed story
+
+On conflict between this file and a `docs/` file, `docs/` wins. The retrospective phase reconciles drift.
+
 ## 1. Project
 
 **Couples Expense Sharing App** — a local-first, CLI-based "predictive asset-based financial engine" for couples managing joint finances. Replaces reactive joint-account top-ups with a deterministic engine that predicts fair transfers, buffers volatility, and keeps an immutable ledger.
 
-- Full product context: [docs/product-brief-accounting-2026-02-02.md](docs/product-brief-accounting-2026-02-02.md)
-- Requirements & NFRs: [docs/prd.md](docs/prd.md)
-- Architecture decisions: [docs/architecture.md](docs/architecture.md)
-- Epics & stories roadmap: [docs/epics.md](docs/epics.md)
+**Current position:** Epic 1 (Foundation). Stories 1.1 and 1.2 are done. **Next story: 1.3 — Ledger Schema & Repository.** *This line is refreshed by the retrospective phase of each story.*
 
-**Current position:** Epic 1 (Foundation). Stories 1.1 and 1.2 are done. **Next story: 1.3 — Ledger Schema & Repository.**
-
-**Stack:** Node.js 20, TypeScript (strict), SQLite via `better-sqlite3` (WAL mode), `dinero.js` for money, `commander` for CLI, `zod` for validation, `vitest` + `fast-check` for tests.
+**Stack:** Node.js 20, TypeScript (strict), SQLite via `better-sqlite3` (WAL mode), `dinero.js` for money, `commander` for CLI, `zod` for validation, `vitest` + `fast-check` + `quickpickle` (when BDD starts) for tests.
 
 ## 2. Architecture — Pragmatic Clean Architecture
 
@@ -32,7 +38,7 @@ Rules:
 
 ## 3. Money & precision
 
-Money bugs are the highest-severity class in this project. Rules are non-negotiable.
+> Full authoritative checklist: [docs/security-checklist.md](docs/security-checklist.md) and product invariants in [docs/quality-assurance.md](docs/quality-assurance.md). This section is the short version for quick reference.
 
 - **Never** use `+ - * /` directly on monetary values. Go through `Money` / Dinero methods.
 - **Banker's Rounding** (round-half-to-even) everywhere rounding is needed. Already implemented in [src/core/shared/money.ts](src/core/shared/money.ts).
@@ -43,34 +49,158 @@ Money bugs are the highest-severity class in this project. Rules are non-negotia
   - System events (migrations, audit log timestamps): UTC.
   - Transactions: ISO 8601 **with offset** (e.g. `2026-04-21T14:30:00+02:00`). Preserves "receipt truth" — the local wall clock when the transaction actually happened.
 - **Versioned rules:** config/rules that change over time (split ratios, buffer targets) use the Validity Window pattern (`valid_from`, `valid_to`). No event sourcing. Queries resolve the active rule by date.
-- **SQLite:** WAL mode enabled in [src/infra/db/sqlite-client.ts](src/infra/db/sqlite-client.ts). DB files **must** be created with `0600` permissions (rule — not yet enforced in code; wire this into the SQLite client or config layer when Story 1.4 lands). Migrations are numbered SQL files under `src/infra/db/migrations/`, run by the custom runner using `PRAGMA user_version`.
+- **SQLite:** WAL mode enabled in [src/infra/db/sqlite-client.ts](src/infra/db/sqlite-client.ts). DB files **must** be created with `0600` permissions (rule — not yet enforced in code; wire this in when Story 1.4 lands). Migrations are numbered SQL files under `src/infra/db/migrations/`, run by the custom runner using `PRAGMA user_version`.
 - **PII:** redact IBANs, names, and similar fields in logs by default.
 
 ## 4. Style
+
+> Full authoritative standards: [docs/engineering-standards.md](docs/engineering-standards.md). This section is the short version.
 
 - **File names:** kebab-case (`sqlite-transaction-repo.ts`, `ingest-use-case.ts`).
 - **Types/classes:** PascalCase. Interfaces have no `I` prefix.
 - **Variables/functions:** camelCase.
 - **DB columns:** snake_case. Repositories translate at the boundary.
 - **No `any`.** `strict: true` is mandatory. Explicit return types on exported functions.
-- **No comments** except when the *why* is non-obvious (subtle invariant, workaround for a specific bug, constraint a reader would otherwise miss). Well-named identifiers are the documentation.
+- **No comments** except when the *why* is non-obvious. Well-named identifiers are the documentation.
 - **Functions:** target under ~50 lines, pure where possible.
 - **Imports:** use the `@core/*` path alias when reaching into Core from elsewhere; consistent relative imports within a layer.
 - **Zod** at every input boundary (CLI args, file reads, config parsing). Not inside Core.
 
-## 5. Testing & Definition of Done
+## 5. Testing
+
+> Full standards: [docs/engineering-standards.md](docs/engineering-standards.md#testing-tiers). Product invariants to test for: [docs/quality-assurance.md](docs/quality-assurance.md).
 
 - **Coverage:** 100% **branch coverage** on everything under `src/core/`. Infra and CLI lower.
-- **Unit tests** live next to the code in `src/core/**/*.test.ts` or under `tests/unit/core/**` (current convention). AAA layout.
+- **Acceptance tests** live under `tests/features/*.feature` with step definitions in `tests/features/steps/*.ts`, run through `quickpickle` (vitest-native). Every user-visible behaviour must have an acceptance scenario written *before* implementation starts — see § 6 and § 7.
+- **Unit tests** live under `tests/unit/<mirror-of-src>/**/*.test.ts`. Single canonical location, no colocation.
 - **Property-based tests** via `fast-check` for every financial invariant: associativity, conservation of total under allocation, idempotence where claimed. Follow the pattern in [tests/unit/core/shared/money.test.ts](tests/unit/core/shared/money.test.ts).
-- **Integration tests** under `tests/integration/` exercise Infra implementations (SQLite repos, migration runner) against real SQLite.
+- **Integration tests** under `tests/integration/` exercise Infra implementations against real SQLite (`tests/integration/` is created when the first integration test is written — does not exist yet).
+- **Testing pattern:** AAA (Arrange-Act-Assert) for unit and integration tests. Given/When/Then via Gherkin step definitions for acceptance tests — see § 7.
 - **Batch processing** (Epic 2+): partial success is allowed. Commit valid rows, surface the failing ones — don't fail the whole batch on a single bad row.
 
-**Definition of Done for any story:**
+## 6. Development workflow
 
-1. `npm run lint && npm run build && npm test` — all green.
+The loop has two formal gates:
+- **Definition of Ready (DoR)** — met when phases 1 and 2 below are complete.
+- **Definition of Done (DoD)** — met when phases 3, 4, 5, and the merge checklist are all complete.
+
+### 6.1 Phases
+
+Phases 1 and 2 together compose DoR. Phases 3 and 4, plus the merge checklist, compose DoD. Phase 5 is continuous-improvement and must complete before merge.
+
+1. **Plan** (Opus): collect intent → diverge on solutions → converge on one → capture Gherkin behaviour → open draft PR → hand-off plan for Sonnet. *Exit:* draft PR exists with PR-template sections 1–6 filled.
+2. **Critical review on the plan** (Opus, 3 passes before implementation):
+   - **P1 — Functional.** Does the planned solution satisfy the target FR/NFRs in [docs/prd.md](docs/prd.md) and the story description in [docs/epics.md](docs/epics.md)? Is the Gherkin complete and unambiguous?
+   - **P2 — Product Quality / QA.** Walk [docs/quality-assurance.md](docs/quality-assurance.md). Does the plan preserve accounting correctness, privacy compliance, and coherence with the product brief?
+   - **P3 — Engineering.** Walk [docs/engineering-standards.md](docs/engineering-standards.md), [docs/architecture.md](docs/architecture.md), and [docs/security-checklist.md](docs/security-checklist.md). Is the plan structurally sound — clean architecture, SOLID where it buys something, KISS, YAGNI — and does it minimize attack surface?
+
+   Each suggestion is tagged **adopted / deferred / rejected** in the PR's Suggestion Log (section 7 of the template). Deferred items **must** link a GitHub issue created from the `deferred-suggestion` template — no bare "deferred". Rejected items must carry a one-line reason.
+
+   *Exit (the **DoR gate**):* no un-tagged suggestions; plan re-written to incorporate adopted items; every deferred item has a GitHub issue link.
+
+3. **Implement** (Sonnet via `Task` with the `sonnet-implementer` agent): writes failing acceptance scenario first, drives down to failing unit tests, makes green, commits per state. Returns the structured report (see 6.3). *Exit:* all tests green, report delivered, branch pushed. (The PR is not marked ready yet.)
+
+4. **Code review on the implementation + refactor plan** (Opus) — re-run P1/P2/P3 **against the actual code**, not the plan:
+   - **P1 retro-check.** Do the green scenarios and unit tests actually deliver the intent? Any behavioural drift from the Gherkin?
+   - **P2 retro-check.** Walk [docs/quality-assurance.md](docs/quality-assurance.md) against the diff. Any product invariant broken in practice? Any new PII path?
+   - **P3 retro-check.** Walk [docs/engineering-standards.md](docs/engineering-standards.md) and [docs/security-checklist.md](docs/security-checklist.md) against the diff. Any SOLID/KISS/YAGNI violation, coupling spike, new attack-surface item?
+
+   Produce a refactor plan covering every issue (blockers are fixed before merge, not deferred). Delegate execution to Sonnet. *Exit:* refactor merged back into the same branch, CI green, every retro-check passes.
+
+5. **Retrospective.** Keep/Change/Try file at `docs/retrospectives/story-<id>.md`. Action items either land in the same PR (CLAUDE.md / `docs/` / template edits) or become follow-up GitHub issues. *Exit:* file committed, action items tagged. Merge is **user-gated** after this.
+
+### 6.2 Model tier
+
+- **Opus:** planning, 3-phase critical review, code review, refactor planning, retrospective synthesis.
+- **Sonnet:** failing tests, implementation, refactor execution.
+- **Haiku:** not used yet.
+
+### 6.3 Sonnet return format
+
+Fixed template Sonnet emits at end of a Task:
+
+```
+## What was built
+## Red → green sequence (per test)
+## Deviations from plan (with rationale)
+## Unknowns encountered
+## Proposed follow-ups
+## Files touched
+```
+
+See [.claude/agents/sonnet-implementer.md](.claude/agents/sonnet-implementer.md) for the full agent spec.
+
+### 6.4 Commit convention inside a story
+
+Commits on state transitions. Story id in every subject (e.g. `(Story 1.3)`):
+
+- `test(<scope>): <scenario> — failing` (red)
+- `feat(<scope>): <scenario> — minimal green` (green)
+- `refactor(<scope>): <what>` (behaviour-preserving cleanup)
+
+Squash on merge is optional.
+
+### 6.5 Refactor-during-green policy
+
+Obvious local cleanups (rename, extract small helper, collapse a duplicated literal) are allowed while tests are green, so long as behaviour is preserved and all tests still pass. Anything structural — new abstraction, cross-module move, changes that touch more than ~20 LOC of existing code — is deferred to the post-review refactor phase. Sonnet must call this out in the return report when it uses this allowance.
+
+### 6.6 Reference docs for review phases
+
+Three authoritative docs; CLAUDE.md does not duplicate their contents.
+
+- [docs/quality-assurance.md](docs/quality-assurance.md) — P2 reference.
+- [docs/engineering-standards.md](docs/engineering-standards.md) — P3 reference (main).
+- [docs/security-checklist.md](docs/security-checklist.md) — walkable attack-surface checklist, part of P3. Run in full at every P3 (plan) and P3 retro-check (post-implementation).
+
+On conflict, `docs/` wins; the retrospective reconciles drift.
+
+### 6.7 Story sizing
+
+One PR per story. If a story has more than ~3 Gherkin scenarios or would plausibly exceed one Sonnet Task round, split into sub-stories before planning.
+
+### 6.8 Maintenance sub-loop
+
+Runs **before the planning phase of every new story**. Unconditional; not skipped.
+
+- **Triage open issues:** re-prioritize, close stale, link duplicates, confirm `deferred-suggestion` items are still relevant.
+- **Review open Dependabot PRs:** for each, check CI green + diff + changelog. Routine bumps (patch, minor dev-dep) → merge directly, no full DoR/DoD/retro. Breaking changes, major bumps, or bumps to critical-path deps (`better-sqlite3`, `dinero.js`, `zod`, `commander`, `vitest`) → open a GitHub issue and handle as a dedicated story through the main loop.
+- **`npm audit`:** any `high`/`critical` → immediate issue, fix plan, runs before the next story.
+
+Maintenance is **lighter** than feature work: no retrospective file for routine bumps. Aggregate learnings surface at the next per-story retrospective ("dependency X keeps breaking; consider pinning / replacing").
+
+## 7. BDD & TDD rules
+
+### 7.1 Runner
+
+`quickpickle` for `.feature` files, running through vitest. Install is deferred until the first story that actually needs a `.feature` file. Layout when it arrives:
+
+- `tests/features/*.feature` — scenarios
+- `tests/features/steps/*.ts` — step definitions
+
+### 7.2 Outside-in flow
+
+Acceptance scenario fails (pending step) → unit tests fail → implementation goes green → unit tests pass → acceptance passes → refactor.
+
+### 7.3 Coverage rule
+
+Unchanged from § 5: 100% branch coverage on `src/core/` via unit tests. Acceptance tests complement, do not replace, unit coverage.
+
+### 7.4 Property-based testing
+
+`fast-check` remains the default for financial invariants. See [tests/unit/core/shared/money.test.ts](tests/unit/core/shared/money.test.ts) for the pattern.
+
+## 8. Definition of Done
+
+A story is merge-ready only when **all** of:
+
+1. `npm run lint && npm run build && npm test` — all green on CI.
 2. Migrations are idempotent (running twice on a fresh DB is a no-op after the first).
 3. Every new invariant in Core has a property test.
 4. No `any`, no TODO comments left behind, no dead code.
-5. Conventional Commit subject referencing the story, e.g. `feat(core): ledger schema & repo (Story 1.3)`. One logical story per commit where practical.
-6. When the work adds a new rule or constraint that a future reader would miss, add a line to the relevant section of this file rather than leaving it only in code.
+5. Commits follow the `test:` / `feat:` / `refactor:` rhythm of § 6.4. Each subject references the story id.
+6. All 10 sections of the PR template are filled — no `TBD` at merge.
+7. Suggestion log has no un-tagged items. Every `deferred` row links a GitHub issue.
+8. P1 / P2 / P3 retro-checks (§ 6.1 phase 4) all pass.
+9. Retrospective file committed at `docs/retrospectives/story-<id>.md`.
+10. Any new rule or constraint that came out of the retrospective has landed in the same PR as a CLAUDE.md / `docs/` / template edit — nothing ships only in code comments.
+11. User has ticked the merge checklist.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,14 +1,4 @@
----
-stepsCompleted: [1, 2, 3, 4, 5, 6, 7, 8]
-workflowType: 'architecture'
-lastStep: 8
-status: 'complete'
-completedAt: 'Tue Feb 03 2026'
----
-
 # Architecture Decisions
-<!-- This file records architectural decisions for the project -->
-<!-- It is built incrementally through the collaborative architecture workflow -->
 
 > **See also** — applied when reviewing a change against this architecture: [quality-assurance.md](quality-assurance.md) (product QA invariants, P2 review), [engineering-standards.md](engineering-standards.md) (how we build, P3 review), [security-checklist.md](security-checklist.md) (attack surface, part of P3).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,8 @@ completedAt: 'Tue Feb 03 2026'
 <!-- This file records architectural decisions for the project -->
 <!-- It is built incrementally through the collaborative architecture workflow -->
 
+> **See also** — applied when reviewing a change against this architecture: [quality-assurance.md](quality-assurance.md) (product QA invariants, P2 review), [engineering-standards.md](engineering-standards.md) (how we build, P3 review), [security-checklist.md](security-checklist.md) (attack surface, part of P3).
+
 ## Project Information
 
 *   **Project Name:** accounting

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -1,0 +1,109 @@
+# Engineering Standards
+
+How we build. Authoritative reference for the **P3** critical review (plan) and the P3 retro-check (implementation) described in [CLAUDE.md § 6.1](../CLAUDE.md). On conflict with a summary elsewhere, this document wins.
+
+The distinction from [quality-assurance.md](quality-assurance.md) and [security-checklist.md](security-checklist.md): engineering is about *how the code is structured and defended*; quality is about *what it promises to users*; security is about *attack surface*. P3 reviewers walk this doc plus the security checklist.
+
+## Architecture principles
+
+- **Clean Architecture.** Core / Infra / CLI with a strict dependency rule. Core depends on nothing; Infra depends on Core via Ports; CLI depends on both. See [architecture.md](architecture.md) for the concrete design.
+- **Ports & Adapters.** Every Infra dependency (SQLite, filesystem, CSV parsers, clock) is expressed as a Port in `src/core/ports/` and implemented as an Adapter in `src/infra/`. Core never imports from Infra.
+- **`Result<T, E>` over exceptions.** Core methods return `Result` values. Exceptions only at the outermost CLI boundary, for truly unexpected failures. No try/catch in Core logic.
+- **Constructor DI only.** Dependencies enter via the constructor. No `new SomeRepo()` inside Core. No service locators, no DI containers — manual wiring in the CLI entry point is fine for a project this size.
+
+## SOLID — applied pragmatically
+
+We use SOLID where it concretely buys readability, testability, or flexibility we actually need. Violations are only flagged in P3 when they hurt something real. Ceremonial application (an interface per class, "just in case") is itself a violation of KISS.
+
+- **SRP.** A class or module does one thing. If a reviewer needs "and" to describe its responsibility, split it.
+- **OCP.** New behaviour preferably arrives as a new type implementing an existing Port, not as edits to existing Core classes. Edit Core only when the contract itself changes.
+- **LSP.** Any implementation of a Port behaves in all the ways Core relies on, including failure modes. An adapter that throws where the Port says `Result.Fail` violates this.
+- **ISP.** Ports are small and cohesive. A repository Port with methods for five unrelated queries is probably two or three Ports wearing a trench coat.
+- **DIP.** Core depends on abstractions (Ports), not on concretions. If Core imports `better-sqlite3`, something is wrong.
+
+## KISS
+
+The simplest thing that makes the tests green is the default. If a reviewer can propose a simpler implementation that passes the same tests, the current version loses.
+
+- No "just in case" abstractions.
+- No frameworks we don't need today.
+- No configurability where a hard-coded value works and isn't a user-facing concern.
+
+## YAGNI
+
+We don't build for tomorrow's hypothetical requirement.
+
+- No speculative features.
+- No hooks, extension points, or plugin systems until at least two concrete callers exist.
+- No generics, no overloads, no configuration flags without a present user.
+
+## Minimizing attack surface
+
+Every new external input, file path, SQL statement, or dependency is scrutinized at P3. Walk [security-checklist.md](security-checklist.md) in full during every P3. A new dependency is treated as a non-trivial decision, not a reflex.
+
+- Prefer prepared statements (`better-sqlite3` enforces this).
+- Zod schemas at every external boundary; never inside Core.
+- Least-privilege file permissions (`0600` for DB and config).
+- New dependencies require a one-line rationale in the PR; dev-deps have a lower bar than runtime deps.
+
+## Testing tiers
+
+| Tier | Location | Runner | Purpose |
+| --- | --- | --- | --- |
+| Acceptance | `tests/features/*.feature` + `tests/features/steps/*.ts` | `quickpickle` (vitest-native) | Outside-in BDD: one scenario per user-visible behaviour |
+| Unit | `tests/unit/<mirror-of-src>/**/*.test.ts` | vitest | AAA pattern; mock all Ports for Core |
+| Property | colocated with unit | vitest + `fast-check` | Financial invariants (allocation sum, associativity, etc.) |
+| Integration | `tests/integration/` (created when first needed) | vitest | Exercise Infra implementations against real SQLite/FS |
+
+## Coverage
+
+- **100% branch coverage** on everything under `src/core/`. Non-negotiable.
+- Infra and CLI lower, but every branch (happy path, error path) is still exercised with intent. No "covered by accident" lines.
+- Coverage reports are advisory; the review looks at *which branches aren't covered*, not just the percentage.
+
+## TDD rhythm
+
+Outside-in, strict sequence:
+
+1. Write the failing acceptance scenario first — `test:` commit.
+2. Drop to failing unit tests for the first slice — `test:` commit.
+3. Implement the minimum to go green at the unit level — `feat:` commit.
+4. Work your way up until the acceptance scenario also goes green — more `feat:` commits as needed.
+5. Refactor while all tests stay green — `refactor:` commit.
+
+No "tests and implementation together" commits. No "write the tests after the code."
+
+## Style
+
+- **File names:** kebab-case (`sqlite-transaction-repo.ts`).
+- **Types / classes:** PascalCase. No `I` prefix on interfaces.
+- **Variables / functions:** camelCase.
+- **DB columns:** snake_case. Repositories translate at the boundary.
+- **No `any`.** `strict: true` is mandatory. Explicit return types on exported functions.
+- **No comments** except when the *why* is non-obvious. Well-named identifiers are the documentation.
+- **Functions under ~50 LOC**, pure where possible.
+- **Imports:** `@core/*` alias when reaching into Core from elsewhere; consistent relative imports within a layer.
+- **Zod** at external boundaries only; never inside Core.
+
+## Refactor-during-green allowance
+
+Obvious local cleanups — rename a variable, extract a tiny helper, collapse a duplicated literal into a constant — are allowed while tests are green, so long as behaviour is preserved and all tests still pass.
+
+Anything structural is deferred to the post-review refactor phase:
+
+- Introducing a new abstraction (interface, base class, factory).
+- Cross-module moves.
+- Touching more than ~20 LOC of existing (not newly-written) code.
+
+When Sonnet uses the allowance, it calls it out in the return report's "Deviations" section.
+
+## Maintainability indicators used in P3
+
+Reviewers actively look for these:
+
+- **Duplication** that represents the same intent (DRY), not just coincidental resemblance.
+- **Coupling spikes** — a new cross-layer import, a Core file suddenly importing from Infra.
+- **Naming drift** — the name no longer describes what the code does after the change.
+- **Dead code** — unused exports, commented-out blocks, orphan TODOs.
+- **Over-abstraction** — a single implementation behind an interface that "might grow" (usually it won't; collapse it).
+- **Premature concurrency or caching** (YAGNI).

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -1,8 +1,3 @@
----
-stepsCompleted: ['step-01-validate-prerequisites', 'step-02-design-epics', 'step-03-create-stories']
-inputDocuments: ['_bmad-output/planning-artifacts/prd.md', '_bmad-output/planning-artifacts/architecture.md']
----
-
 # accounting - Epic Breakdown
 
 ## Overview

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -11,6 +11,8 @@ classification:
 
 # Product Requirements Document - Couples Expense Sharing App
 
+> **See also** — [quality-assurance.md](quality-assurance.md) is the test-plan reference for these requirements. Product invariants listed there are walked during the P2 critical review and the P2 retro-check.
+
 **Author:** Xavier
 **Date:** Tue Feb 03 2026
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,14 +1,3 @@
----
-stepsCompleted: ['step-01-init', 'step-02-discovery', 'step-03-success', 'step-04-journeys', 'step-05-domain', 'step-06-innovation', 'step-07-project-type', 'step-08-scoping', 'step-09-functional', 'step-10-nonfunctional', 'step-11-polish']
-inputDocuments: ['_bmad-output/planning-artifacts/product-brief-accounting-2026-02-02.md', '_bmad-output/project-context.md', '_bmad-output/brainstorming/brainstorming-session-2026-02-02.md']
-workflowType: 'prd'
-classification:
-  projectType: 'cli_tool'
-  domain: 'fintech'
-  complexity: 'high'
-  projectContext: 'greenfield'
----
-
 # Product Requirements Document - Couples Expense Sharing App
 
 > **See also** — [quality-assurance.md](quality-assurance.md) is the test-plan reference for these requirements. Product invariants listed there are walked during the P2 critical review and the P2 retro-check.

--- a/docs/product-brief-accounting-2026-02-02.md
+++ b/docs/product-brief-accounting-2026-02-02.md
@@ -1,14 +1,6 @@
----
-stepsCompleted: [1, 2, 3, 4, 5, 6]
-inputDocuments: ['_bmad-output/brainstorming/brainstorming-session-2026-02-02.md']
-date: 'Mon Feb 02 2026'
-author: 'Xavier'
-status: 'complete'
----
-
 # Product Brief: accounting
 
-<!-- Content will be appended sequentially through collaborative workflow steps -->
+**Date:** 2026-02-02  **Author:** Xavier
 
 ## Executive Summary
 

--- a/docs/quality-assurance.md
+++ b/docs/quality-assurance.md
@@ -1,0 +1,42 @@
+# Quality Assurance
+
+Product-level invariants this project must preserve for its users. Walked during every **P2** of the critical review (see [CLAUDE.md § 6.1](../CLAUDE.md)) on the plan, and again at the P2 retro-check on the implementation. On conflict with a summary elsewhere, this document wins.
+
+The distinction from [engineering-standards.md](engineering-standards.md) and [security-checklist.md](security-checklist.md): QA is about *what the product promises to its users*, not *how the code is structured* or *how we defend against attackers*.
+
+## Accounting correctness
+
+- Every recorded transaction satisfies `sum(debits) == sum(credits)`, enforced at write time. See also [architecture.md](architecture.md).
+- Account balances are mathematically derivable from the ledger alone. No hidden state, no cached totals that can drift from the journal.
+- **Currency consistency per account.** An account has exactly one currency for its lifetime. Mixed-currency operations fail loudly with `Result.Fail`; silent coercion is unacceptable.
+- **Allocations are conservative to the cent.** Splits use Largest Remainder so `sum(parts) == total` exactly; no rounding error leaks out of an allocation.
+- **Determinism.** Historical recalculations produce identical results given the same inputs. If a user runs the same report twice with the same data, the numbers match byte-for-byte.
+- **Validity windows.** Versioned rules (split ratios, buffer targets) apply the rule that was active on the transaction's date, not today's rule. A transaction dated 2024-05 recomputes with the 2024-05 split, regardless of later config changes.
+- **No silent data loss.** Ingesting the same CSV twice produces zero new transactions (idempotent). Ingesting a CSV with a malformed row produces all valid rows plus an explicit per-row error report.
+
+## Privacy & data sovereignty
+
+- **Local-only is a hard promise.** No network egress of ledger data under any flag. The product never phones home.
+- **PII is never logged verbatim.** Names, IBANs, account identifiers, and bank references are redacted before logging or error output. Test fixtures contain synthetic data only.
+- **Portability.** The user can export every byte of their data at any time, in a documented and re-importable format ("Graceful Dissolution"). Export is complete — no "admin-only" fields, no opaque blobs.
+- **File permissions.** DB and config files are created with `0600`. A shared-machine scenario cannot leak data to a second account via file reads.
+
+## Coherence with the product brief
+
+- **User journeys reachable.** Every journey documented in [product-brief-accounting-2026-02-02.md](product-brief-accounting-2026-02-02.md) must remain achievable through the CLI. A refactor that orphans a journey is a P2 blocker, not a deferred item.
+- **"Conversational CFO" truthfulness.** Human-readable explanations must match the mathematical result they reference. A sentence like "you'll be short €240 in March" must be backed by a deterministic calculation the user can reproduce.
+- **Audit trail.** Every user action that changes state leaves a traceable entry (ledger row, audit-log row, or both). "What changed and why" must be answerable from the local data alone.
+- **Soft edits, not hard edits.** Corrections are recorded as new balancing transactions (reversal + correction). The original is never mutated.
+
+## Observability of failures
+
+- **Batch operations surface per-row outcomes.** A 500-row CSV with 3 bad rows must report *exactly* which 3 failed and why; the other 497 must commit atomically.
+- **Human-readable error messages at the CLI boundary.** A user never sees a raw stack trace, a raw `Result.Fail` payload, or a TypeScript type name. Errors translate to a sentence the user can act on.
+- **Exit codes reflect outcome.** `0` for full success, non-zero for any failure. Scripts calling the CLI can branch on it reliably.
+
+## Non-goals (to preempt false-positive reviews)
+
+- Multi-user concurrent writes. This is a single-user local tool; SQLite WAL is overkill already.
+- High availability, replication, backups beyond the user's own local filesystem tools.
+- Complex authentication or authorization. The OS handles that.
+- International tax compliance. The tool records and predicts; it is not an accountant.

--- a/docs/retrospectives/README.md
+++ b/docs/retrospectives/README.md
@@ -1,0 +1,43 @@
+# Retrospectives
+
+Each completed story produces a retrospective here. Format: Keep / Change / Try. Action items either land in the same PR (as CLAUDE.md, `docs/`, or template edits) or become follow-up GitHub issues — nothing is left unresolved.
+
+The retrospective phase of the development loop is described in [CLAUDE.md § 6.1](../../CLAUDE.md). The retro must be committed **before** the merge checklist can be ticked.
+
+## Template for a new retrospective
+
+Copy into `story-<id>.md` (e.g. `story-1.3.md`) and fill in.
+
+```markdown
+# Story <id> retrospective
+
+**PR:** <url>  **Closed:** YYYY-MM-DD
+
+## Keep
+-
+
+## Change
+-
+
+## Try
+-
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+|      |                |        |
+```
+
+### Field guidance
+
+- **Keep** — what worked and should be repeated on the next story.
+- **Change** — something that happened this story and should be different next time. Be specific: "the plan under-specified the migration rollback path" beats "better planning."
+- **Try** — an experiment for the next story only. If it proves itself, it graduates to Keep (and usually into CLAUDE.md / a `docs/` file).
+- **Action items** — concrete, assignable. `Where it lands` is one of: in-PR edit (which file), or an issue link. `Status` is `done`, `open`, or a link.
+
+## Index
+
+Updated as retrospectives land.
+
+- _(none yet)_

--- a/docs/security-checklist.md
+++ b/docs/security-checklist.md
@@ -1,0 +1,57 @@
+# Security Checklist
+
+Walkable attack-surface checklist. Part of the **P3** critical review (engineering), run against the plan (phase 2) and again against the implementation diff (phase 4). Cross-referenced by [engineering-standards.md](engineering-standards.md).
+
+A failure of any item at P3-retro is a **merge blocker**, not a deferred suggestion.
+
+## Money precision
+
+- [ ] No `+ - * /` on monetary values anywhere. `Money` / Dinero methods only.
+- [ ] All monetary storage uses two columns: `INTEGER NOT NULL` cents + `TEXT NOT NULL` ISO 4217 currency code.
+- [ ] Banker's rounding (half-to-even) used wherever rounding is needed.
+- [ ] No `Number.parseFloat`, no `toFixed`, no `.toString()` round-trips for money.
+
+## Data integrity
+
+- [ ] Ledger tables are append-only. No `UPDATE` or `DELETE` statements anywhere against them. Corrections are new balancing entries.
+- [ ] The `sum(debits) == sum(credits)` invariant is enforced at write time, before the transaction is visible in the DB.
+- [ ] All SQL executes via `better-sqlite3` prepared statements. No string concatenation or template-literal interpolation into query text.
+- [ ] Migrations are numbered and idempotent. Running the migrator twice on a fresh DB is a no-op after the first run.
+- [ ] No transaction ID or other primary key relies on client-supplied data for uniqueness.
+
+## Validation & boundaries
+
+- [ ] Zod schemas validate every external input: CLI args, file reads, config parsing. Validation happens before the data reaches Core.
+- [ ] Core (`src/core/`) contains no calls to Node APIs (`fs`, `path`, `os`, `crypto`), no `commander`, no `better-sqlite3`, no `process.exit`.
+- [ ] No user-controlled path strings reach `fs` without prior normalization; no path traversal (`../`) possible via ingestion.
+- [ ] CLI commands refuse unknown flags (commander's default).
+
+## Secrets & PII
+
+- [ ] Logs and error messages redact PII (names, IBANs, account identifiers, email addresses). Redaction is the default; plaintext logging requires an explicit per-call opt-in.
+- [ ] No `.env`, credentials files, API tokens, or production data committed in any branch. `.gitignore` covers them.
+- [ ] Test fixtures contain synthetic data only. No real IBANs, no real names.
+- [ ] DB and config files are created with `0600` permissions. (Rule — wire into `sqlite-client.ts` / config layer in Story 1.4.)
+- [ ] No logging of raw CSV rows without PII redaction.
+
+## Supply chain
+
+- [ ] `npm audit` is clean of `high` and `critical` advisories. Moderate findings are noted; anything higher becomes an immediate fix issue.
+- [ ] New runtime dependencies require a one-line justification in the PR.
+- [ ] Dependency-update PRs (Dependabot) walk this full checklist before merge.
+- [ ] Lock file (`package-lock.json`) is committed and consistent with `package.json`.
+
+## Error handling
+
+- [ ] Core returns `Result<T, E>`; no thrown exceptions inside Core.
+- [ ] Infra catches only exceptions it can translate to `Result.Fail`; others propagate.
+- [ ] No bare `catch` blocks that swallow errors.
+- [ ] CLI boundary converts `Result.Fail` to a human-readable message plus a non-zero exit code.
+
+## Review cadence
+
+- Run this checklist **in full** at:
+  - P3 of the pre-implementation critical review (against the plan).
+  - P3 retro-check of the post-implementation review (against the diff).
+- At every Dependabot PR review (short-form: supply chain only is mandatory, full walk if the bump touches a critical-path dep).
+- Any box that cannot be ticked must either be fixed or resolved via a documented exception (GitHub issue referenced in the suggestion log).


### PR DESCRIPTION
## 1. Story

**N/A — process-bootstrap PR.** This PR introduces the development loop itself; it does not implement a story from [docs/epics.md](docs/epics.md). Story work resumes at 1.3 (Ledger Schema & Repository) in the next cycle, using this loop.

## 2. Intent

Codify the Opus-plans / Sonnet-implements product development loop so it's repeatable, legible, and doesn't require re-explaining on every story. Establish DoR + DoD gates, a PR template that forces each phase to leave a written trace, independent reference docs for product-QA / engineering / security, and the Sonnet subagent definition for Task-delegated implementation.

## 3. Alternatives considered

- **Separate sessions per phase vs. Task-tool delegation.** Rejected separate sessions — friction of handoff outweighs context-isolation benefit.
- **Gherkin runner: cucumber-js vs. quickpickle vs. markdown-only.** Picked `quickpickle` for single-runner simplicity; cucumber-js adds a second CI step for no gain at this scale.
- **Single vs. multi-doc canon.** Rejected a single mega-doc; split by audience (product-QA / engineering / security) so each P-phase has one walkable reference.
- **Slash-command skills now vs. later.** Rejected now — YAGNI; revisit after 2–3 completed stories if we feel friction.
- **Security as part of QA vs. engineering.** Settled on engineering per user's framing (attack surface = engineering concern, compliance = quality concern).

## 4. Selected solution & rationale

CLAUDE.md becomes the AI-facing cheat sheet; three new `docs/` files are the authoritative reference; a 10-section PR template makes each phase of the loop leave a visible artefact. Sonnet gets a dedicated subagent definition with a fixed return format and strict scope. Dependabot + a `deferred-suggestion` issue template close the loop on dependency hygiene and suggestion tracking. No skills or new runtime deps — minimum viable process.

## 5. Gherkin scenarios

N/A — process change, no user-visible behaviour.

## 6. Plan for Sonnet

N/A — executed directly in Opus. No Sonnet Task was spawned for this PR.

## 7. Suggestion log

This PR was planned in plan mode with multiple user-driven revisions (rename of quality-standards → engineering-standards, extraction of quality-assurance as a separate doc, reframing of P2/P3). All revisions were **adopted** into the plan before implementation. No suggestions were deferred or rejected.

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| Plan-time | Rename \`docs/quality-standards.md\` → \`engineering-standards.md\` | adopted | Clearer audience split |
| Plan-time | Extract \`docs/quality-assurance.md\` for product-QA | adopted | P2/P3 separation demanded it |
| Plan-time | Security → engineering (not quality) | adopted | Attack surface is an engineering concern |
| Plan-time | Deferred suggestions must open a GitHub issue | adopted | Codified in template + issue form |
| Plan-time | Add maintenance sub-loop | adopted | § 6.8 + Dependabot config |

## 8. Sonnet's learnings

N/A — no Sonnet Task was run for this PR.

## 9. Retrospective

- **Keep:** Plan mode for multi-turn scoping; iterative user feedback inside plan mode caught three structural issues before they hit the code.
- **Change:** CLAUDE.md ended up sizeable (~205 lines). Next time, try to keep it under ~150 by pushing more into `docs/` earlier.
- **Try:** Running Story 1.3 through the loop end-to-end, with a real `sonnet-implementer` Task, and seeing where the process actually bites.

Full retrospective: **deferred to after Story 1.3 runs** — we'd be retro-ing a process we haven't actually used yet. The first real retrospective will land at `docs/retrospectives/story-1.3.md`.

## 10. Merge checklist

- [x] \`lint\` / \`build\` / \`test\` green locally (CI will re-verify)
- [x] PR out of draft (opening as non-draft since this is a process-bootstrap PR)
- [x] Retrospective: deferred per § 9 (acceptable exception for bootstrap PR)
- [x] All suggestion-log items resolved
- [x] All phase-4 retro-checks pass (N/A — no implementation to retro-check)
- [x] User approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)