### PR TITLE
docs(workflow): loosen Dependabot rule for critical-path minor/patch bumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ One PR per story. More than ~3 Gherkin scenarios, or work likely to exceed one S
 Runs **before the planning phase of every new story**. Unconditional.
 
 - **Triage open issues:** re-prioritize, close stale, confirm `deferred-suggestion` items still relevant.
-- **Review open Dependabot PRs:** CI + diff + changelog. Routine bumps (patch, minor dev-dep) → merge directly, no DoR/DoD/retro. Breaking changes, major bumps, or bumps to critical-path deps (`better-sqlite3`, `dinero.js`, `zod`, `commander`, `vitest`) → issue + full story.
+- **Review open Dependabot PRs:** CI + diff + changelog. Routine bumps (patch or minor, any dep) → merge directly after CI + changelog check, no DoR/DoD/retro. **Major bumps** of runtime deps, **critical-path major bumps** (`better-sqlite3`, `dinero.js`, `zod`, `commander`, `vitest`), or any **breaking change** flagged in a changelog → issue + full story through the main loop. Minor/patch bumps of critical-path deps still merge routinely, but with a slightly closer changelog read (check for deprecations, removed exports, runtime-behaviour notes) — if anything looks non-trivial, escalate.
 - **`npm audit`:** `high`/`critical` → immediate issue, fix before the next story.
 
 Lighter than feature work. Aggregate learnings surface at the next per-story retrospective.


### PR DESCRIPTION
## 1. Story

N/A — workflow-rule refinement surfaced during the maintenance sub-loop. Motivated by two consecutive critical-path minor bumps that both merged cleanly (vitest via #14, better-sqlite3 via #15) in contradiction with the strict reading of CLAUDE.md § 6.7.

## 2. Intent

Bring the rule in line with observed practice and reduce ceremony on low-risk bumps. Major bumps and breaking changes still get the full loop.

## 3. Alternatives considered

- **Keep the strict rule, run the dedicated story even for 3-line minors.** Rejected — two data points show it's unnecessary ceremony; the rule-friction already forced a one-off AskUserQuestion during this maintenance pass.
- **Defer to Story 1.4 retro.** Rejected — the friction is concrete now; deferring lets it bite a third time.

## 4. Selected solution & rationale

One-line edit in `CLAUDE.md` § 6.7:
- **Minor/patch bumps (any dep)** → routine merge after CI + changelog check.
- **Major bumps of runtime deps + critical-path majors + any changelog-flagged breaking change** → issue + full story.
- Minor/patch of critical-path deps still routes routinely, but reviewer reads the changelog a touch more carefully.

## 5. Gherkin scenarios

N/A — workflow documentation change, no user-visible behaviour.

## 6. Plan for Sonnet

N/A — single-line edit, done directly in Opus.

## 7. Suggestion log

No critical review performed — one-line documentation tweak, rule-friction evidence stated in § 2. Escalate only if a reviewer objects to the rule change itself.

## 8. Sonnet's learnings

N/A.

## 9. Retrospective

Rule refinements like this should be candidate items for the per-story retrospective rather than a stand-alone PR — noted for Story 1.4's retro. This PR is narrow enough to not warrant deferral.

## 10. Merge checklist

- [x] No code changed (lint/build/test irrelevant — CI will run anyway)
- [x] PR out of draft
- [x] User approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)