### PR TITLE
feat(config): YAML configuration manager + 0600 DB perms (Story 1.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ data/*.db
 # Testing
 coverage/
 
+# Accounting config (contains household data — copy from accounting.example.yaml)
+/accounting.yaml
+/accounting.yml
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,10 @@ State transitions. Story id in every subject, e.g. `(Story 1.3)`.
 
 **Empty `refactor:` commit with a justification message** (e.g. `refactor(db): tidy prepared statements (Story 1.3)` with body *"No-op: all functions under 50 LOC, naming is clear, no duplication identified"*) is an acceptable pattern when the refactor slot has nothing to clean up. Keeps the commit sequence aligned with the plan and documents the review.
 
+**Commit subjects: summary over enumeration (retro finding, Story 1.4).** Prefer a summary verb in the subject rather than listing every scenario the commit covers. `test(config): schema validation suite — failing (Story 1.4)` ages better than `test(config): rejects missing splits, non-ISO currency, ratio sum — failing (Story 1.4)` — the latter goes stale the moment an 11th assertion lands. Scenario details belong in the commit body, not the subject.
+
+**Plan in slices, not tests-per-commit (retro finding, Story 1.4).** When drafting the TDD commit sequence in the plan-for-Sonnet section, one slice = one behaviour + its tests + the minimal code to make them green (often one Gherkin scenario). Over-decomposing into per-assertion commits invites green-on-landing collapses that divorce the plan from execution. Target 6–10 commits per story; only split further when a slice's failing test genuinely cannot turn green without an intermediate `feat:` step.
+
 Squash on merge is optional.
 
 ### 6.5 Refactor-during-green policy

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ npm ci
 npm run migrate
 ```
 
+## Configuration
+
+The app reads its split rules and buffer targets from `accounting.yaml` in the project root. This file is git-ignored because it contains household data.
+
+```bash
+cp accounting.example.yaml accounting.yaml
+# Edit accounting.yaml with your own values
+```
+
+Alternatively, place the config at `$XDG_CONFIG_HOME/accounting/config.yaml` (defaults to `~/.config/accounting/config.yaml`). The project-root file takes precedence if both are present.
+
+See `accounting.example.yaml` for the full schema with inline documentation.
+
 ## Scripts
 
 | Command | What it does |

--- a/accounting.example.yaml
+++ b/accounting.example.yaml
@@ -1,0 +1,32 @@
+# accounting.example.yaml
+# Copy this file to accounting.yaml (git-ignored) and edit it with your own values.
+#
+# The real accounting.yaml contains household data (partner names, account paths,
+# financial targets) and must never be committed to version control.
+
+# Path to the SQLite database file, relative to the project root.
+dbPath: ./data/ledger.db
+
+# ISO 4217 three-letter currency code used for all monetary amounts in this file.
+defaultCurrency: EUR
+
+# Split rules: who pays what share of shared expenses.
+# ratios must sum exactly to 1.0.
+# Each partner name must be unique (case-sensitive).
+splits:
+  - partner: Alex
+    ratio: 0.5
+  - partner: Sam
+    ratio: 0.5
+
+# Buffer buckets: target balances you want to maintain for specific goals.
+# target: the minimum balance to maintain (required, non-negative decimal).
+# cap:    the maximum to accumulate (optional; must be >= target if provided).
+# Amounts are in the defaultCurrency above.
+# An empty list is valid if you have no buffer targets yet.
+buffers:
+  - name: Car
+    target: 1000
+  - name: House
+    target: 5000
+    cap: 10000

--- a/docs/retrospectives/story-1.4.md
+++ b/docs/retrospectives/story-1.4.md
@@ -1,0 +1,42 @@
+# Story 1.4 retrospective
+
+**PR:** https://github.com/xavierbriand/accounting/pull/20  **Closed:** _pending merge_
+
+Second end-to-end run of the product development loop (first was Story 1.3). Smoother and faster than the first run — most of what we changed after Story 1.3's retro actually paid off. One new friction surfaced around commit granularity.
+
+## Keep
+
+- **Pre-implementation Suggestion Log caught a real issue before code was written.** P2 flagged that `superRefine` custom messages for duplicate partner / bucket names could leak PII (`"Duplicate partner: Alex"`). Sonnet implemented the PII-safe version (`path + "duplicate name"`) from the start — **zero Phase-4 blockers**. This is exactly what DoR is supposed to do.
+- **Pre-delegation alias sanity** (Story 1.3 retro action) confirmed `@core/*` was wired in both `tsconfig.json` and `vitest.config.js` before spawning Sonnet — nothing to discover mid-implementation.
+- **"This test fails if …" comments** (Story 1.3 retro action) landed naturally in every test. Two of them (the PII-safe assertions `expect(error).not.toContain('Alex')` and `expect(error).not.toContain('Car')`) are the kind of test that would silently rot without the comment saying what they guard.
+- **`accounting.example.yaml` drift-guard test** (reads the checked-in example and runs it through the schema) is a cheap insurance policy. Catches future schema changes that would break the template silently.
+- **Plan authorizing the new dep (`yaml@^2`) up-front** avoided a Sonnet stop-and-ask. The "install listed, call out in Deviations" pattern worked cleanly.
+
+## Change
+
+- **Commit granularity was over-specified in the plan.** Sonnet collapsed four separate commit pairs (#3+#4, #5, #7+#8, #13 green-on-landing) because the plan's step-per-test granularity was more fine-grained than the actual red→green work. Every collapse was justified, but the pattern says the plan was wrong, not the execution. Next time: plan commit sequence in terms of *slices* (one `test:` + one `feat:` per coherent slice), not per-scenario.
+- **Commit subjects under-described content.** `test(config): schema rejects missing splits, non-ISO currency, ratio sum — failing` landed with all 10 unit tests + 2 property tests (not the three named). Reads fine but the subject is a partial truth. Next time: summary verbs (`test(config): schema validation suite — failing`) beat enumerations that go stale as tests accrete.
+- **Minor cross-platform gap.** `FileConfigService` uses `'/tmp'` as the absolute-last HOME fallback, where `os.homedir()` would be more correct (only matters when `HOME` env var is unset — rare on POSIX, normal on Windows). Filed as #22; trivial fix when cross-platform becomes a real concern.
+
+## Try
+
+- **Plan-in-slices, not tests-per-commit.** A slice = one behaviour + its test(s) + the minimal code to make them green. Usually corresponds to one Gherkin scenario, not one assertion. Target 6–10 commits per story instead of 14.
+- **Summary commit subjects.** `test(<scope>): <area> suite — failing (Story N.M)` rather than enumerating every case. Story id still in subject; state still (`test:`/`feat:`/`refactor:`); scenario detail lives in the commit body if needed.
+- **Explicit pre-authorized deps in the plan.** The pattern was successful here; keep it: list each new dep with version and a one-line rationale, mark as "authorized"; Sonnet installs at the designated commit step.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| A. CLAUDE.md § 6.4 — add a line on commit subjects (summary over enumeration) | CLAUDE.md in this PR | in same commit as this retro |
+| B. `os.homedir()` fallback in `FileConfigService` | issue #22 | open |
+| C. Plan-time: slice-per-commit not test-per-commit — fold into the next story's planning brief | next planning session | carried forward |
+
+## Loop metrics (second run)
+
+- Plan phase: 1 Explore agent + 1 Plan agent + 3-pass critical review.
+- Implementation: 1 Sonnet Task (9 commits — 14 planned, 5 collapsed with justification).
+- Phase-4 retro: **zero blockers** (first-run had 2). Two minor observations → one follow-up issue (#22) + one commit-style action in CLAUDE.md.
+- Deferred at plan: 1 issue (#21 dbPath traversal).
+- Deferred from retro: 1 issue (#22 HOME fallback).
+- Time-to-DoD: roughly on par with Story 1.3, but with far less Phase-4 churn — the DoR gate earned its keep.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "csv-parse": "^6.1.0",
         "dinero.js": "^1.9.1",
         "ora": "^9.1.0",
+        "yaml": "^2.8.3",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -3982,6 +3983,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "csv-parse": "^6.1.0",
     "dinero.js": "^1.9.1",
     "ora": "^9.1.0",
+    "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/core/config/app-config.ts
+++ b/src/core/config/app-config.ts
@@ -1,0 +1,19 @@
+import type { Money } from '@core/shared/money.js';
+
+export interface SplitRule {
+  readonly partner: string;
+  readonly ratio: number;
+}
+
+export interface BufferBucket {
+  readonly name: string;
+  readonly target: Money;
+  readonly cap?: Money;
+}
+
+export interface AppConfig {
+  readonly dbPath: string;
+  readonly defaultCurrency: string;
+  readonly splits: readonly SplitRule[];
+  readonly buffers: readonly BufferBucket[];
+}

--- a/src/core/ports/config-service.ts
+++ b/src/core/ports/config-service.ts
@@ -1,0 +1,6 @@
+import type { Result } from '@core/shared/result.js';
+import type { AppConfig } from '@core/config/app-config.js';
+
+export interface ConfigService {
+  load(): Result<AppConfig>;
+}

--- a/src/infra/config/config-schema.ts
+++ b/src/infra/config/config-schema.ts
@@ -88,14 +88,14 @@ export function parseRawConfig(raw: unknown): Result<AppConfig> {
   const data = parsed.data;
   const currency = data.defaultCurrency;
 
-  const buffers: AppConfig['buffers'] = [];
+  const buffers: Array<{ name: string; target: Money; cap?: Money }> = [];
   for (let i = 0; i < data.buffers.length; i++) {
     const b = data.buffers[i];
     const targetResult = Money.fromDecimal(b.target, currency);
     if (targetResult.isFailure) {
       return Result.fail(`buffers.${i}.target: ${targetResult.error}`);
     }
-    let cap: InstanceType<typeof Money> | undefined;
+    let cap: Money | undefined;
     if (b.cap !== undefined) {
       const capResult = Money.fromDecimal(b.cap, currency);
       if (capResult.isFailure) {

--- a/src/infra/config/config-schema.ts
+++ b/src/infra/config/config-schema.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+import type { ZodError } from 'zod';
+import { Result } from '@core/shared/result.js';
+import { Money } from '@core/shared/money.js';
+import type { AppConfig } from '@core/config/app-config.js';
+
+const SplitRuleSchema = z.object({
+  partner: z.string().min(1),
+  ratio: z.number().min(0).max(1),
+});
+
+const BufferBucketRawSchema = z.object({
+  name: z.string().min(1),
+  target: z.number().nonnegative(),
+  cap: z.number().nonnegative().optional(),
+});
+
+const RawConfigSchema = z
+  .object({
+    dbPath: z.string().min(1),
+    defaultCurrency: z
+      .string()
+      .regex(/^[A-Z]{3}$/, 'must be a 3-letter ISO 4217 code'),
+    splits: z
+      .array(SplitRuleSchema)
+      .min(1)
+      .superRefine((splits, ctx) => {
+        const sum = splits.reduce((acc, s) => acc + s.ratio, 0);
+        if (Math.abs(sum - 1.0) > 1e-9) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `ratios must sum to 1.0 (got ${sum.toFixed(4)})`,
+          });
+        }
+        const names = splits.map(s => s.partner);
+        names.forEach((name, i) => {
+          if (names.indexOf(name) !== i) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [i, 'partner'],
+              message: 'duplicate name',
+            });
+          }
+        });
+      }),
+    buffers: z
+      .array(BufferBucketRawSchema)
+      .superRefine((buffers, ctx) => {
+        buffers.forEach((b, i) => {
+          if (b.cap !== undefined && b.cap < b.target) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [i, 'cap'],
+              message: 'cap must be >= target',
+            });
+          }
+        });
+      })
+      .superRefine((buffers, ctx) => {
+        const names = buffers.map(b => b.name);
+        names.forEach((name, i) => {
+          if (names.indexOf(name) !== i) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [i, 'name'],
+              message: 'duplicate name',
+            });
+          }
+        });
+      }),
+  })
+  .strict();
+
+export function formatZodError(err: ZodError): string {
+  const issues = err.issues.map(issue => {
+    const pathStr = issue.path.length > 0 ? issue.path.join('.') + ': ' : '';
+    return `  - ${pathStr}${issue.message}`;
+  });
+  return `Invalid accounting config:\n${issues.join('\n')}`;
+}
+
+export function parseRawConfig(raw: unknown): Result<AppConfig> {
+  const parsed = RawConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    return Result.fail(formatZodError(parsed.error));
+  }
+
+  const data = parsed.data;
+  const currency = data.defaultCurrency;
+
+  const buffers: AppConfig['buffers'] = [];
+  for (let i = 0; i < data.buffers.length; i++) {
+    const b = data.buffers[i];
+    const targetResult = Money.fromDecimal(b.target, currency);
+    if (targetResult.isFailure) {
+      return Result.fail(`buffers.${i}.target: ${targetResult.error}`);
+    }
+    let cap: InstanceType<typeof Money> | undefined;
+    if (b.cap !== undefined) {
+      const capResult = Money.fromDecimal(b.cap, currency);
+      if (capResult.isFailure) {
+        return Result.fail(`buffers.${i}.cap: ${capResult.error}`);
+      }
+      cap = capResult.value;
+    }
+    buffers.push({ name: b.name, target: targetResult.value, cap });
+  }
+
+  return Result.ok({
+    dbPath: data.dbPath,
+    defaultCurrency: currency,
+    splits: data.splits,
+    buffers,
+  });
+}

--- a/src/infra/config/config-service.ts
+++ b/src/infra/config/config-service.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+import { parse as yamlParse } from 'yaml';
+import type { ConfigService } from '@core/ports/config-service.js';
+import type { AppConfig } from '@core/config/app-config.js';
+import { Result } from '@core/shared/result.js';
+import { parseRawConfig } from './config-schema.js';
+
+interface FileConfigServiceOptions {
+  projectDir: string;
+  xdgConfigHome?: string;
+  homeDir?: string;
+}
+
+export class FileConfigService implements ConfigService {
+  private readonly opts: FileConfigServiceOptions;
+
+  constructor(opts: FileConfigServiceOptions) {
+    this.opts = opts;
+  }
+
+  public load(): Result<AppConfig> {
+    const projectPath = path.join(this.opts.projectDir, 'accounting.yaml');
+
+    // XDG_CONFIG_HOME is read lazily at load time so tests can swap env easily
+    const xdgHome =
+      this.opts.xdgConfigHome ??
+      process.env['XDG_CONFIG_HOME'] ??
+      path.join(this.opts.homeDir ?? process.env['HOME'] ?? os_homedir(), '.config');
+
+    const xdgPath = path.join(xdgHome, 'accounting', 'config.yaml');
+
+    let rawContent: string | undefined;
+
+    if (fs.existsSync(projectPath)) {
+      rawContent = fs.readFileSync(projectPath, 'utf8');
+    } else if (fs.existsSync(xdgPath)) {
+      rawContent = fs.readFileSync(xdgPath, 'utf8');
+    } else {
+      return Result.fail(
+        `No config file found. Searched:\n  - ${projectPath}\n  - ${xdgPath}\n` +
+          `Copy accounting.example.yaml to accounting.yaml and edit it.`,
+      );
+    }
+
+    let raw: unknown;
+    try {
+      raw = yamlParse(rawContent);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return Result.fail(`Malformed YAML: ${msg}`);
+    }
+
+    return parseRawConfig(raw);
+  }
+}
+
+function os_homedir(): string {
+  return process.env['HOME'] ?? '/tmp';
+}

--- a/src/infra/config/config-service.ts
+++ b/src/infra/config/config-service.ts
@@ -26,7 +26,7 @@ export class FileConfigService implements ConfigService {
     const xdgHome =
       this.opts.xdgConfigHome ??
       process.env['XDG_CONFIG_HOME'] ??
-      path.join(this.opts.homeDir ?? process.env['HOME'] ?? os_homedir(), '.config');
+      path.join(this.opts.homeDir ?? process.env['HOME'] ?? '/tmp', '.config');
 
     const xdgPath = path.join(xdgHome, 'accounting', 'config.yaml');
 
@@ -53,8 +53,4 @@ export class FileConfigService implements ConfigService {
 
     return parseRawConfig(raw);
   }
-}
-
-function os_homedir(): string {
-  return process.env['HOME'] ?? '/tmp';
 }

--- a/src/infra/db/sqlite-client.ts
+++ b/src/infra/db/sqlite-client.ts
@@ -1,14 +1,19 @@
+import fs from 'fs';
 import Database from 'better-sqlite3';
 
 let dbInstance: Database.Database | null = null;
 
 export function getDb(dbPath: string = 'accounting.db'): Database.Database {
   if (!dbInstance) {
+    const isNewFile = dbPath !== ':memory:' && !fs.existsSync(dbPath);
     dbInstance = new Database(dbPath);
     // WAL mode defaults to synchronous = FULL, satisfying NFR7 (>= NORMAL).
     dbInstance.pragma('journal_mode = WAL');
     // Enforce FK constraints at the connection level (defense-in-depth).
     dbInstance.pragma('foreign_keys = ON');
+    if (isNewFile && process.platform !== 'win32') {
+      fs.chmodSync(dbPath, 0o600);
+    }
   }
   return dbInstance;
 }

--- a/tests/integration/infra/config/config-service.test.ts
+++ b/tests/integration/infra/config/config-service.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { FileConfigService } from '../../../../src/infra/config/config-service.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Walk up from this test file to the repo root to find accounting.example.yaml
+const repoRoot = path.resolve(__dirname, '../../../../');
+
+function writeConfig(dir: string, filename: string, content: string): void {
+  fs.writeFileSync(path.join(dir, filename), content, 'utf8');
+}
+
+const validYaml = `
+dbPath: ./data/ledger.db
+defaultCurrency: EUR
+splits:
+  - partner: Alex
+    ratio: 0.5
+  - partner: Sam
+    ratio: 0.5
+buffers:
+  - name: Car
+    target: 1000
+  - name: House
+    target: 5000
+    cap: 10000
+`;
+
+describe('FileConfigService', () => {
+  let tmpDir: string;
+  let xdgDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-config-test-'));
+    xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-xdg-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(xdgDir, { recursive: true });
+  });
+
+  it('loads accounting.yaml from projectDir when present', () => {
+    writeConfig(tmpDir, 'accounting.yaml', validYaml);
+    const service = new FileConfigService({ projectDir: tmpDir, xdgConfigHome: xdgDir });
+
+    // fails if FileConfigService does not read accounting.yaml from projectDir
+    const result = service.load();
+
+    expect(result.isSuccess).toBe(true);
+    const config = result.value;
+    expect(config.defaultCurrency).toBe('EUR');
+    expect(config.splits).toHaveLength(2);
+    expect(config.splits[0].partner).toBe('Alex');
+    expect(config.splits[0].ratio).toBe(0.5);
+    expect(config.buffers[0].target.amount).toBe(100000);
+    expect(config.buffers[0].target.currency).toBe('EUR');
+  });
+
+  it('falls back to XDG_CONFIG_HOME/accounting/config.yaml', () => {
+    const xdgSubDir = path.join(xdgDir, 'accounting');
+    fs.mkdirSync(xdgSubDir, { recursive: true });
+    writeConfig(xdgSubDir, 'config.yaml', validYaml);
+    const service = new FileConfigService({ projectDir: tmpDir, xdgConfigHome: xdgDir });
+
+    // fails if FileConfigService does not fall back to XDG path when project file absent
+    const result = service.load();
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.defaultCurrency).toBe('EUR');
+  });
+
+  it('fails with both-missing error citing both paths AND mentioning accounting.example.yaml', () => {
+    const service = new FileConfigService({ projectDir: tmpDir, xdgConfigHome: xdgDir });
+
+    // fails if FileConfigService does not report both searched paths when neither file exists
+    const result = service.load();
+
+    expect(result.isFailure).toBe(true);
+    const err = result.error;
+    expect(err).toContain(path.join(tmpDir, 'accounting.yaml'));
+    expect(err).toContain(path.join(xdgDir, 'accounting', 'config.yaml'));
+    expect(err).toContain('accounting.example.yaml');
+  });
+
+  it('fails on malformed YAML syntax with readable message (no stack trace)', () => {
+    writeConfig(tmpDir, 'accounting.yaml', 'key: [unclosed bracket');
+    const service = new FileConfigService({ projectDir: tmpDir, xdgConfigHome: xdgDir });
+
+    // fails if malformed YAML throws instead of returning Result.fail
+    const result = service.load();
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('Malformed YAML');
+    expect(result.error).not.toContain('at Object');
+    expect(result.error).not.toContain('Error:');
+  });
+
+  it('fails on schema violation (propagates schema error)', () => {
+    writeConfig(tmpDir, 'accounting.yaml', 'dbPath: ./data/ledger.db\ndefaultCurrency: EUR\n');
+    const service = new FileConfigService({ projectDir: tmpDir, xdgConfigHome: xdgDir });
+
+    // fails if schema validation errors are not propagated from FileConfigService
+    const result = service.load();
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('splits');
+  });
+
+  it('accounting.example.yaml at repo root itself validates', () => {
+    const examplePath = path.join(repoRoot, 'accounting.example.yaml');
+    const exampleContent = fs.readFileSync(examplePath, 'utf8');
+    writeConfig(tmpDir, 'accounting.yaml', exampleContent);
+    const service = new FileConfigService({ projectDir: tmpDir, xdgConfigHome: xdgDir });
+
+    // fails if accounting.example.yaml drifts from the schema and no longer validates
+    const result = service.load();
+
+    expect(result.isSuccess).toBe(true);
+  });
+});

--- a/tests/integration/infra/db/sqlite-transaction-repo.test.ts
+++ b/tests/integration/infra/db/sqlite-transaction-repo.test.ts
@@ -185,6 +185,47 @@ describe('SqliteTransactionRepository', () => {
     });
   });
 
+  describe('File permissions (NFR11)', () => {
+    it.skipIf(process.platform === 'win32')(
+      'getDb() chmods a newly-created DB file to 0o600 on POSIX',
+      () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-chmod-test-'));
+        closeDb();
+        try {
+          const dbPath = path.join(tmpDir, 'new.db');
+          // fails if getDb() does not chmod a newly-created DB file to 0o600
+          getDb(dbPath);
+          const stat = fs.statSync(dbPath);
+          expect(stat.mode & 0o777).toBe(0o600);
+        } finally {
+          closeDb();
+          fs.rmSync(tmpDir, { recursive: true });
+        }
+      },
+    );
+
+    it.skipIf(process.platform === 'win32')(
+      'getDb() leaves an existing DB file perms unchanged (0o644 stays 0o644 on POSIX)',
+      () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-chmod-test-'));
+        closeDb();
+        try {
+          const dbPath = path.join(tmpDir, 'existing.db');
+          // Pre-create the file with 0o644 permissions
+          fs.writeFileSync(dbPath, '');
+          fs.chmodSync(dbPath, 0o644);
+          // fails if getDb() modifies permissions on a pre-existing DB file
+          getDb(dbPath);
+          const stat = fs.statSync(dbPath);
+          expect(stat.mode & 0o777).toBe(0o644);
+        } finally {
+          closeDb();
+          fs.rmSync(tmpDir, { recursive: true });
+        }
+      },
+    );
+  });
+
   describe('Repository surface (type-level)', () => {
     it('exposes save and findById', () => {
       expect(typeof repo.save).toBe('function');

--- a/tests/unit/infra/config/config-schema.test.ts
+++ b/tests/unit/infra/config/config-schema.test.ts
@@ -140,7 +140,7 @@ describe('parseRawConfig', () => {
           fc.array(
             fc.record({
               partner: fc.string({ minLength: 1, maxLength: 10 }).filter(s => /^[a-zA-Z]+$/.test(s)),
-              weight: fc.float({ min: 0.01, max: 1.0, noNaN: true }),
+              weight: fc.float({ min: Math.fround(0.01), max: Math.fround(1.0), noNaN: true }),
             }),
             { minLength: 1, maxLength: 5 },
           ).filter(items => {
@@ -166,7 +166,7 @@ describe('parseRawConfig', () => {
           fc.array(
             fc.record({
               partner: fc.string({ minLength: 1, maxLength: 10 }).filter(s => /^[a-zA-Z]+$/.test(s)),
-              ratio: fc.float({ min: 0.01, max: 0.4, noNaN: true }),
+              ratio: fc.float({ min: Math.fround(0.01), max: Math.fround(0.4), noNaN: true }),
             }),
             { minLength: 1, maxLength: 3 },
           ).filter(items => {

--- a/tests/unit/infra/config/config-schema.test.ts
+++ b/tests/unit/infra/config/config-schema.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import { parseRawConfig } from '../../../../src/infra/config/config-schema.js';
+
+const minimalValid = {
+  dbPath: './data/ledger.db',
+  defaultCurrency: 'EUR',
+  splits: [
+    { partner: 'Alex', ratio: 0.5 },
+    { partner: 'Sam', ratio: 0.5 },
+  ],
+  buffers: [],
+};
+
+describe('parseRawConfig', () => {
+  it('accepts minimal valid config (no buffers)', () => {
+    // fails if parseRawConfig rejects a config with empty buffers array
+    const result = parseRawConfig(minimalValid);
+    expect(result.isSuccess).toBe(true);
+    const config = result.value;
+    expect(config.defaultCurrency).toBe('EUR');
+    expect(config.splits).toHaveLength(2);
+  });
+
+  it('rejects missing splits with friendly message', () => {
+    const raw = { dbPath: './data/ledger.db', defaultCurrency: 'EUR', buffers: [] };
+    // fails if parseRawConfig does not produce a human-readable error for missing splits
+    const result = parseRawConfig(raw);
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('splits');
+    expect(result.error).not.toContain('ZodError');
+    expect(result.error).not.toContain('at Object');
+  });
+
+  it('rejects ratios not summing to 1', () => {
+    const raw = {
+      ...minimalValid,
+      splits: [
+        { partner: 'Alex', ratio: 0.4 },
+        { partner: 'Sam', ratio: 0.5 },
+      ],
+    };
+    // fails if parseRawConfig does not validate that split ratios sum to 1.0
+    const result = parseRawConfig(raw);
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('ratios must sum to 1.0');
+  });
+
+  it('rejects duplicate partner names — error cites path not value', () => {
+    const raw = {
+      ...minimalValid,
+      splits: [
+        { partner: 'Alex', ratio: 0.5 },
+        { partner: 'Alex', ratio: 0.5 },
+      ],
+    };
+    // fails if parseRawConfig does not detect duplicate partner names
+    const result = parseRawConfig(raw);
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('duplicate');
+    // PII-safe: error must NOT contain the actual partner name value
+    expect(result.error).not.toContain('Alex');
+  });
+
+  it('rejects ratio out of [0,1]', () => {
+    const raw = {
+      ...minimalValid,
+      splits: [
+        { partner: 'Alex', ratio: 1.5 },
+        { partner: 'Sam', ratio: -0.5 },
+      ],
+    };
+    // fails if parseRawConfig does not validate ratio range [0, 1]
+    const result = parseRawConfig(raw);
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('rejects non-ISO currency ("EURO")', () => {
+    const raw = { ...minimalValid, defaultCurrency: 'EURO' };
+    // fails if parseRawConfig does not enforce 3-letter ISO currency code
+    const result = parseRawConfig(raw);
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('3-letter ISO 4217');
+  });
+
+  it('rejects buffer with cap < target', () => {
+    const raw = {
+      ...minimalValid,
+      buffers: [{ name: 'Car', target: 200, cap: 100 }],
+    };
+    // fails if parseRawConfig does not enforce cap >= target for buffers
+    const result = parseRawConfig(raw);
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('cap');
+  });
+
+  it('rejects duplicate bucket names — error cites path not value', () => {
+    const raw = {
+      ...minimalValid,
+      buffers: [
+        { name: 'Car', target: 1000 },
+        { name: 'Car', target: 2000 },
+      ],
+    };
+    // fails if parseRawConfig does not detect duplicate bucket names
+    const result = parseRawConfig(raw);
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('duplicate');
+    // PII-safe: error must NOT contain the actual bucket name value
+    expect(result.error).not.toContain('Car');
+  });
+
+  it('rejects unknown top-level key ("dbPaht")', () => {
+    const raw = { ...minimalValid, dbPaht: './data/ledger.db' };
+    // fails if parseRawConfig does not reject unknown top-level keys (schema not strict)
+    const result = parseRawConfig(raw);
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('dbPaht');
+  });
+
+  it('maps decimal targets/caps to Money with defaultCurrency', () => {
+    const raw = {
+      ...minimalValid,
+      buffers: [{ name: 'Car', target: 1000.5, cap: 2000 }],
+    };
+    // fails if parseRawConfig does not convert decimal amounts to Money using defaultCurrency
+    const result = parseRawConfig(raw);
+    expect(result.isSuccess).toBe(true);
+    const bucket = result.value.buffers[0];
+    expect(bucket.target.amount).toBe(100050);
+    expect(bucket.target.currency).toBe('EUR');
+    expect(bucket.cap?.amount).toBe(200000);
+    expect(bucket.cap?.currency).toBe('EUR');
+  });
+
+  describe('property tests', () => {
+    it('succeeds for any splits where ratios sum to 1 with unique partners', () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.record({
+              partner: fc.string({ minLength: 1, maxLength: 10 }).filter(s => /^[a-zA-Z]+$/.test(s)),
+              weight: fc.float({ min: 0.01, max: 1.0, noNaN: true }),
+            }),
+            { minLength: 1, maxLength: 5 },
+          ).filter(items => {
+            const names = items.map(i => i.partner);
+            return new Set(names).size === names.length;
+          }),
+          (items) => {
+            const totalWeight = items.reduce((sum, i) => sum + i.weight, 0);
+            const splits = items.map(i => ({ partner: i.partner, ratio: i.weight / totalWeight }));
+            const raw = { ...minimalValid, splits };
+            // fails if parseRawConfig rejects a splits array whose ratios were correctly rescaled to sum to 1
+            const result = parseRawConfig(raw);
+            return result.isSuccess;
+          },
+        ),
+        { numRuns: 50 },
+      );
+    });
+
+    it('fails for any splits where ratios do not sum to 1', () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.record({
+              partner: fc.string({ minLength: 1, maxLength: 10 }).filter(s => /^[a-zA-Z]+$/.test(s)),
+              ratio: fc.float({ min: 0.01, max: 0.4, noNaN: true }),
+            }),
+            { minLength: 1, maxLength: 3 },
+          ).filter(items => {
+            const names = items.map(i => i.partner);
+            const sum = items.reduce((s, i) => s + i.ratio, 0);
+            return new Set(names).size === names.length && Math.abs(sum - 1.0) > 1e-9;
+          }),
+          (items) => {
+            const raw = { ...minimalValid, splits: items };
+            // fails if parseRawConfig accepts a splits array whose ratios do not sum to 1
+            const result = parseRawConfig(raw);
+            return result.isFailure;
+          },
+        ),
+        { numRuns: 50 },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 1. Story

[Story 1.4 — Configuration Manager](https://github.com/xavierbriand/accounting/blob/main/docs/epics.md#story-14-configuration-manager) in `docs/epics.md` (Epic 1 — Foundation & Core Ledger).

> **As an** Admin User, **I want to** define my split rules and buffer targets in an `accounting.yaml` file, **so that** the system knows how to process my finances without hardcoding values.

Secondary scope (explicit NFR11 corollary per CLAUDE.md § 3 deferred from Story 1.3): wire `0600` file permissions for newly-created DB files in `sqlite-client.ts`.

## 2. Intent

Wire the Admin-user-facing configuration pipeline: YAML at a known path → Zod validation → Core `AppConfig` with `Money`-typed monetary fields. Honour the Ports & Adapters layering (Zod + yaml in Infra, types in Core). Deliver the deferred NFR11 `0600` rule for newly-created DB files at the same time. Human-readable errors; no stack traces.

## 3. Alternatives considered

- **`js-yaml` vs `yaml`.** Chose `yaml` (eemeli) — TS-native, smaller, maintained.
- **Core holds decimals vs Core holds `Money`.** Chose `Money` — keeps Core fully validated past the boundary; parallels `Transaction`.
- **Injected `fs` / `yamlParser` for testability.** Rejected — speculative abstraction; integration tests use real fs + `mkdtempSync`.
- **Time-series splits now.** Rejected — FR12 / Epic 3 concern; AC says "splits" (singular rule set).
- **`chmod` on every open (idempotent).** Rejected per user — only on new file creation.
- **Structured `ValidationError` DTO vs flat string.** Chose flat string for v1; revisit when `--json` output lands (Epic 4).
- **Terse-map YAML shape for splits / buffers.** Rejected — object arrays are explicit, preserve order, extend cleanly.
- **Check in `accounting.yaml`.** Rejected (user flag) — contains real household data. Git-ignore the real file; ship `accounting.example.yaml` as a checked-in template.
- **Split into 1.4a + 1.4b.** Rejected — one coherent "load config safely" story.

## 4. Selected solution & rationale

1. **Two-table contract.** `AppConfig` = `{ dbPath, defaultCurrency, splits: SplitRule[], buffers: BufferBucket[] }`. All types in `src/core/config/`. Port in `src/core/ports/`. Zod schema + `FileConfigService` in `src/infra/config/`. No Zod in Core.
2. **YAML shape (object arrays):** `splits: [{ partner, ratio }]`; `buffers: [{ name, target, cap? }]`. Decimals in YAML; `Money.fromDecimal` at the boundary.
3. **Repo surface:** `ConfigService.load(): Result<AppConfig>`. Single method.
4. **File resolution:** `./accounting.yaml` → `\$XDG_CONFIG_HOME/accounting/config.yaml` (default `\$HOME/.config/…`). Both missing → `Result.fail` naming both paths AND pointing at `accounting.example.yaml`.
5. **Error format:** flat multiline string. Each issue on its own line (`path.join('.') + ': ' + message`).
6. **DB `0600`:** detect newly-created via `fs.existsSync` *before* open; `fs.chmodSync(dbPath, 0o600)` after open, POSIX only. Guard against `:memory:`.
7. **Gitignore:** add `/accounting.yaml`.
8. **Template:** `accounting.example.yaml` at repo root, fully commented, checked in. Validated by a dedicated test to catch example drift.
9. **README:** short Configuration subsection pointing at the template + XDG fallback.

## 5. Gherkin scenarios

\`\`\`gherkin
Feature: Configuration loading

  Scenario: Valid accounting.yaml in project root loads successfully
    Given a valid accounting.yaml in the project directory
    When ConfigService.load() is called
    Then the result is Success with an AppConfig
    And the split ratios match the file
    And buffer targets are Money instances in the defaultCurrency

  Scenario: Fallback to XDG_CONFIG_HOME/accounting/config.yaml
    Given no accounting.yaml in the project directory
    And a valid config.yaml under XDG_CONFIG_HOME/accounting
    When ConfigService.load() is called
    Then the result is Success with an AppConfig matching the XDG file

  Scenario: Both locations missing fails with a readable message
    Given no accounting.yaml in the project directory
    And no config.yaml under XDG_CONFIG_HOME/accounting
    When ConfigService.load() is called
    Then the result is Failure
    And the error names both searched paths
    And the error tells the user to copy accounting.example.yaml

  Scenario: Missing required field returns a readable validation error
    Given an accounting.yaml missing the "splits" key
    When ConfigService.load() is called
    Then the result is Failure
    And the error reads like prose (e.g. "splits: Required") with no TypeScript type name or stack trace

  Scenario: Split ratios not summing to 1.0 are rejected
    Given an accounting.yaml where split ratios sum to 0.9
    When ConfigService.load() is called
    Then the result is Failure
    And the error mentions "ratios must sum to 1.0"

  Scenario: Buffer cap less than target is rejected
    Given an accounting.yaml where a buffer has cap 100 and target 200
    When ConfigService.load() is called
    Then the result is Failure
    And the error names the offending buffer and explains cap >= target

  Scenario: Malformed YAML syntax is reported, not thrown
    Given an accounting.yaml containing invalid YAML syntax
    When ConfigService.load() is called
    Then the result is Failure
    And the error is a human-readable parse message (no stack trace)

  Scenario: New DB file is created with 0600 permissions on POSIX
    Given a POSIX platform
    And no DB file exists at the target path
    When getDb() opens the DB
    Then the file's mode & 0o777 equals 0o600

  Scenario: Existing DB file's perms are not modified
    Given a POSIX platform
    And a DB file exists at the target path with mode 0o644
    When getDb() opens the DB
    Then the file's mode & 0o777 remains 0o644
\`\`\`

## 6. Plan for Sonnet

### Files to create

- **\`src/core/config/app-config.ts\`** — \`AppConfig\`, \`SplitRule\`, \`BufferBucket\` interfaces. \`BufferBucket.target\` is \`Money\`; \`cap\` is \`Money | undefined\`. \`splits\` is \`readonly SplitRule[]\`. No Zod, no Node APIs.
- **\`src/core/ports/config-service.ts\`** — \`interface ConfigService { load(): Result<AppConfig> }\`.
- **\`src/infra/config/config-schema.ts\`** — Zod v4 schemas; \`parseRawConfig(raw: unknown): Result<AppConfig, string>\` handles \`.safeParse()\` + decimal→Money mapping; \`formatZodError(err: ZodError): string\` flattens to multiline.
- **\`src/infra/config/config-service.ts\`** — \`FileConfigService implements ConfigService\` with \`(opts: { projectDir: string; xdgConfigHome?: string; homeDir?: string })\` constructor. \`load()\` tries project path → XDG path → both-missing error (naming both paths + mentioning the template file).
- **\`accounting.example.yaml\`** at repo root — checked in, fully commented, a valid config by itself. Values like \`dbPath: ./data/ledger.db\`, \`defaultCurrency: EUR\`, Alex/Sam 50/50 splits, Car + House buffer buckets. Header comment: "Copy to accounting.yaml (git-ignored) and edit."
- **\`tests/unit/infra/config/config-schema.test.ts\`** — unit tests + fast-check property (ratio-sum invariant).
- **\`tests/integration/infra/config/config-service.test.ts\`** — integration tests via \`fs.mkdtempSync\`.

### Schema rules

- \`dbPath\`: \`z.string().min(1)\`.
- \`defaultCurrency\`: \`z.string().regex(/^[A-Z]{3}\$/, 'must be a 3-letter ISO 4217 code')\`.
- \`splits\`: \`z.array(SplitRule).min(1)\` with superRefine — ratios sum to 1 (ε = 1e-9); partner names unique (case-sensitive).
- Each \`ratio\`: \`z.number().min(0).max(1)\`.
- \`buffers\`: \`z.array(BufferBucket)\` — empty array allowed.
  - \`name\`: non-empty string; unique across array (superRefine).
  - \`target\`: \`z.number().nonnegative()\`.
  - \`cap\`: \`z.number().nonnegative().optional()\`; if present, \`cap >= target\` (superRefine).
- Top-level schema \`.strict()\` — unknown keys rejected.

### Error translator sample

\`\`\`
Invalid accounting config:
  - splits: ratios must sum to 1.0 (got 0.9)
  - buffers.0.target: Expected number, received "abc"
  - defaultCurrency: must be a 3-letter ISO 4217 code
\`\`\`

### Files to modify

- **\`src/infra/db/sqlite-client.ts\`** — compute \`const isNewFile = dbPath !== ':memory:' && !fs.existsSync(dbPath);\` before open. After opening + pragmas, if \`isNewFile && process.platform !== 'win32'\`, \`fs.chmodSync(dbPath, 0o600)\`.
- **\`tests/integration/infra/db/sqlite-transaction-repo.test.ts\`** — add \`describe('File permissions (NFR11)')\`:
  - \`getDb() chmods a newly-created DB file to 0o600 on POSIX\` (\`it.skipIf(process.platform === 'win32')\`).
  - \`getDb() leaves an existing DB file's perms unchanged (0o644 stays 0o644 on POSIX)\`.
- **\`package.json\`** — add \`"yaml": "^2.5.0"\` (or latest stable 2.x) to \`dependencies\`.
- **\`.gitignore\`** — add a new \`# Accounting config\` section with \`/accounting.yaml\`.
- **\`README.md\`** — append a short "Configuration" subsection.

### Tests (name conventions + "fails if …" comments)

Each test includes a \`// fails if …\` comment immediately above its main assertion, naming the production-path condition it guards (Story 1.3 retro action item).

- **Unit — \`config-schema.test.ts\`:**
  - \`accepts minimal valid config (no buffers)\`
  - \`rejects missing splits with friendly message\`
  - \`rejects ratios not summing to 1\`
  - \`rejects duplicate partner names\`
  - \`rejects ratio out of [0,1]\`
  - \`rejects non-ISO currency ("EURO")\`
  - \`rejects buffer with cap < target\`
  - \`rejects duplicate bucket names\`
  - \`rejects unknown top-level key ("dbPaht")\`
  - \`maps decimal targets/caps to Money with defaultCurrency\`
  - **Property (fast-check):** for any splits array with ratios that sum to 1 (rescaled) + unique partners, \`parseRawConfig\` succeeds; for any array that does not sum to 1, it fails.
- **Integration — \`config-service.test.ts\`:**
  - \`loads accounting.yaml from projectDir when present\`
  - \`falls back to XDG_CONFIG_HOME/accounting/config.yaml\`
  - \`fails with both-missing error citing both paths AND mentioning accounting.example.yaml\`
  - \`fails on malformed YAML syntax with readable message (no stack trace)\`
  - \`fails on schema violation (propagates schema error)\`
  - \`accounting.example.yaml at repo root itself validates\` — read via \`fs.readFileSync\` from the checked-in file; catches drift.

### TDD commit sequence (each subject ends \`(Story 1.4)\`)

1. \`test(config): load valid accounting.yaml parses to AppConfig — failing (Story 1.4)\`
2. \`test(config): schema rejects missing splits, non-ISO currency, ratio sum — failing (Story 1.4)\`
3. \`feat(config): AppConfig types + Zod schema happy path — minimal green (Story 1.4)\`
4. \`feat(config): schema validation rules (ratios, currency, buffers) — minimal green (Story 1.4)\`
5. \`test(config): FileConfigService XDG fallback and both-missing — failing (Story 1.4)\`
6. \`feat(config): FileConfigService with project + XDG resolution — minimal green (Story 1.4)\` *(installs \`yaml@^2\` per plan authorization — call out in Deviations)*
7. \`test(config): malformed YAML syntax + schema violation propagate — failing (Story 1.4)\`
8. \`feat(config): yaml parse error translation + error plumbing — minimal green (Story 1.4)\`
9. \`test(config): property test — ratio-sum invariant (Story 1.4)\` *(green-on-landing OK per CLAUDE.md § 6.4; note in Deviations)*
10. \`test(db): sqlite-client chmods 0600 on new POSIX file — failing (Story 1.4)\`
11. \`feat(db): wire 0600 chmod into getDb for new files — minimal green (Story 1.4)\`
12. \`feat(config): accounting.example.yaml template + .gitignore entry + README subsection (Story 1.4)\`
13. \`test(config): accounting.example.yaml itself validates (Story 1.4)\` *(green-on-landing OK; note in Deviations)*
14. \`refactor(config): tidy or empty-justification (Story 1.4)\`

Sonnet may collapse consecutive steps that go green-on-landing; call each collapse out in Deviations.

### Gotchas

- \`yaml.parse()\` throws on malformed YAML — wrap in try/catch; translate to \`Result.fail("Malformed YAML: <message>")\`.
- Zod v4: use \`.safeParse()\`; \`.parse()\` throws.
- \`fs.existsSync(':memory:')\` returns \`false\`, so guard on \`dbPath !== ':memory:'\` explicitly before chmod.
- POSIX-only chmod: integration tests \`it.skipIf(process.platform === 'win32')\`.
- Do not disturb the WAL + FK pragmas already in \`sqlite-client.ts\`.
- Every test has a \`// fails if …\` comment above its main assertion (Story 1.3 retro action item).
- \`FileConfigService\` reads \`process.env.XDG_CONFIG_HOME\` lazily inside \`load()\` (not captured at construction) — makes env-swap in tests painless.

### Leave alone

- \`src/core/ledger/\`, \`src/core/shared/\`.
- Existing migrations.
- \`src/cli/\` — CLI wiring of \`FileConfigService\` lives with the first command that needs a loaded config (Epic 2).

## 7. Suggestion log

3-phase critical review on the plan complete. DoR gate: all suggestions tagged; adopted items folded into §§ 4 / 6; deferred item linked to #21.

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P1 | Plan satisfies Story 1.4 ACs and FR coverage (FR1, FR2, FR3, NFR11); Gherkin scenarios concrete and testable. | adopted | Confirmation only — no change. |
| P2 | `quality-assurance.md` § Privacy: partner / bucket names are PII — validation error messages must not echo them verbatim (logging risk). | adopted | Added a Gotcha in § 6 + instruction that duplicate-name errors cite the JSON path, not the value; assertion added to unit tests. |
| P3 | `.gitignore` should cover `/accounting.yml` too — YAML spec allows both extensions; if a user creates `.yml` by habit it would still be committed. | adopted | Updated § 6 → `.gitignore` entry now covers both `.yaml` and `.yml`. |
| P3 | Test that reads `accounting.example.yaml` must resolve the path from the module (via `fileURLToPath(import.meta.url)`), not from `process.cwd()`. | adopted | Added to Gotchas in § 6. |
| P3 | `dbPath` in config is user-controlled; path-traversal validation becomes a concern when CLI wires ConfigService → getDb. Not a Story 1.4 blocker (nothing in 1.4 opens the path). | deferred | #21 — dedicated story when CLI wiring lands (Epic 2). |

**DoR gate reached.** No un-tagged items. Plan rewritten to incorporate adopted changes. Deferred item linked to #21.


## 8. Sonnet's learnings

Single Sonnet Task run (commits `1e6837e → 6388d5f`). 9 commits delivered vs 14 planned — 5 justified collapses; zero Phase-4 blockers.

**What was built.** All 9 Gherkin scenarios from § 5 pass. Core: `AppConfig`, `SplitRule`, `BufferBucket` in `src/core/config/`; `ConfigService` port. Infra: `FileConfigService` (project→XDG path resolution, yaml.parse, error translation) + Zod schema with PII-safe `superRefine` messages. `sqlite-client.ts` chmods newly-created DB files to `0o600` on POSIX. `accounting.example.yaml` checked in; `/accounting.yaml` + `/accounting.yml` gitignored. README has a new Configuration section. `npm run migrate` on a fresh DB → `ls -l accounting.db` reports `-rw-------`. 46/46 tests pass.

**Red → green sequence.**
- `test(config): load valid accounting.yaml parses to AppConfig — failing` · `1e6837e` — integration tests red.
- `test(config): schema rejects missing splits, non-ISO currency, ratio sum — failing` · `044ab7a` — unit schema tests red.
- `feat(config): AppConfig types + Zod schema happy path — minimal green` · `466b807` — unit + property assertions green (commits #3 + #4 collapsed).
- `feat(config): FileConfigService with project + XDG resolution — minimal green` · `a59ae68` — all non-example integration tests green; installs `yaml@^2` (pre-authorized).
- `test(db): sqlite-client chmods 0600 on new POSIX file — failing` · `569d890` — chmod test red.
- `feat(db): wire 0600 chmod into getDb for new files — minimal green` · `6ce1d16` — chmod tests green.
- `feat(config): accounting.example.yaml template + .gitignore entry + README subsection` · `5985fc6` — example-drift test turns green.
- `test(config): property test — ratio-sum invariant (+ minor fc.float constraint fix)` · `a12a6e6` — green-on-landing per CLAUDE.md § 6.4.
- `refactor(config): remove dead os_homedir helper` · `6388d5f` — one-line cleanup found during review.

**Deviations.** Five collapses (all justified in commit bodies + Sonnet's report). One authorized new dep (`yaml@^2.8.3`). Minor `fc.float(Math.fround(...))` to satisfy fast-check v4's 32-bit-float constraint.

**Unknowns.** None.

**Proposed follow-ups.**
- `dbPath` path-traversal validation when CLI wires ConfigService → getDb (already tracked as #21).
- `accounting.example.yaml` references `./data/ledger.db` — the `data/` directory isn't auto-created by `migrate`. First-run directory creation would improve UX.

## 9. Retrospective

Full file: [docs/retrospectives/story-1.4.md](../blob/feat/config-manager-story-1.4/docs/retrospectives/story-1.4.md). Three-line summary:

- **Keep:** pre-implementation Suggestion Log caught the PII-leak risk before code was written (zero Phase-4 blockers); pre-delegation alias/tsconfig check + "this test fails if …" comments (Story 1.3 retro actions) paid off; `accounting.example.yaml` drift-guard test is cheap insurance.
- **Change:** plan over-decomposed commits (14 planned → 9 actual with 5 collapses) — plan in *slices*, not tests-per-commit; commit subjects were enumerations that went stale — use summary verbs. Both changes landed in CLAUDE.md § 6.4 in this PR.
- **Try:** plan-in-slices for the next story (target 6–10 commits); explicit pre-authorized dep list in the plan kept working — formalize it.

Loop metrics: 1 Explore + 1 Plan + 3-pass critical review; 1 Sonnet Task (9 commits, zero refactor pass needed); 2 minor retro findings → 1 follow-up issue (#22). DoR gate earned its keep.

## 10. Merge checklist

- [x] `lint` / `build` / `test` green locally (CI will confirm — 46/46 tests pass)
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-1.4.md`
- [x] All suggestion-log items resolved (no blank `Resolution` cells; deferred linked to #21)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation; zero blockers)
- [x] User approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)
