### PR TITLE
feat(ingest): transaction builder + auto-tagger + card-settlement classifier (Story 2.3)

### DIFF
--- a/.claude/agents/sonnet-implementer.md
+++ b/.claude/agents/sonnet-implementer.md
@@ -35,6 +35,8 @@ Never combine red and green in one commit. Never write implementation before the
 
 You may do local, behaviour-preserving cleanups while tests are green: rename a variable, extract a small helper, collapse a duplicated literal. Everything else — new abstractions, cross-module moves, touching >~20 LOC of existing code — defers to the post-review refactor phase. When you use the allowance, call it out in the "Deviations" section of the return.
 
+**60 LOC + duplication trigger (retro finding, Story 2.3).** If a newly-written function ends up over ~60 LOC with ≥2 duplicated blocks (same payload shape, different arguments), call it out explicitly in "Deviations" as a post-green refactor candidate — do not silently ship the bloat. The initial refactor slot may still defer the extraction (if it'd exceed the 20-LOC-touch rule against the just-written code), but the *signal* must be surfaced. Otherwise Opus's Phase 4 review discovers it by eyeball, adding a round-trip.
+
 ## 4. Return format (mandatory)
 
 When you finish, return **exactly** this structure. No preamble, no trailing commentary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ On conflict between this file and a `docs/` file, `docs/` wins. The retrospectiv
 
 **Couples Expense Sharing App** — a local-first, CLI-based "predictive asset-based financial engine" for couples managing joint finances. Replaces reactive joint-account top-ups with a deterministic engine that predicts fair transfers, buffers volatility, and keeps an immutable ledger.
 
-**Current position:** Epic 2 (Transaction Ingestion & Tagging). Stories 1.1–1.4 + 2.1 are done. **Next story: 2.3 — Transaction Builder & Auto-Tagging Domain Service.** *This line is refreshed by the retrospective phase of each story.*
+**Current position:** Epic 2 (Transaction Ingestion & Tagging). Stories 1.1–1.4 + 2.1–2.3 are done. **Next story: 2.4 — Interactive Ingest Command (CLI).** *This line is refreshed by the retrospective phase of each story.*
 
 **Stack:** Node.js 20, TypeScript (strict), SQLite via `better-sqlite3` (WAL), `dinero.js`, `commander`, `zod`, `vitest` + `fast-check`.
 

--- a/accounting.example.yaml
+++ b/accounting.example.yaml
@@ -22,8 +22,11 @@ timezone: Europe/Paris
 # Prefixes must be unique so a file matches at most one account.
 accounts:
   - id: main-12345678901
+    type: bank
     filenamePrefix: "12345678901_"
   - id: card-1234
+    type: card
+    cardSuffix: "1234"
     filenamePrefix: "carte_1234_"
 
 # Split rules: who pays what share of shared expenses.

--- a/docs/plans/story-2.3.md
+++ b/docs/plans/story-2.3.md
@@ -1,0 +1,329 @@
+# Epic 2, Story 2.3 — Transaction Builder & Auto-Tagging Domain Service
+
+## Context
+
+Stories 2.1 (CSV parser) and 2.2 (idempotency filter) are merged. Story 2.3 consumes the `fresh` `IngestItem`s that survive dedup and turns each one into a balanced double-entry `Transaction` via regex-based auto-tagging + a CoA-style account-name scheme. No persistence (Story 2.5), no CLI (Story 2.4).
+
+**Problem.** `IngestItem` carries `{ sourceAccount, occurredAt, direction, description, amount }` but no category and no opposing ledger account. Turning this into a valid double-entry requires (a) deciding the *category* (`Expense:Transport`, `Income:Refund`, etc.) via description regex, (b) deciding the *opposing real account* based on the source-account type (bank vs card), and (c) handling the BPCE card-settlement special case from issue #26 (the monthly "PAIEMENT CARTE X####" lines on the main account must be classified as internal transfers — not as expenses — to avoid double-counting against the per-card granular statements).
+
+**Maintenance sub-loop** (pre-planning, CLAUDE.md § 6.7): `npm audit` clean, zero Dependabot PRs, 13 open issues (all deferred or dependencies). Story 2.2's retro action A already landed (plans live in `docs/plans/`; this file is proof). CLAUDE.md § 1 "Current position" line needs a one-line refresh to "Next story: 2.4" as commit 1.
+
+## Story (verbatim from [docs/epics.md](docs/epics.md))
+
+> As a System, I want to auto-assign categories to transactions and convert them into balanced double-entry sets, so that raw bank lines become valid accounting entries.
+>
+> **AC1:** matches "Uber" to the "Transport" bucket via regex rules.
+> **AC2:** creates a `Transaction` with two entries: Debit `Expense:Transport`, Credit `Liabilities:CreditCard` (or the bank-source equivalent).
+> **AC3:** verifies `Sum(Debits) == Sum(Credits)` — inherited from existing [Transaction.create()](src/core/ledger/transaction.ts:49) invariants.
+
+FR coverage: **FR6** (auto-tagging by description), **FR15** (double-entry consistency). Walks QA invariant "Every recorded transaction satisfies `sum(debits) == sum(credits)`" + "No silent data loss — no line is dropped silently."
+
+## Selected solution
+
+Three Core concerns + one config change, no new ports.
+
+- **Config additions** — two new `AccountConfig` fields:
+  - `type: 'bank' | 'card'` (required enum). Determines the opposing ledger account: bank IngestItems map to `Assets:Bank:<id>`, card IngestItems to `Liabilities:CreditCard:<id>`.
+  - `cardSuffix?: string` — optional, required **only when `type: 'card'`**. Explicit last-4 digits matching the bank's "PAIEMENT CARTE Xnnnn" line (e.g., `"1234"`). Revised per Plan agent pushback: the first draft matched the suffix against `id.endsWith(…)`, which silently collides if a bank account id also ends in those 4 digits (e.g., `bank-91234` vs `card-1234` → both end in `1234`). Explicit `cardSuffix` is unambiguous, documents the real BPCE field, and survives id rename.
+
+- **Account-name convention** — CoA-style colon-delimited strings, established in Story 2.3 because nothing writes to `transaction_entries.account` yet:
+  - Category accounts: `Expense:<Category>`, `Income:<Category>` (e.g., `Expense:Transport`, `Income:Refund`).
+  - Real accounts: `Assets:Bank:<sourceAccount-id>`, `Liabilities:CreditCard:<sourceAccount-id>` (e.g., `Assets:Bank:main-12345678901`, `Liabilities:CreditCard:card-1234`). The id comes straight from `AccountConfig.id`, so whatever the user named it in YAML is what appears in the ledger. This keeps a single source of truth and avoids a secondary rename table.
+  - Internal transfer (issue #26 settlements): same `Assets:Bank:...` + `Liabilities:CreditCard:...` but double-entry is *between the two real accounts*, no category. No `Expense:` or `Income:` side.
+  - Constants live in `src/core/ingest/account-names.ts` as tiny pure helpers: `bankAccount(id)`, `cardAccount(id)`, `expenseAccount(category)`, `incomeAccount(category)`. Avoids magic strings scattered through the builder.
+
+- **Auto-tagger** — hardcoded seed rule list in `src/core/ingest/auto-tag-rules.ts`. Each rule is `{ pattern: RegExp, category: string, direction?: 'inflow' | 'outflow' }`. Applied in order against the (already-normalised by Story 2.2's canonicalizer-style) description; first match wins. Seed covers ~8 categories that map to typical BPCE bank descriptions the user's real data contains (GROCERIES, TRANSPORT, FUEL, RESTAURANT, UTILITIES, BANKING-FEES, INSURANCE, SUBSCRIPTIONS). No match → `Uncategorized` category, `confidence: 'low'`. User customisation of rules is explicitly **out of scope** (YAGNI; Story 2.4's interactive tagging loop will let the user override per-item, which is more ergonomic than a YAML rule editor).
+
+- **TransactionBuilder** — Core class `src/core/ingest/transaction-builder.ts`. Constructor DI on `AppConfig.accounts` (readonly array; Core doesn't depend on ConfigService port because the accounts list is already a value passed in by the caller). Method `build(item: IngestItem): Result<BuildOutcome>` where:
+  ```ts
+  interface BuildOutcome {
+    readonly transaction: Transaction;
+    readonly category: string;          // e.g. "Transport" or "Uncategorized" or the special "InternalTransfer"
+    readonly confidence: 'high' | 'low'; // 'low' when the rule matched Uncategorized; 'low' also for card-settlement-without-matching-card-config (see below)
+    readonly classification: 'expense' | 'income' | 'internal-transfer';
+  }
+  ```
+  Batch convenience: `buildAll(items): Result<{ built: BuildOutcome[]; failed: { item: IngestItem; reason: string }[] }>` — the ingestion pipeline (Story 2.4) needs this shape so one item's failure doesn't abort the batch. Per-item `Result.fail` only for genuinely unrecoverable cases (a `Transaction.create` invariant violation that shouldn't be possible given our inputs — but guard anyway).
+
+- **Card-settlement classifier (issue #26)** — run *before* auto-tagging. Pattern: `^PAIEMENT\s+CARTE\s+X?(\d{4})(?:\s.*)?$` (case-insensitive; the description was NFC+trim+whitespace-collapsed upstream so simple). Match condition: `sourceAccount` has `type: 'bank'` AND description matches. When matched, the builder:
+  1. Extracts the 4-digit suffix from the capture group.
+  2. Looks for an `AccountConfig` where `type: 'card'` AND `cardSuffix === extracted`. Explicit field (not `id.endsWith(…)`) prevents the collision case a bank id ending in the same 4 digits would otherwise cause.
+  3. If exactly one match: emit `{ classification: 'internal-transfer', category: 'InternalTransfer', confidence: 'high' }` with a `Transaction` debiting `Liabilities:CreditCard:<card-id>` and crediting `Assets:Bank:<sourceAccount-id>` for the full amount.
+  4. If zero or multiple cards match the suffix: emit `{ classification: 'expense', category: 'Uncategorized', confidence: 'low' }` — fall back to the regular expense path. Story 2.4 will surface `confidence: 'low'` items for user review. Never silently classify as internal-transfer to a wrong card. (Hard-failing would lose the transaction entirely; the "Sunday Morning Audit" journey and QA "No silent data loss" both favour Uncategorized-with-review over hard-fail.)
+
+- **Direction → debit/credit mapping** (single table, no cleverness):
+
+  | sourceAccount.type | IngestItem.direction | Classification        | Debit                                | Credit                               |
+  | ------------------ | -------------------- | --------------------- | ------------------------------------ | ------------------------------------ |
+  | bank               | outflow              | expense               | `Expense:<Category>`                 | `Assets:Bank:<id>`                   |
+  | bank               | inflow               | income                | `Assets:Bank:<id>`                   | `Income:<Category>`                  |
+  | card               | outflow              | expense               | `Expense:<Category>`                 | `Liabilities:CreditCard:<id>`        |
+  | card               | inflow               | income (refund)       | `Liabilities:CreditCard:<id>`        | `Income:<Category>`                  |
+  | bank + PAIEMENT    | outflow              | internal-transfer     | `Liabilities:CreditCard:<card-id>`   | `Assets:Bank:<id>`                   |
+
+### Types
+
+```ts
+// src/core/ingest/types.ts — addition
+export type Classification = 'expense' | 'income' | 'internal-transfer';
+export type Confidence = 'high' | 'low';
+
+export interface BuildOutcome {
+  readonly transaction: Transaction;
+  readonly category: string;
+  readonly classification: Classification;
+  readonly confidence: Confidence;
+}
+
+export interface BuildBatchOutcome {
+  readonly built: readonly BuildOutcome[];
+  readonly failed: readonly { readonly item: IngestItem; readonly reason: string }[];
+}
+```
+
+### Config change
+
+```ts
+// src/core/config/app-config.ts — addition
+export interface AccountConfig {
+  readonly id: string;
+  readonly type: 'bank' | 'card';        // NEW
+  readonly filenamePrefix: string;
+  readonly cardSuffix?: string;          // NEW, required iff type === 'card' (cross-field refinement in Zod)
+}
+```
+
+```ts
+// src/infra/config/config-schema.ts — addition inside AccountConfigSchema + a superRefine
+// - type: z.enum(['bank', 'card'])
+// - cardSuffix: z.string().regex(/^\d{4}$/).optional()
+// - superRefine: if type==='card' and !cardSuffix → 'cardSuffix is required for card accounts'
+//                if type==='bank' and cardSuffix → 'cardSuffix must not be set on bank accounts'
+//   Both messages must stay PII-safe (name the field, never echo the value).
+```
+
+```yaml
+# accounting.example.yaml — edits
+accounts:
+  - id: main-12345678901
+    type: bank
+    filenamePrefix: "12345678901_"
+  - id: card-1234
+    type: card
+    cardSuffix: "1234"
+    filenamePrefix: "carte_1234_"
+```
+
+### TransactionBuilder signature
+
+```ts
+// src/core/ingest/transaction-builder.ts
+export class TransactionBuilder {
+  constructor(
+    private readonly accounts: readonly AccountConfig[],
+    private readonly rules: readonly AutoTagRule[] = DEFAULT_RULES,
+    private readonly idGen: () => string = defaultUuidGen,
+  ) {}
+  build(item: IngestItem): Result<BuildOutcome> { … }
+  buildAll(items: readonly IngestItem[]): Result<BuildBatchOutcome> { … }
+}
+```
+
+- `idGen` default is injected for deterministic testing (tests pass a stub sequence generator). Production wires `crypto.randomUUID` from a thin Infra factory — or we inline `crypto.randomUUID()` and note it as a Core dependency on a Node built-in. **Decision:** `idGen` is a Core port/function type (no `crypto` import in Core); Infra provides a `nodeUuidGen` (file `src/infra/crypto/node-uuid-gen.ts`, 3 LOC). Mirrors the `HashFn` port shape from Story 2.2.
+
+### Auto-tag rule seed
+
+```ts
+// src/core/ingest/auto-tag-rules.ts
+export interface AutoTagRule {
+  readonly pattern: RegExp;
+  readonly category: string;
+}
+export const DEFAULT_RULES: readonly AutoTagRule[] = [
+  { pattern: /uber|bolt|taxi|freenow/i, category: 'Transport' },
+  { pattern: /carrefour|monoprix|auchan|intermarche|biocoop|leclerc/i, category: 'Groceries' },
+  { pattern: /total|shell|bp|esso|station service/i, category: 'Fuel' },
+  { pattern: /restaurant|cafe|bar|brasserie|snack/i, category: 'Restaurant' },
+  { pattern: /edf|engie|veolia|orange|sfr|free|bouygues/i, category: 'Utilities' },
+  { pattern: /cotisation|frais bancaires|agios/i, category: 'BankingFees' },
+  { pattern: /assurance|mutuelle/i, category: 'Insurance' },
+  { pattern: /netflix|spotify|prime|disney|apple.com|abonnement/i, category: 'Subscriptions' },
+];
+```
+
+Rules are deliberately broad-brush and French-biased because the user's real data is BPCE. A later story (or issue) will add more as patterns emerge. The PRD doesn't require a rich taxonomy in MVP — the "Sunday Morning Audit" loop assumes ~5 interactive reviews per 150 transactions; a wide-net `Uncategorized` is acceptable.
+
+## Rationale (vs alternatives)
+
+- **CoA-style colon-delimited account names** vs enum/integer account ids. KISS — strings are debuggable in DB dumps, align with Ledger / Plaintext Accounting conventions (hledger, ledger-cli), and future `Epic:Explain` output reads naturally. A formal `accounts` table (issue #17's territory) is post-MVP.
+- **Hardcoded auto-tag rules in Core** vs YAML-loaded user-customizable rules. YAGNI. Story 2.4's interactive tagging per-item is more ergonomic than editing a YAML dictionary. If a user wants custom rules before 2.4 lands, they can open a PR — it's one line per rule.
+- **"Uncategorized" fallback with `confidence: 'low'`** vs hard-fail on unmatched. QA "No silent data loss" favours never dropping a transaction. The "Sunday Morning Audit" journey explicitly describes the user reviewing flagged items; that's the mechanism.
+- **Explicit `cardSuffix` field on AccountConfig** vs deriving from id via `endsWith(…)`. The plan agent caught the collision case: if a future bank account id ends in the same 4 digits as a card's suffix, `endsWith` silently lights up on the wrong account, and the user sees an Uncategorized fallback (multi-match) for a transaction that should have been an internal transfer. Explicit `cardSuffix` also documents what the field represents (the real BPCE pattern) and survives id rename.
+- **`AccountConfig.type` as a required field** vs optional + default 'bank'. Explicit > implicit. The user is declaring a real-world account; making them name its type prevents the "forgot to set type on the card and got Uncategorized'd" surprise.
+- **`idGen` as a Core port (function type)** vs hardcoded `crypto.randomUUID()` in Core. Core-depends-on-nothing rule — `crypto.randomUUID` is Node, Infra territory. Port lets tests inject a deterministic sequence. Same pattern as `HashFn` from Story 2.2.
+- **Batch method `buildAll` returns `{ built, failed }` rather than `Result<BuildOutcome[]>`**. One item's Transaction.create failure shouldn't abort a 150-row batch — parallel to Story 2.1's per-row parse-stage errors. The per-item reason is reported to the caller (Story 2.4 CLI) which can show the user what failed.
+- **Card-settlement classifier runs BEFORE auto-tagging** (not as a rule in the list). The classifier needs `sourceAccount.type == 'bank'` AND a match against the card-account registry — it's a structural classifier, not a description-only regex. Mixing it into `AutoTagRule[]` would require each rule to take the full IngestItem + accounts array, bloating the type. Keep the rule list simple and dispatch from the builder.
+- **Not adding a port for "is this an internal transfer"** — the classifier is a pure function of `(item, accounts)`. No IO. Keep it a module-local helper.
+
+## Critical files to create / touch
+
+| Path | Change |
+| --- | --- |
+| `CLAUDE.md` | **edit** — refresh § 1 "Current position" to `Epic 2 ... Next story: 2.4 — Interactive Ingest Command (CLI)` (`chore(docs)` commit at top of branch) |
+| `src/core/config/app-config.ts` | **edit** — add `type: 'bank' \| 'card'` to `AccountConfig` |
+| `src/infra/config/config-schema.ts` | **edit** — Zod `z.enum(['bank', 'card'])` on `type`; propagate to `parseRawConfig` |
+| `accounting.example.yaml` | **edit** — add `type: bank` / `type: card` lines on example accounts |
+| `src/core/ingest/types.ts` | **edit** — add `Classification`, `Confidence`, `BuildOutcome`, `BuildBatchOutcome` |
+| `src/core/ingest/account-names.ts` | **new** — pure helpers: `bankAccount(id)`, `cardAccount(id)`, `expenseAccount(cat)`, `incomeAccount(cat)` |
+| `src/core/ingest/auto-tag-rules.ts` | **new** — `AutoTagRule` type + `DEFAULT_RULES` seed |
+| `src/core/ports/uuid-gen.ts` | **new** — `UuidGen = () => string` port |
+| `src/core/ingest/transaction-builder.ts` | **new** — `TransactionBuilder` class; `build()` + `buildAll()`; card-settlement classifier; direction→debit/credit table |
+| `src/infra/crypto/node-uuid-gen.ts` | **new** — thin wrapper over `crypto.randomUUID` |
+| `tests/unit/infra/config/config-schema.test.ts` | **edit** — cover new `type` field (required, enum validation, PII-safe error) |
+| `tests/integration/infra/config/config-service.test.ts` | **edit** — fixture yaml includes `type:` lines |
+| `tests/unit/core/ingest/account-names.test.ts` | **new** — one unit test per helper; round-trip property |
+| `tests/unit/core/ingest/auto-tag-rules.test.ts` | **new** — each seed rule matches a known BPCE-style description and misses a decoy; Uncategorized fallback |
+| `tests/unit/core/ingest/transaction-builder.test.ts` | **new** — the four direction/type rows of the table, card-settlement match + mismatch, batch `built`/`failed` split, Transaction invariants propagate, `buildAll` preserves order |
+| `tests/unit/infra/crypto/node-uuid-gen.test.ts` | **new** — minimal: returns a string, uniqueness property, v4 format check |
+
+Reuses: `Transaction.create()` + `Entry` ([src/core/ledger/transaction.ts](src/core/ledger/transaction.ts)) — the double-entry invariant check is already there; we just supply correct entries. `Result.ok/fail` ([src/core/shared/result.ts](src/core/shared/result.ts)). `IngestItem` + `AppConfig` shapes from Stories 2.1/2.2. **No new deps** — `crypto.randomUUID` is Node built-in (Node 20+).
+
+**Not in scope:** no persistence (Story 2.5), no CLI interaction (Story 2.4), no user-customisable rules (YAGNI; 2.4's interactive override is the MVP affordance), no per-account currency cross-transaction enforcement (issue #17, still deferred), no confidence-score numeric scale (binary high/low suffices for Story 2.4's low-confidence prompt).
+
+## Gherkin scenarios
+
+Story 2.3 has no CLI surface — scenarios map 1:1 to unit tests (one `describe` per scenario, one `it` per assertion). Each carries a "fails if …" note.
+
+```gherkin
+Feature: Transaction builder & auto-tagging
+
+  Scenario: AC1/AC2 — expense on a bank account, matched rule
+    Given a bank-type AccountConfig 'main-1' and a card-type AccountConfig 'card-1234'
+    And an IngestItem { sourceAccount: 'main-1', direction: 'outflow', amount: 20.00 EUR,
+                        description: 'UBER TRIP 2026', occurredAt: '2026-04-20T00:00:00+02:00' }
+    When builder.build(item) runs
+    Then the result is Result.ok
+    And outcome.classification == 'expense'
+    And outcome.category == 'Transport'
+    And outcome.confidence == 'high'
+    And outcome.transaction has two entries: debit 'Expense:Transport' 20.00 EUR; credit 'Assets:Bank:main-1' 20.00 EUR
+    # fails if: the uber rule isn't in DEFAULT_RULES, or the bank→outflow row of the direction table is wrong,
+    # or Transaction.create's sum(debits)==sum(credits) invariant rejects the entries
+
+  Scenario: expense on a card account routes to CreditCard liability
+    Given a bank-type 'main-1' and a card-type 'card-1234'
+    And an IngestItem { sourceAccount: 'card-1234', direction: 'outflow', amount: 42.00 EUR,
+                        description: 'CARREFOUR MARKET' }
+    When builder.build runs
+    Then outcome.category == 'Groceries'
+    And transaction entries are: debit 'Expense:Groceries' 42.00 EUR; credit 'Liabilities:CreditCard:card-1234' 42.00 EUR
+    # fails if: the card→outflow row routes to Assets:Bank instead
+
+  Scenario: income/refund on a card account reverses the sides
+    Given a card-type 'card-1234'
+    And an IngestItem { sourceAccount: 'card-1234', direction: 'inflow', amount: 15.00 EUR,
+                        description: 'REMBOURSEMENT MUTUELLE' }
+    When builder.build runs
+    Then outcome.category == 'Insurance'
+    And outcome.classification == 'income'
+    And entries are: debit 'Liabilities:CreditCard:card-1234' 15.00 EUR; credit 'Income:Insurance' 15.00 EUR
+    # fails if: inflow on a card is treated as expense (would wrongly increase the CC liability)
+
+  Scenario: unmatched description → Uncategorized with confidence=low
+    Given an IngestItem with description 'WEIRD MERCHANT XYZ' (matches no rule)
+    When builder.build runs
+    Then outcome.category == 'Uncategorized'
+    And outcome.confidence == 'low'
+    And outcome.classification == 'expense' (or 'income', per direction)
+    # fails if: unmatched items get dropped (silent data loss), or confidence reports 'high'
+
+  Scenario: AC/#26 — PAIEMENT CARTE on main account maps to internal transfer
+    Given a bank-type 'main-1' and a card-type 'card-1234'
+    And an IngestItem { sourceAccount: 'main-1', direction: 'outflow', amount: 523.45 EUR,
+                        description: 'PAIEMENT CARTE X1234 AVRIL' }
+    When builder.build runs
+    Then outcome.classification == 'internal-transfer'
+    And outcome.category == 'InternalTransfer'
+    And outcome.confidence == 'high'
+    And entries are: debit 'Liabilities:CreditCard:card-1234' 523.45 EUR; credit 'Assets:Bank:main-1' 523.45 EUR
+    # fails if: the classifier doesn't run, or it runs against card-sourced items (should only fire on bank sources),
+    # or the suffix isn't resolved back to card-1234's id
+
+  Scenario: PAIEMENT CARTE with ambiguous/unknown suffix → Uncategorized expense, not silent internal-transfer
+    Given a bank-type 'main-1' and NO card-type account with suffix 9999
+    And an IngestItem { sourceAccount: 'main-1', direction: 'outflow', amount: 100 EUR,
+                        description: 'PAIEMENT CARTE X9999' }
+    When builder.build runs
+    Then outcome.classification == 'expense'
+    And outcome.category == 'Uncategorized'
+    And outcome.confidence == 'low'
+    # fails if: the classifier silently guesses a card, or hard-fails the whole item (silent data loss)
+
+  Scenario: batch buildAll preserves input order and splits built/failed
+    Given 5 IngestItems, one of which triggers a Transaction.create invariant violation
+    When builder.buildAll(items) runs
+    Then outcome.built.length == 4
+    And outcome.failed.length == 1
+    And built items appear in the input's relative order
+    And failed.item references the 3rd input item (by reference identity)
+    # fails if: one bad item aborts the batch, or ordering is lost
+
+  Scenario: batch buildAll assigns a distinct Transaction.id per item
+    Given 5 valid IngestItems
+    When builder.buildAll(items) runs
+    Then the 5 built Transactions all have distinct .id values
+    # fails if: idGen is called once in the constructor and reused, or a cached UUID leaks across items
+    # (silent at the Transaction-level; would only surface as a UNIQUE violation at Story 2.5's INSERT)
+
+  Scenario: Transaction.description preserves the original IngestItem.description verbatim
+    Given an IngestItem with description 'UBER TRIP 2026-04-20' matched to category 'Transport'
+    When builder.build runs
+    Then transaction.description === 'UBER TRIP 2026-04-20' (the original, NOT 'Transport' or a transformed string)
+    # fails if: the category leaks into description, or the builder rewrites the description
+    # (would corrupt the audit trail — QA § Coherence / Conversational CFO truthfulness)
+
+  Scenario: Transaction.occurredAt is passed through unchanged
+    Given an IngestItem with occurredAt '2026-04-20T00:00:00+02:00'
+    When builder.build runs
+    Then transaction.occurredAt === '2026-04-20T00:00:00+02:00' (same string, no reformat)
+    # fails if: the builder re-parses and re-serialises the timestamp (determinism risk), or
+    # strips the offset (Story 2.2's idempotency hash depends on the exact string)
+```
+
+## Plan for Sonnet (commit slices — adapter-story sizing per § 6.6)
+
+Target 7–8 commits. Slice per distinct external concern.
+
+1. `chore(docs): refresh CLAUDE.md § 1 current-position line (Story 2.3 maintenance)` — one-liner to `Next story: 2.4`.
+2. `test(config): AccountConfig.type enum validation — failing (Story 2.3)` — extend existing config tests with `type` required + enum; update fixtures.
+3. `feat(config): AccountConfig.type minimal green (Story 2.3)` — add the field to AppConfig, Zod schema, example YAML.
+4. `test(ingest): TransactionBuilder + auto-tagger obvious basics — failing (Story 2.3)` — tests for account-name helpers, the four-row direction table, auto-tag seed match + Uncategorized fallback, `buildAll` built/failed split + order preservation. Introduce the new Core files as empty skeletons so the test compiles.
+5. `feat(ingest): TransactionBuilder + auto-tagger minimal green (Story 2.3)` — implement `account-names.ts`, `auto-tag-rules.ts` seed, `TransactionBuilder.build` + `buildAll`. Wire through `UuidGen` port (Core type) and `NodeUuidGen` adapter (Infra).
+6. `test(ingest): card-settlement classifier — failing (Story 2.3)` — tests for matching-suffix success, ambiguous-suffix fallback, card-sourced item not classified, non-matching regex ignored.
+7. `feat(ingest): card-settlement classifier minimal green (Story 2.3)` — add the classifier step that runs before auto-tagging; resolve suffix against `accounts`.
+8. `refactor(ingest): tidy TransactionBuilder (Story 2.3)` or empty-refactor commit per § 6.4 if nothing to clean.
+
+Estimated 7–8 commits. No green-on-landing expected — the card classifier (slice 6-7) is a distinct counterintuitive rule that won't fall out of slice 5's "obvious basics".
+
+### Deps pre-authorised
+
+None. `node:crypto.randomUUID` is built-in.
+
+### Verification (end-to-end)
+
+- `npm run lint && npm run build && npm test` all green.
+- Each Gherkin scenario has ≥1 matching test.
+- 100% branch coverage on `src/core/ingest/transaction-builder.ts`, `auto-tag-rules.ts`, `account-names.ts` (all Core).
+- Manual: no user-facing surface; deferred to Story 2.4's CLI.
+
+## Risks & deferrals
+
+- **Auto-tag rule seed is deliberately small (8 categories), hardcoded in Core, no YAML override.** Flag per Plan agent: if Story 2.4's interactive loop is deferred past the next sprint, or if the user needs to ingest historical data before 2.4 lands, they'll have to edit TS to add a rule. Mitigation cost is tiny (one commit per rule). **Trigger condition:** if Story 2.4 slips more than one iteration past Story 2.3, file a YAML-override issue. Additions meanwhile are one-line PRs.
+- **Per-account currency consistency (#17) still deferred.** Story 2.3 doesn't enforce cross-transaction currency consistency per account. It will use `item.amount.currency` (already single-currency per item per Story 2.1's contract). A future story (or the #17 resolution) will add the `accounts` table with a `currency` column.
+- **Card-settlement classifier is locale-aware** — matches French "PAIEMENT CARTE Xnnnn" pattern. When a second bank format lands (issue #23), similar rules for that format will need adding. File a small issue at review time noting this dependency if it isn't already captured under #26.
+- **The `idGen` port's default in production** needs to be wired at the CLI assembly point (Story 2.4). Story 2.3 ships the port + adapter; Story 2.4 consumes.
+
+## Carryovers resolved
+
+- Story 2.2 retro action A — plan at `docs/plans/story-2.3.md` (this file). ✓
+- Story 2.2 retro action B — Phase 4 will explicitly audit "this test fails if …" notes against the production path.

--- a/docs/retrospectives/story-2.3.md
+++ b/docs/retrospectives/story-2.3.md
@@ -1,0 +1,47 @@
+# Story 2.3 retrospective
+
+**PR:** _pending_ (will be linked on draft PR open)  **Closed:** pending merge
+
+Fifth end-to-end run of the product development loop. Cleanest Phase 1+2 to date — plan stress-test caught a real collision risk (`endsWith`-on-id classifier) and three missing assertions before implementation. Phase 4 produced one legitimate refactor (the 84-LOC `build()` method), handled in a follow-up Sonnet pass. Nine commits total on the branch.
+
+## Keep
+
+- **Plan agent flipped a correctness bug pre-implementation.** First draft of the card-settlement classifier matched `AccountConfig.id.endsWith(suffix)`; Plan agent pointed out `bank-91234` (type:bank) would collide with `card-1234` (type:card) since both end in `1234`. Switched to explicit `cardSuffix: string` field on `AccountConfig` with a Zod cross-field refinement (required iff `type === 'card'`). The collision case is not a theoretical concern — it's exactly the kind of silent-misclassification-dressed-as-Uncategorized the user wouldn't notice until settlement math diverged.
+- **Plan agent caught three missing test assertions**: (1) distinct UUIDs across a batch (the kind of bug that passes per-item tests but blows up at Story 2.5's `INSERT ... UNIQUE` constraint); (2) `transaction.description` preservation (must carry the *original* `IngestItem.description`, not the matched category — audit-trail invariant); (3) `transaction.occurredAt` pass-through (Story 2.2's idempotency hash depends on the exact ISO string; any silent reformat would cascade into broken dedup). All three landed as Gherkin scenarios + tests.
+- **Adapter-story sizing (CLAUDE.md § 6.6) held for the second consecutive story.** Plan called for 8 slices; Sonnet delivered 8 clean commits (config + obvious-basics + card-settlement + refactor) with zero green-on-landing collapses — compare to Story 2.1's 3-of-5. The rule is validated.
+- **Plan file at `docs/plans/story-2.3.md` from commit 1** (Story 2.2 retro action A applied). Zero sensitive-path permission prompts during planning, unlike Stories 2.1/2.2 which each triggered ~10. Doc-in-repo is the right default for project-scoped plans.
+- **Phase 4 retro-check's explicit "this test fails if …" audit** (Story 2.2 retro action B) caught nothing new here — tests are well-scoped. That's *also* a signal the practice works: when it catches nothing, that's because the plan's "fails if" notes are already rigorous. Low-cost discipline.
+- **Refactor-in-a-second-pass pattern.** The initial refactor slot (`de2b1b5`) did a tiny cleanup and explicitly deferred the bigger 84-LOC-`build()` extraction with a note citing § 6.5's during-green limit. Opus's Phase 4 retro-check decided it *should* be fixed before merge (violated <50 LOC guideline, 4-way duplication added a DRY concern). A second `refactor(ingest)` commit (`df31b03`) extracted `makeOutcome`; `build()` dropped from 84 LOC to 33 LOC, all 151 tests stayed green without modification. This is the § 6.1 phase 4 "blockers are fixed before merge" pattern working correctly.
+
+## Change
+
+- **First-draft `build()` was 84 LOC with 4-way duplication** — each of the four (source.type, direction) branches had a full `Transaction.create({…})` block. Sonnet's initial refactor slot explicitly deferred extracting the helper, citing the during-green 20-LOC touch rule. Arguably Sonnet should have seen this as a structural refactor candidate *during* the `feat:` commit and either flagged it more loudly or called out in Deviations that a follow-up was coming. The extraction was trivial once surfaced — a single `makeOutcome` helper with 6 positional args. Next time: if an `feat:` commit produces a function over ~60 LOC with >2 duplicated blocks, Sonnet's Deviations should say "this will need post-green refactoring" so Opus's Phase 4 review doesn't have to discover it.
+- **Refactor-slot commit message was too brief.** `de2b1b5`'s message says `defaultUuidGen IIFE` simplification — one LOC changed. The substantive 29-LOC reduction happened in `df31b03` after Phase 4. The initial commit's message should have been explicit: "deferred the direction-table extraction to Phase 4 — see Deviations." Minor but affects reviewability of the git history.
+
+## Try
+
+- **Add a "60 LOC trigger" to sonnet-implementer § 3** (Refactor-during-green allowance). Current wording says "<~20 LOC of existing code" for the deferral threshold. Add: *if a newly-written function exceeds ~60 LOC with >2 duplicated blocks, call it out explicitly in Deviations as a post-green refactor candidate — don't silently ship the bloat.* Action item A.
+- **Phase 4 LOC audit pass.** Opus's Phase 4 retro-check should include a grep for functions exceeding 50 LOC in the diff before deciding if a refactor round is needed. Currently decided by eyeball; a pre-commit or Phase-4 shell one-liner (e.g. `awk`/`grep`) would make the check explicit. Not urgent — documenting it as a future polish, not filing an issue.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| A. Add "60 LOC + duplication ≥ 2 blocks = flag in Deviations" threshold to `.claude/agents/sonnet-implementer.md` § 3 (Refactor-during-green allowance) | `.claude/agents/sonnet-implementer.md` in this PR | in same commit as this retro |
+
+## Loop metrics (fifth run)
+
+- **Plan phase:** 1 maintenance Explore + 1 landscape Explore (parallel) + 1 Plan agent (stress-test, 4 findings) + 3-pass Opus critical review.
+- **Implementation:** 1 Sonnet task (8 commits — 7 planned + 1 refactor slot, zero collapsed, one minor green-on-landing called out) + 1 Phase-4 refactor Sonnet task (1 commit, `makeOutcome` extraction).
+- **Phase-4 retro-check:** 1 refactor-fix (build() LOC + duplication), resolved in branch pre-merge. Zero blockers that required test changes.
+- **Deferred at plan:** 0 new issues filed (Story 2.5 tightening is already #29; auto-tag YAML override has a trigger condition, no issue yet).
+- **Total commits on branch:** 10 (1 chore + 6 test/feat + 2 refactor + 1 retro).
+- **Test count:** 151 (was 108 after Story 2.2).
+- **Sensitive-path permission prompts during planning:** 0 (plan file in `docs/plans/`, thanks to 2.2 retro action A).
+- **Time-to-DoD:** one working session.
+
+## Carryovers resolved
+
+- Story 2.1 retro action D (CLAUDE.md § 1 refresh) → already closed in Story 2.2; this story's first commit keeps it current (Next story → 2.4).
+- Story 2.2 retro action A (plans at `docs/plans/`) → validated — this is the first plan authored there from the start.
+- Story 2.2 retro action B (Phase 4 "this test fails if …" audit) → no findings, indicating the practice works without surfacing issues each time.

--- a/src/core/config/app-config.ts
+++ b/src/core/config/app-config.ts
@@ -13,7 +13,9 @@ export interface BufferBucket {
 
 export interface AccountConfig {
   readonly id: string;
+  readonly type: 'bank' | 'card';
   readonly filenamePrefix: string;
+  readonly cardSuffix?: string;
 }
 
 export interface AppConfig {

--- a/src/core/ingest/account-names.ts
+++ b/src/core/ingest/account-names.ts
@@ -1,0 +1,15 @@
+export function bankAccount(id: string): string {
+  throw new Error(`not implemented: ${id}`);
+}
+
+export function cardAccount(id: string): string {
+  throw new Error(`not implemented: ${id}`);
+}
+
+export function expenseAccount(category: string): string {
+  throw new Error(`not implemented: ${category}`);
+}
+
+export function incomeAccount(category: string): string {
+  throw new Error(`not implemented: ${category}`);
+}

--- a/src/core/ingest/account-names.ts
+++ b/src/core/ingest/account-names.ts
@@ -1,15 +1,15 @@
 export function bankAccount(id: string): string {
-  throw new Error(`not implemented: ${id}`);
+  return `Assets:Bank:${id}`;
 }
 
 export function cardAccount(id: string): string {
-  throw new Error(`not implemented: ${id}`);
+  return `Liabilities:CreditCard:${id}`;
 }
 
 export function expenseAccount(category: string): string {
-  throw new Error(`not implemented: ${category}`);
+  return `Expense:${category}`;
 }
 
 export function incomeAccount(category: string): string {
-  throw new Error(`not implemented: ${category}`);
+  return `Income:${category}`;
 }

--- a/src/core/ingest/auto-tag-rules.ts
+++ b/src/core/ingest/auto-tag-rules.ts
@@ -3,4 +3,13 @@ export interface AutoTagRule {
   readonly category: string;
 }
 
-export const DEFAULT_RULES: readonly AutoTagRule[] = [];
+export const DEFAULT_RULES: readonly AutoTagRule[] = [
+  { pattern: /uber|bolt|taxi|freenow/i, category: 'Transport' },
+  { pattern: /carrefour|monoprix|auchan|intermarche|biocoop|leclerc/i, category: 'Groceries' },
+  { pattern: /total|shell|bp|esso|station service/i, category: 'Fuel' },
+  { pattern: /restaurant|cafe|bar|brasserie|snack/i, category: 'Restaurant' },
+  { pattern: /edf|engie|veolia|orange|sfr|free|bouygues/i, category: 'Utilities' },
+  { pattern: /cotisation|frais bancaires|agios/i, category: 'BankingFees' },
+  { pattern: /assurance|mutuelle/i, category: 'Insurance' },
+  { pattern: /netflix|spotify|prime|disney|apple\.com|abonnement/i, category: 'Subscriptions' },
+];

--- a/src/core/ingest/auto-tag-rules.ts
+++ b/src/core/ingest/auto-tag-rules.ts
@@ -1,0 +1,6 @@
+export interface AutoTagRule {
+  readonly pattern: RegExp;
+  readonly category: string;
+}
+
+export const DEFAULT_RULES: readonly AutoTagRule[] = [];

--- a/src/core/ingest/transaction-builder.ts
+++ b/src/core/ingest/transaction-builder.ts
@@ -13,9 +13,10 @@ import { Result } from '@core/shared/result.js';
 // Capture group 1 is the 4-digit suffix.
 const CARD_SETTLEMENT_RE = /^PAIEMENT\s+CARTE\s+X?(\d{4})(?:\s.*)?$/i;
 
-const defaultUuidGen: UuidGen = (): string =>
-  // Replaced at the CLI assembly point (Story 2.4). Core has no access to node:crypto.
-  (() => { throw new Error('TransactionBuilder: idGen not wired — provide a UuidGen in constructor'); })();
+// Replaced at the CLI assembly point (Story 2.4). Core has no access to node:crypto.
+const defaultUuidGen: UuidGen = (): string => {
+  throw new Error('TransactionBuilder: idGen not wired — provide a UuidGen in constructor');
+};
 
 function tagDescription(description: string, rules: readonly AutoTagRule[]): { category: string; confidence: Confidence } {
   const matched = rules.find((r) => r.pattern.test(description));

--- a/src/core/ingest/transaction-builder.ts
+++ b/src/core/ingest/transaction-builder.ts
@@ -1,0 +1,26 @@
+import type { AccountConfig } from '@core/config/app-config.js';
+import type { UuidGen } from '@core/ports/uuid-gen.js';
+import type { IngestItem, BuildOutcome, BuildBatchOutcome } from './types.js';
+import type { AutoTagRule } from './auto-tag-rules.js';
+import { DEFAULT_RULES } from './auto-tag-rules.js';
+import { Result } from '@core/shared/result.js';
+
+const defaultUuidGen: UuidGen = (): string => {
+  throw new Error('TransactionBuilder: idGen not wired — provide a UuidGen in constructor');
+};
+
+export class TransactionBuilder {
+  constructor(
+    private readonly accounts: readonly AccountConfig[],
+    private readonly rules: readonly AutoTagRule[] = DEFAULT_RULES,
+    private readonly idGen: UuidGen = defaultUuidGen,
+  ) {}
+
+  build(_item: IngestItem): Result<BuildOutcome> {
+    return Result.fail('TransactionBuilder.build: not implemented');
+  }
+
+  buildAll(_items: readonly IngestItem[]): Result<BuildBatchOutcome> {
+    return Result.fail('TransactionBuilder.buildAll: not implemented');
+  }
+}

--- a/src/core/ingest/transaction-builder.ts
+++ b/src/core/ingest/transaction-builder.ts
@@ -3,11 +3,22 @@ import type { UuidGen } from '@core/ports/uuid-gen.js';
 import type { IngestItem, BuildOutcome, BuildBatchOutcome } from './types.js';
 import type { AutoTagRule } from './auto-tag-rules.js';
 import { DEFAULT_RULES } from './auto-tag-rules.js';
+import { bankAccount, cardAccount, expenseAccount, incomeAccount } from './account-names.js';
+import { Transaction } from '@core/ledger/transaction.js';
 import { Result } from '@core/shared/result.js';
 
-const defaultUuidGen: UuidGen = (): string => {
-  throw new Error('TransactionBuilder: idGen not wired — provide a UuidGen in constructor');
-};
+const defaultUuidGen: UuidGen = (): string =>
+  // Replaced at the CLI assembly point (Story 2.4). Core has no access to node:crypto.
+  // Tests must inject a deterministic sequence via the constructor.
+  (() => { throw new Error('TransactionBuilder: idGen not wired — provide a UuidGen in constructor'); })();
+
+function tagDescription(description: string, rules: readonly AutoTagRule[]): { category: string; confidence: 'high' | 'low' } {
+  const matched = rules.find((r) => r.pattern.test(description));
+  if (matched) {
+    return { category: matched.category, confidence: 'high' };
+  }
+  return { category: 'Uncategorized', confidence: 'low' };
+}
 
 export class TransactionBuilder {
   constructor(
@@ -16,11 +27,85 @@ export class TransactionBuilder {
     private readonly idGen: UuidGen = defaultUuidGen,
   ) {}
 
-  build(_item: IngestItem): Result<BuildOutcome> {
-    return Result.fail('TransactionBuilder.build: not implemented');
+  build(item: IngestItem): Result<BuildOutcome> {
+    const source = this.accounts.find((a) => a.id === item.sourceAccount);
+    if (!source) {
+      return Result.fail(`Unknown sourceAccount: ${item.sourceAccount}`);
+    }
+
+    const { category, confidence } = tagDescription(item.description, this.rules);
+
+    const id = this.idGen();
+
+    if (source.type === 'bank' && item.direction === 'outflow') {
+      const txResult = Transaction.create({
+        id,
+        occurredAt: item.occurredAt,
+        description: item.description,
+        entries: [
+          { account: expenseAccount(category), side: 'debit', amount: item.amount },
+          { account: bankAccount(source.id), side: 'credit', amount: item.amount },
+        ],
+      });
+      if (txResult.isFailure) return Result.fail(txResult.error);
+      return Result.ok({ transaction: txResult.value, category, classification: 'expense', confidence });
+    }
+
+    if (source.type === 'bank' && item.direction === 'inflow') {
+      const txResult = Transaction.create({
+        id,
+        occurredAt: item.occurredAt,
+        description: item.description,
+        entries: [
+          { account: bankAccount(source.id), side: 'debit', amount: item.amount },
+          { account: incomeAccount(category), side: 'credit', amount: item.amount },
+        ],
+      });
+      if (txResult.isFailure) return Result.fail(txResult.error);
+      return Result.ok({ transaction: txResult.value, category, classification: 'income', confidence });
+    }
+
+    if (source.type === 'card' && item.direction === 'outflow') {
+      const txResult = Transaction.create({
+        id,
+        occurredAt: item.occurredAt,
+        description: item.description,
+        entries: [
+          { account: expenseAccount(category), side: 'debit', amount: item.amount },
+          { account: cardAccount(source.id), side: 'credit', amount: item.amount },
+        ],
+      });
+      if (txResult.isFailure) return Result.fail(txResult.error);
+      return Result.ok({ transaction: txResult.value, category, classification: 'expense', confidence });
+    }
+
+    // card + inflow (refund/income)
+    const txResult = Transaction.create({
+      id,
+      occurredAt: item.occurredAt,
+      description: item.description,
+      entries: [
+        { account: cardAccount(source.id), side: 'debit', amount: item.amount },
+        { account: incomeAccount(category), side: 'credit', amount: item.amount },
+      ],
+    });
+    if (txResult.isFailure) return Result.fail(txResult.error);
+    return Result.ok({ transaction: txResult.value, category, classification: 'income', confidence });
   }
 
-  buildAll(_items: readonly IngestItem[]): Result<BuildBatchOutcome> {
-    return Result.fail('TransactionBuilder.buildAll: not implemented');
+  buildAll(items: readonly IngestItem[]): Result<BuildBatchOutcome> {
+    const built: BuildOutcome[] = [];
+    const failed: { item: IngestItem; reason: string }[] = [];
+
+    for (const item of items) {
+      const result = this.build(item);
+      if (result.isSuccess) {
+        built.push(result.value);
+      } else {
+        failed.push({ item, reason: result.error });
+      }
+    }
+
+    return Result.ok({ built, failed });
   }
 }

--- a/src/core/ingest/transaction-builder.ts
+++ b/src/core/ingest/transaction-builder.ts
@@ -1,23 +1,54 @@
 import type { AccountConfig } from '@core/config/app-config.js';
 import type { UuidGen } from '@core/ports/uuid-gen.js';
-import type { IngestItem, BuildOutcome, BuildBatchOutcome } from './types.js';
+import type { IngestItem, BuildOutcome, BuildBatchOutcome, Classification, Confidence } from './types.js';
 import type { AutoTagRule } from './auto-tag-rules.js';
 import { DEFAULT_RULES } from './auto-tag-rules.js';
 import { bankAccount, cardAccount, expenseAccount, incomeAccount } from './account-names.js';
 import { Transaction } from '@core/ledger/transaction.js';
 import { Result } from '@core/shared/result.js';
 
+// Matches French bank descriptions like:
+//   "PAIEMENT CARTE X1234 AVRIL"
+//   "PAIEMENT CARTE 1234"
+// Capture group 1 is the 4-digit suffix.
+const CARD_SETTLEMENT_RE = /^PAIEMENT\s+CARTE\s+X?(\d{4})(?:\s.*)?$/i;
+
 const defaultUuidGen: UuidGen = (): string =>
   // Replaced at the CLI assembly point (Story 2.4). Core has no access to node:crypto.
-  // Tests must inject a deterministic sequence via the constructor.
   (() => { throw new Error('TransactionBuilder: idGen not wired — provide a UuidGen in constructor'); })();
 
-function tagDescription(description: string, rules: readonly AutoTagRule[]): { category: string; confidence: 'high' | 'low' } {
+function tagDescription(description: string, rules: readonly AutoTagRule[]): { category: string; confidence: Confidence } {
   const matched = rules.find((r) => r.pattern.test(description));
   if (matched) {
     return { category: matched.category, confidence: 'high' };
   }
   return { category: 'Uncategorized', confidence: 'low' };
+}
+
+function tryCardSettlement(
+  item: IngestItem,
+  source: AccountConfig,
+  accounts: readonly AccountConfig[],
+): { category: string; classification: Classification; confidence: Confidence; cardId: string } | null {
+  if (source.type !== 'bank') return null;
+
+  const match = CARD_SETTLEMENT_RE.exec(item.description);
+  if (!match) return null;
+
+  const suffix = match[1];
+  const matchingCards = accounts.filter((a) => a.type === 'card' && a.cardSuffix === suffix);
+
+  if (matchingCards.length !== 1) {
+    // Zero or multiple matches → fall back to regular expense path (not silent data loss)
+    return null;
+  }
+
+  return {
+    category: 'InternalTransfer',
+    classification: 'internal-transfer',
+    confidence: 'high',
+    cardId: matchingCards[0].id,
+  };
 }
 
 export class TransactionBuilder {
@@ -33,9 +64,29 @@ export class TransactionBuilder {
       return Result.fail(`Unknown sourceAccount: ${item.sourceAccount}`);
     }
 
-    const { category, confidence } = tagDescription(item.description, this.rules);
-
     const id = this.idGen();
+
+    const settlement = tryCardSettlement(item, source, this.accounts);
+    if (settlement) {
+      const txResult = Transaction.create({
+        id,
+        occurredAt: item.occurredAt,
+        description: item.description,
+        entries: [
+          { account: cardAccount(settlement.cardId), side: 'debit', amount: item.amount },
+          { account: bankAccount(source.id), side: 'credit', amount: item.amount },
+        ],
+      });
+      if (txResult.isFailure) return Result.fail(txResult.error);
+      return Result.ok({
+        transaction: txResult.value,
+        category: settlement.category,
+        classification: settlement.classification,
+        confidence: settlement.confidence,
+      });
+    }
+
+    const { category, confidence } = tagDescription(item.description, this.rules);
 
     if (source.type === 'bank' && item.direction === 'outflow') {
       const txResult = Transaction.create({

--- a/src/core/ingest/transaction-builder.ts
+++ b/src/core/ingest/transaction-builder.ts
@@ -52,6 +52,28 @@ function tryCardSettlement(
   };
 }
 
+function makeOutcome(
+  id: string,
+  item: IngestItem,
+  debitAccount: string,
+  creditAccount: string,
+  classification: Classification,
+  category: string,
+  confidence: Confidence,
+): Result<BuildOutcome> {
+  const txResult = Transaction.create({
+    id,
+    occurredAt: item.occurredAt,
+    description: item.description,
+    entries: [
+      { account: debitAccount, side: 'debit', amount: item.amount },
+      { account: creditAccount, side: 'credit', amount: item.amount },
+    ],
+  });
+  if (txResult.isFailure) return Result.fail(txResult.error);
+  return Result.ok({ transaction: txResult.value, category, classification, confidence });
+}
+
 export class TransactionBuilder {
   constructor(
     private readonly accounts: readonly AccountConfig[],
@@ -69,80 +91,29 @@ export class TransactionBuilder {
 
     const settlement = tryCardSettlement(item, source, this.accounts);
     if (settlement) {
-      const txResult = Transaction.create({
-        id,
-        occurredAt: item.occurredAt,
-        description: item.description,
-        entries: [
-          { account: cardAccount(settlement.cardId), side: 'debit', amount: item.amount },
-          { account: bankAccount(source.id), side: 'credit', amount: item.amount },
-        ],
-      });
-      if (txResult.isFailure) return Result.fail(txResult.error);
-      return Result.ok({
-        transaction: txResult.value,
-        category: settlement.category,
-        classification: settlement.classification,
-        confidence: settlement.confidence,
-      });
+      return makeOutcome(
+        id, item,
+        cardAccount(settlement.cardId), bankAccount(source.id),
+        settlement.classification, settlement.category, settlement.confidence,
+      );
     }
 
     const { category, confidence } = tagDescription(item.description, this.rules);
 
     if (source.type === 'bank' && item.direction === 'outflow') {
-      const txResult = Transaction.create({
-        id,
-        occurredAt: item.occurredAt,
-        description: item.description,
-        entries: [
-          { account: expenseAccount(category), side: 'debit', amount: item.amount },
-          { account: bankAccount(source.id), side: 'credit', amount: item.amount },
-        ],
-      });
-      if (txResult.isFailure) return Result.fail(txResult.error);
-      return Result.ok({ transaction: txResult.value, category, classification: 'expense', confidence });
+      return makeOutcome(id, item, expenseAccount(category), bankAccount(source.id), 'expense', category, confidence);
     }
 
     if (source.type === 'bank' && item.direction === 'inflow') {
-      const txResult = Transaction.create({
-        id,
-        occurredAt: item.occurredAt,
-        description: item.description,
-        entries: [
-          { account: bankAccount(source.id), side: 'debit', amount: item.amount },
-          { account: incomeAccount(category), side: 'credit', amount: item.amount },
-        ],
-      });
-      if (txResult.isFailure) return Result.fail(txResult.error);
-      return Result.ok({ transaction: txResult.value, category, classification: 'income', confidence });
+      return makeOutcome(id, item, bankAccount(source.id), incomeAccount(category), 'income', category, confidence);
     }
 
     if (source.type === 'card' && item.direction === 'outflow') {
-      const txResult = Transaction.create({
-        id,
-        occurredAt: item.occurredAt,
-        description: item.description,
-        entries: [
-          { account: expenseAccount(category), side: 'debit', amount: item.amount },
-          { account: cardAccount(source.id), side: 'credit', amount: item.amount },
-        ],
-      });
-      if (txResult.isFailure) return Result.fail(txResult.error);
-      return Result.ok({ transaction: txResult.value, category, classification: 'expense', confidence });
+      return makeOutcome(id, item, expenseAccount(category), cardAccount(source.id), 'expense', category, confidence);
     }
 
     // card + inflow (refund/income)
-    const txResult = Transaction.create({
-      id,
-      occurredAt: item.occurredAt,
-      description: item.description,
-      entries: [
-        { account: cardAccount(source.id), side: 'debit', amount: item.amount },
-        { account: incomeAccount(category), side: 'credit', amount: item.amount },
-      ],
-    });
-    if (txResult.isFailure) return Result.fail(txResult.error);
-    return Result.ok({ transaction: txResult.value, category, classification: 'income', confidence });
+    return makeOutcome(id, item, cardAccount(source.id), incomeAccount(category), 'income', category, confidence);
   }
 
   buildAll(items: readonly IngestItem[]): Result<BuildBatchOutcome> {

--- a/src/core/ingest/types.ts
+++ b/src/core/ingest/types.ts
@@ -1,4 +1,5 @@
 import type { Money } from '@core/shared/money.js';
+import type { Transaction } from '@core/ledger/transaction.js';
 
 // The only supported bank format in Story 2.1. Add a new member when a second bank format lands.
 // Callers reading CSV files via Story 2.4 must decode BPCE files using latin1 encoding:
@@ -30,4 +31,19 @@ export interface ParseOutcome {
 export interface IdempotencyOutcome {
   readonly fresh: readonly IngestItem[];
   readonly duplicates: readonly IngestItem[];
+}
+
+export type Classification = 'expense' | 'income' | 'internal-transfer';
+export type Confidence = 'high' | 'low';
+
+export interface BuildOutcome {
+  readonly transaction: Transaction;
+  readonly category: string;
+  readonly classification: Classification;
+  readonly confidence: Confidence;
+}
+
+export interface BuildBatchOutcome {
+  readonly built: readonly BuildOutcome[];
+  readonly failed: readonly { readonly item: IngestItem; readonly reason: string }[];
 }

--- a/src/core/ports/uuid-gen.ts
+++ b/src/core/ports/uuid-gen.ts
@@ -1,0 +1,1 @@
+export type UuidGen = () => string;

--- a/src/infra/config/config-schema.ts
+++ b/src/infra/config/config-schema.ts
@@ -18,9 +18,27 @@ const BufferBucketRawSchema = z.object({
 const AccountConfigSchema = z
   .object({
     id: z.string().min(1),
+    type: z.enum(['bank', 'card']),
     filenamePrefix: z.string().min(1),
+    cardSuffix: z.string().regex(/^\d{4}$/).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((acct, ctx) => {
+    if (acct.type === 'card' && acct.cardSuffix === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['cardSuffix'],
+        message: 'cardSuffix is required for card accounts',
+      });
+    }
+    if (acct.type === 'bank' && acct.cardSuffix !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['cardSuffix'],
+        message: 'cardSuffix must not be set on bank accounts',
+      });
+    }
+  });
 
 const RawConfigSchema = z
   .object({

--- a/src/infra/crypto/node-uuid-gen.ts
+++ b/src/infra/crypto/node-uuid-gen.ts
@@ -1,0 +1,4 @@
+import { randomUUID } from 'node:crypto';
+import type { UuidGen } from '@core/ports/uuid-gen.js';
+
+export const nodeUuidGen: UuidGen = (): string => randomUUID();

--- a/tests/integration/infra/config/config-service.test.ts
+++ b/tests/integration/infra/config/config-service.test.ts
@@ -32,8 +32,11 @@ buffers:
     cap: 10000
 accounts:
   - id: main-12345678901
+    type: bank
     filenamePrefix: "12345678901_"
   - id: card-1234
+    type: card
+    cardSuffix: "1234"
     filenamePrefix: "carte_1234_"
 `;
 

--- a/tests/unit/core/ingest/account-names.test.ts
+++ b/tests/unit/core/ingest/account-names.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for account-name helpers.
+ *
+ * Gherkin coverage (Scenario: obvious basics):
+ *   - bankAccount(id) returns 'Assets:Bank:<id>'
+ *   - cardAccount(id) returns 'Liabilities:CreditCard:<id>'
+ *   - expenseAccount(cat) returns 'Expense:<cat>'
+ *   - incomeAccount(cat) returns 'Income:<cat>'
+ *
+ * fails if: any helper returns wrong prefix or wrong separator
+ */
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import {
+  bankAccount,
+  cardAccount,
+  expenseAccount,
+  incomeAccount,
+} from '../../../../src/core/ingest/account-names.js';
+
+describe('bankAccount', () => {
+  it('prefixes with Assets:Bank:', () => {
+    // fails if bankAccount returns a wrong prefix
+    expect(bankAccount('main-1')).toBe('Assets:Bank:main-1');
+  });
+
+  it('property: always starts with Assets:Bank:', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (id) => {
+        return bankAccount(id).startsWith('Assets:Bank:');
+      }),
+    );
+  });
+});
+
+describe('cardAccount', () => {
+  it('prefixes with Liabilities:CreditCard:', () => {
+    // fails if cardAccount returns a wrong prefix
+    expect(cardAccount('card-1234')).toBe('Liabilities:CreditCard:card-1234');
+  });
+
+  it('property: always starts with Liabilities:CreditCard:', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (id) => {
+        return cardAccount(id).startsWith('Liabilities:CreditCard:');
+      }),
+    );
+  });
+});
+
+describe('expenseAccount', () => {
+  it('prefixes with Expense:', () => {
+    // fails if expenseAccount returns a wrong prefix
+    expect(expenseAccount('Transport')).toBe('Expense:Transport');
+  });
+
+  it('property: always starts with Expense:', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (cat) => {
+        return expenseAccount(cat).startsWith('Expense:');
+      }),
+    );
+  });
+});
+
+describe('incomeAccount', () => {
+  it('prefixes with Income:', () => {
+    // fails if incomeAccount returns a wrong prefix
+    expect(incomeAccount('Refund')).toBe('Income:Refund');
+  });
+
+  it('property: always starts with Income:', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (cat) => {
+        return incomeAccount(cat).startsWith('Income:');
+      }),
+    );
+  });
+});

--- a/tests/unit/core/ingest/auto-tag-rules.test.ts
+++ b/tests/unit/core/ingest/auto-tag-rules.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for auto-tag rule seed.
+ *
+ * Gherkin coverage (Scenario: TransactionBuilder + auto-tagger obvious basics):
+ *   - Each seed rule matches a known BPCE-style description
+ *   - A known decoy does not match any rule
+ *   - Unmatched descriptions fall through to Uncategorized
+ *
+ * fails if: a seed rule pattern is missing, mis-spelled, or uses wrong flags;
+ *           or if a rule accidentally matches unrelated descriptions
+ */
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_RULES } from '../../../../src/core/ingest/auto-tag-rules.js';
+
+function matchCategory(description: string): string | undefined {
+  const rule = DEFAULT_RULES.find((r) => r.pattern.test(description));
+  return rule?.category;
+}
+
+describe('DEFAULT_RULES auto-tag seed', () => {
+  it('matches Transport for Uber', () => {
+    // fails if the /uber/i rule is absent or misspelled
+    expect(matchCategory('UBER TRIP 2026')).toBe('Transport');
+    expect(matchCategory('BOLT EATS')).toBe('Transport');
+    expect(matchCategory('TAXI PARISIEN')).toBe('Transport');
+  });
+
+  it('matches Groceries for French supermarkets', () => {
+    // fails if supermarket patterns are absent
+    expect(matchCategory('CARREFOUR MARKET')).toBe('Groceries');
+    expect(matchCategory('MONOPRIX PARIS')).toBe('Groceries');
+    expect(matchCategory('BIOCOOP LYON')).toBe('Groceries');
+  });
+
+  it('matches Fuel for petrol stations', () => {
+    // fails if fuel patterns are absent
+    expect(matchCategory('TOTAL STATION 75')).toBe('Fuel');
+    expect(matchCategory('SHELL SERVICES')).toBe('Fuel');
+  });
+
+  it('matches Restaurant for dining', () => {
+    // fails if restaurant pattern is absent
+    expect(matchCategory('LE PETIT RESTAURANT')).toBe('Restaurant');
+    expect(matchCategory('CAFE DU MARCHE')).toBe('Restaurant');
+  });
+
+  it('matches Utilities for telecom/energy', () => {
+    // fails if utilities patterns are absent
+    expect(matchCategory('EDF PRELEVEMENT')).toBe('Utilities');
+    expect(matchCategory('FREE MOBILE')).toBe('Utilities');
+    expect(matchCategory('ORANGE TELECOM')).toBe('Utilities');
+  });
+
+  it('matches BankingFees for bank charges', () => {
+    // fails if banking-fees patterns are absent
+    expect(matchCategory('COTISATION CB VISA')).toBe('BankingFees');
+    expect(matchCategory('FRAIS BANCAIRES MENSUELS')).toBe('BankingFees');
+  });
+
+  it('matches Insurance for mutuelle/assurance', () => {
+    // fails if insurance patterns are absent
+    expect(matchCategory('ASSURANCE HABITATION')).toBe('Insurance');
+    expect(matchCategory('MUTUELLE OBLIGATOIRE')).toBe('Insurance');
+  });
+
+  it('matches Subscriptions for streaming/digital', () => {
+    // fails if subscription patterns are absent
+    expect(matchCategory('NETFLIX.COM')).toBe('Subscriptions');
+    expect(matchCategory('SPOTIFY PREMIUM')).toBe('Subscriptions');
+    expect(matchCategory('ABONNEMENT PRESSE')).toBe('Subscriptions');
+  });
+
+  it('returns undefined for an unrelated description (decoy)', () => {
+    // fails if a rule over-matches and catches unrelated text
+    expect(matchCategory('WEIRD MERCHANT XYZ 99999')).toBeUndefined();
+    expect(matchCategory('PAIEMENT CARTE X1234')).toBeUndefined();
+  });
+});

--- a/tests/unit/core/ingest/transaction-builder.test.ts
+++ b/tests/unit/core/ingest/transaction-builder.test.ts
@@ -250,3 +250,94 @@ describe('TransactionBuilder — obvious basics', () => {
     });
   });
 });
+
+describe('TransactionBuilder — card-settlement classifier', () => {
+  beforeEach(() => { idSeq = 0; });
+
+  describe('Scenario AC/#26: PAIEMENT CARTE on main account → internal transfer', () => {
+    it('matches PAIEMENT CARTE X1234 and classifies as internal-transfer', () => {
+      // fails if: the classifier doesn't run, or it doesn't recognise the PAIEMENT CARTE pattern
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'main-1',
+        direction: 'outflow',
+        description: 'PAIEMENT CARTE X1234 AVRIL',
+        amount: eur(52345),
+      });
+      const result = builder.build(item);
+      expect(result.isSuccess).toBe(true);
+      const outcome = result.value;
+      expect(outcome.classification).toBe('internal-transfer');
+      expect(outcome.category).toBe('InternalTransfer');
+      expect(outcome.confidence).toBe('high');
+    });
+
+    it('debit Liabilities:CreditCard:card-1234, credit Assets:Bank:main-1', () => {
+      // fails if: the internal-transfer entries swap debit/credit sides,
+      // or it resolves to the wrong card account id
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'main-1',
+        direction: 'outflow',
+        description: 'PAIEMENT CARTE X1234 AVRIL',
+        amount: eur(52345),
+      });
+      const outcome = builder.build(item).value;
+      const debit = outcome.transaction.entries.find((e) => e.side === 'debit');
+      const credit = outcome.transaction.entries.find((e) => e.side === 'credit');
+      expect(debit?.account).toBe('Liabilities:CreditCard:card-1234');
+      expect(credit?.account).toBe('Assets:Bank:main-1');
+      expect(debit?.amount.amount).toBe(52345);
+      expect(credit?.amount.amount).toBe(52345);
+    });
+
+    it('also matches without X prefix: PAIEMENT CARTE 1234', () => {
+      // fails if: the regex requires the X prefix (some BPCE statements omit it)
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'main-1',
+        direction: 'outflow',
+        description: 'PAIEMENT CARTE 1234',
+        amount: eur(10000),
+      });
+      const outcome = builder.build(item).value;
+      expect(outcome.classification).toBe('internal-transfer');
+    });
+  });
+
+  describe('Scenario: PAIEMENT CARTE with unknown suffix → Uncategorized expense, confidence=low', () => {
+    it('falls back to expense when suffix matches no card', () => {
+      // fails if: the classifier silently guesses a card, or hard-fails the item (silent data loss)
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'main-1',
+        direction: 'outflow',
+        description: 'PAIEMENT CARTE X9999',
+        amount: eur(10000),
+      });
+      const result = builder.build(item);
+      expect(result.isSuccess).toBe(true);
+      const outcome = result.value;
+      expect(outcome.classification).toBe('expense');
+      expect(outcome.category).toBe('Uncategorized');
+      expect(outcome.confidence).toBe('low');
+    });
+  });
+
+  describe('Scenario: card-sourced item is NOT classified by the card-settlement classifier', () => {
+    it('PAIEMENT CARTE on a card account is treated as regular expense, not internal-transfer', () => {
+      // fails if: the classifier runs against card-sourced items
+      // (should only fire when sourceAccount.type === 'bank')
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'card-1234',
+        direction: 'outflow',
+        description: 'PAIEMENT CARTE X1234',
+        amount: eur(10000),
+      });
+      const outcome = builder.build(item).value;
+      expect(outcome.classification).not.toBe('internal-transfer');
+      expect(outcome.classification).toBe('expense');
+    });
+  });
+});

--- a/tests/unit/core/ingest/transaction-builder.test.ts
+++ b/tests/unit/core/ingest/transaction-builder.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for TransactionBuilder.
+ *
+ * Slice 1 (obvious basics): direction table, auto-tag match + Uncategorized fallback,
+ *   buildAll built/failed split + order preservation, distinct UUIDs,
+ *   description pass-through, occurredAt pass-through.
+ *
+ * Slice 2 (card-settlement classifier): see bottom of this file — tests are initially skipped
+ * and enabled in the separate failing-test commit for that slice.
+ *
+ * fails if: direction→debit/credit rows wrong, auto-tag seed absent, Uncategorized fallback
+ *   not implemented, buildAll aborts on one failure, ordering lost, idGen called once and reused,
+ *   description/occurredAt mutated by the builder.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TransactionBuilder } from '../../../../src/core/ingest/transaction-builder.js';
+import type { AccountConfig } from '../../../../src/core/config/app-config.js';
+import type { IngestItem } from '../../../../src/core/ingest/types.js';
+import { Money } from '../../../../src/core/shared/money.js';
+
+const bankAccount: AccountConfig = {
+  id: 'main-1',
+  type: 'bank',
+  filenamePrefix: '12345678901_',
+};
+
+const cardAccount: AccountConfig = {
+  id: 'card-1234',
+  type: 'card',
+  cardSuffix: '1234',
+  filenamePrefix: 'carte_1234_',
+};
+
+const accounts: readonly AccountConfig[] = [bankAccount, cardAccount];
+
+function eur(cents: number): Money {
+  return Money.fromCents(cents, 'EUR').value;
+}
+
+function makeItem(
+  overrides: Partial<IngestItem> & Pick<IngestItem, 'sourceAccount' | 'direction'>,
+): IngestItem {
+  return {
+    occurredAt: '2026-04-20T00:00:00+02:00',
+    description: 'UBER TRIP 2026',
+    amount: eur(2000),
+    ...overrides,
+  };
+}
+
+let idSeq = 0;
+const seqIdGen = (): string => `test-id-${++idSeq}`;
+
+describe('TransactionBuilder — obvious basics', () => {
+  beforeEach(() => { idSeq = 0; });
+
+  describe('Scenario AC1/AC2: expense on a bank account (bank + outflow)', () => {
+    it('returns Result.ok with classification=expense, category=Transport, confidence=high', () => {
+      // fails if: bank→outflow row routes to wrong accounts, or Uber rule absent
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({ sourceAccount: 'main-1', direction: 'outflow', description: 'UBER TRIP 2026' });
+      const result = builder.build(item);
+
+      expect(result.isSuccess).toBe(true);
+      const outcome = result.value;
+      expect(outcome.classification).toBe('expense');
+      expect(outcome.category).toBe('Transport');
+      expect(outcome.confidence).toBe('high');
+    });
+
+    it('transaction has debit Expense:Transport and credit Assets:Bank:main-1', () => {
+      // fails if: direction table maps bank+outflow to wrong credit account
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({ sourceAccount: 'main-1', direction: 'outflow', description: 'UBER TRIP 2026', amount: eur(2000) });
+      const outcome = builder.build(item).value;
+      const entries = outcome.transaction.entries;
+
+      const debit = entries.find((e) => e.side === 'debit');
+      const credit = entries.find((e) => e.side === 'credit');
+      expect(debit?.account).toBe('Expense:Transport');
+      expect(credit?.account).toBe('Assets:Bank:main-1');
+      expect(debit?.amount.amount).toBe(2000);
+      expect(credit?.amount.amount).toBe(2000);
+    });
+  });
+
+  describe('Scenario: expense on a card account (card + outflow)', () => {
+    it('routes credit to Liabilities:CreditCard, not Assets:Bank', () => {
+      // fails if: card→outflow row routes to Assets:Bank instead of Liabilities:CreditCard
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'card-1234',
+        direction: 'outflow',
+        description: 'CARREFOUR MARKET',
+        amount: eur(4200),
+      });
+      const outcome = builder.build(item).value;
+      const entries = outcome.transaction.entries;
+
+      expect(outcome.category).toBe('Groceries');
+      const debit = entries.find((e) => e.side === 'debit');
+      const credit = entries.find((e) => e.side === 'credit');
+      expect(debit?.account).toBe('Expense:Groceries');
+      expect(credit?.account).toBe('Liabilities:CreditCard:card-1234');
+    });
+  });
+
+  describe('Scenario: income/refund on a card account (card + inflow)', () => {
+    it('reverses sides: debit CreditCard, credit Income', () => {
+      // fails if: inflow on a card is treated as expense (would wrongly increase CC liability)
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'card-1234',
+        direction: 'inflow',
+        description: 'REMBOURSEMENT MUTUELLE',
+        amount: eur(1500),
+      });
+      const outcome = builder.build(item).value;
+
+      expect(outcome.classification).toBe('income');
+      expect(outcome.category).toBe('Insurance');
+      const debit = outcome.transaction.entries.find((e) => e.side === 'debit');
+      const credit = outcome.transaction.entries.find((e) => e.side === 'credit');
+      expect(debit?.account).toBe('Liabilities:CreditCard:card-1234');
+      expect(credit?.account).toBe('Income:Insurance');
+    });
+  });
+
+  describe('Scenario: bank account inflow → income', () => {
+    it('routes to debit Assets:Bank, credit Income', () => {
+      // fails if: bank+inflow row routes credit to Expense instead of Income
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'main-1',
+        direction: 'inflow',
+        description: 'REMBOURSEMENT EDF',
+        amount: eur(5000),
+      });
+      const outcome = builder.build(item).value;
+
+      expect(outcome.classification).toBe('income');
+      const debit = outcome.transaction.entries.find((e) => e.side === 'debit');
+      const credit = outcome.transaction.entries.find((e) => e.side === 'credit');
+      expect(debit?.account).toBe('Assets:Bank:main-1');
+      expect(credit?.account).toBe('Income:Utilities');
+    });
+  });
+
+  describe('Scenario: unmatched description → Uncategorized, confidence=low', () => {
+    it('sets category=Uncategorized and confidence=low, does NOT drop the item', () => {
+      // fails if: unmatched items get dropped (silent data loss), or confidence reports 'high'
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'main-1',
+        direction: 'outflow',
+        description: 'WEIRD MERCHANT XYZ',
+      });
+      const result = builder.build(item);
+
+      expect(result.isSuccess).toBe(true);
+      expect(result.value.category).toBe('Uncategorized');
+      expect(result.value.confidence).toBe('low');
+      expect(result.value.classification).toBe('expense');
+    });
+  });
+
+  describe('Scenario: batch buildAll preserves input order and splits built/failed', () => {
+    it('built.length == 4, failed.length == 1, order preserved', () => {
+      // fails if: one bad item aborts the batch, or ordering is lost
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const goodItem = (desc: string): IngestItem =>
+        makeItem({ sourceAccount: 'main-1', direction: 'outflow', description: desc });
+
+      const items: IngestItem[] = [
+        goodItem('UBER TRIP A'),
+        goodItem('UBER TRIP B'),
+        makeItem({ sourceAccount: 'unknown-account', direction: 'outflow' }),
+        goodItem('UBER TRIP D'),
+        goodItem('UBER TRIP E'),
+      ];
+
+      const result = builder.buildAll(items);
+      expect(result.isSuccess).toBe(true);
+      const batch = result.value;
+      expect(batch.built).toHaveLength(4);
+      expect(batch.failed).toHaveLength(1);
+      expect(batch.failed[0].item).toBe(items[2]);
+    });
+
+    it('built items appear in the same relative order as input', () => {
+      // fails if: ordering is lost (e.g. parallel processing without sort)
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const items: IngestItem[] = [
+        makeItem({ sourceAccount: 'main-1', direction: 'outflow', description: 'UBER TRIP 1', amount: eur(100) }),
+        makeItem({ sourceAccount: 'main-1', direction: 'outflow', description: 'CARREFOUR', amount: eur(200) }),
+        makeItem({ sourceAccount: 'main-1', direction: 'outflow', description: 'NETFLIX', amount: eur(1499) }),
+      ];
+      const batch = builder.buildAll(items).value;
+      expect(batch.built[0].transaction.description).toBe('UBER TRIP 1');
+      expect(batch.built[1].transaction.description).toBe('CARREFOUR');
+      expect(batch.built[2].transaction.description).toBe('NETFLIX');
+    });
+  });
+
+  describe('Scenario: batch buildAll assigns a distinct Transaction.id per item', () => {
+    it('5 valid items → 5 distinct ids', () => {
+      // fails if: idGen is called once in the constructor and reused,
+      // or a cached UUID leaks across items
+      let callCount = 0;
+      const uniqueIdGen = (): string => `uid-${++callCount}`;
+      const builder = new TransactionBuilder(accounts, undefined, uniqueIdGen);
+
+      const items: IngestItem[] = Array.from({ length: 5 }, (_, i) =>
+        makeItem({ sourceAccount: 'main-1', direction: 'outflow', description: `UBER ${i}` }),
+      );
+      const batch = builder.buildAll(items).value;
+
+      const ids = batch.built.map((o) => o.transaction.id);
+      expect(new Set(ids).size).toBe(5);
+    });
+  });
+
+  describe('Scenario: Transaction.description pass-through', () => {
+    it('transaction.description === original item.description, NOT the category', () => {
+      // fails if: the category leaks into description, or builder rewrites the description
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'main-1',
+        direction: 'outflow',
+        description: 'UBER TRIP 2026-04-20',
+      });
+      const outcome = builder.build(item).value;
+      expect(outcome.transaction.description).toBe('UBER TRIP 2026-04-20');
+      expect(outcome.transaction.description).not.toBe('Transport');
+    });
+  });
+
+  describe('Scenario: Transaction.occurredAt pass-through', () => {
+    it('transaction.occurredAt === original item.occurredAt, no reformat', () => {
+      // fails if: the builder re-parses and re-serialises the timestamp,
+      // or strips the offset (Story 2.2 idempotency hash depends on exact string)
+      const builder = new TransactionBuilder(accounts, undefined, seqIdGen);
+      const item = makeItem({
+        sourceAccount: 'main-1',
+        direction: 'outflow',
+        occurredAt: '2026-04-20T00:00:00+02:00',
+      });
+      const outcome = builder.build(item).value;
+      expect(outcome.transaction.occurredAt).toBe('2026-04-20T00:00:00+02:00');
+    });
+  });
+});

--- a/tests/unit/infra/config/config-schema.test.ts
+++ b/tests/unit/infra/config/config-schema.test.ts
@@ -249,6 +249,107 @@ describe('parseRawConfig', () => {
       const result = parseRawConfig(raw);
       expect(result.isFailure).toBe(true);
     });
+
+    describe('type field (Story 2.3)', () => {
+      it('accepts a bank account with type: bank', () => {
+        // fails if parseRawConfig rejects a valid bank-type account entry
+        const raw = {
+          ...minimalValid,
+          accounts: [
+            { id: 'main-1', type: 'bank', filenamePrefix: '12345678901_' },
+          ],
+        };
+        const result = parseRawConfig(raw);
+        expect(result.isSuccess).toBe(true);
+        expect(result.value.accounts[0].type).toBe('bank');
+      });
+
+      it('accepts a card account with type: card and valid cardSuffix', () => {
+        // fails if parseRawConfig rejects a valid card-type account with a 4-digit cardSuffix
+        const raw = {
+          ...minimalValid,
+          accounts: [
+            { id: 'main-1', type: 'bank', filenamePrefix: '12345678901_' },
+            { id: 'card-1234', type: 'card', cardSuffix: '1234', filenamePrefix: 'carte_1234_' },
+          ],
+        };
+        const result = parseRawConfig(raw);
+        expect(result.isSuccess).toBe(true);
+        expect(result.value.accounts[1].type).toBe('card');
+        expect(result.value.accounts[1].cardSuffix).toBe('1234');
+      });
+
+      it('rejects an account with an unknown type value — error names the field not the value', () => {
+        // fails if parseRawConfig accepts an account with type !== 'bank' | 'card'
+        const raw = {
+          ...minimalValid,
+          accounts: [
+            { id: 'main-1', type: 'savings', filenamePrefix: '12345678901_' },
+          ],
+        };
+        const result = parseRawConfig(raw);
+        expect(result.isFailure).toBe(true);
+        expect(result.error).toContain('type');
+        // PII-safe: must not echo the user-supplied value
+        expect(result.error).not.toContain('savings');
+      });
+
+      it('rejects a missing type field', () => {
+        // fails if parseRawConfig accepts an account entry with no type field
+        const raw = {
+          ...minimalValid,
+          accounts: [
+            { id: 'main-1', filenamePrefix: '12345678901_' },
+          ],
+        };
+        const result = parseRawConfig(raw);
+        expect(result.isFailure).toBe(true);
+        expect(result.error).toContain('type');
+      });
+
+      it('rejects a card account missing cardSuffix — error names the field not the value', () => {
+        // fails if parseRawConfig accepts a card-type account without a cardSuffix
+        // (cross-field superRefine: type==='card' requires cardSuffix)
+        const raw = {
+          ...minimalValid,
+          accounts: [
+            { id: 'card-1234', type: 'card', filenamePrefix: 'carte_1234_' },
+          ],
+        };
+        const result = parseRawConfig(raw);
+        expect(result.isFailure).toBe(true);
+        expect(result.error).toContain('cardSuffix');
+      });
+
+      it('rejects a card account with a non-4-digit cardSuffix', () => {
+        // fails if parseRawConfig accepts cardSuffix not matching /^\d{4}$/
+        const raw = {
+          ...minimalValid,
+          accounts: [
+            { id: 'card-1234', type: 'card', cardSuffix: '12', filenamePrefix: 'carte_1234_' },
+          ],
+        };
+        const result = parseRawConfig(raw);
+        expect(result.isFailure).toBe(true);
+        expect(result.error).toContain('cardSuffix');
+      });
+
+      it('rejects a bank account that has a cardSuffix — error names the field not the value', () => {
+        // fails if parseRawConfig allows cardSuffix on a bank account
+        // (cross-field superRefine: type==='bank' must not have cardSuffix)
+        const raw = {
+          ...minimalValid,
+          accounts: [
+            { id: 'main-1', type: 'bank', cardSuffix: '1234', filenamePrefix: '12345678901_' },
+          ],
+        };
+        const result = parseRawConfig(raw);
+        expect(result.isFailure).toBe(true);
+        expect(result.error).toContain('cardSuffix');
+        // PII-safe: must not echo the user-supplied suffix value
+        expect(result.error).not.toContain('1234');
+      });
+    });
   });
 
   describe('property tests', () => {

--- a/tests/unit/infra/config/config-schema.test.ts
+++ b/tests/unit/infra/config/config-schema.test.ts
@@ -12,8 +12,8 @@ const minimalValid = {
   buffers: [],
   timezone: 'Europe/Paris',
   accounts: [
-    { id: 'main-12345678901', filenamePrefix: '12345678901_' },
-    { id: 'card-1234', filenamePrefix: 'carte_1234_' },
+    { id: 'main-12345678901', type: 'bank', filenamePrefix: '12345678901_' },
+    { id: 'card-1234', type: 'card', cardSuffix: '1234', filenamePrefix: 'carte_1234_' },
   ],
 };
 
@@ -202,8 +202,8 @@ describe('parseRawConfig', () => {
       const raw = {
         ...minimalValid,
         accounts: [
-          { id: 'main-12345678901', filenamePrefix: '12345678901_' },
-          { id: 'main-12345678901', filenamePrefix: 'carte_1234_' },
+          { id: 'main-12345678901', type: 'bank', filenamePrefix: '12345678901_' },
+          { id: 'main-12345678901', type: 'bank', filenamePrefix: 'carte_1234_' },
         ],
       };
       // fails if parseRawConfig does not detect duplicate account ids
@@ -218,8 +218,8 @@ describe('parseRawConfig', () => {
       const raw = {
         ...minimalValid,
         accounts: [
-          { id: 'main-aaa', filenamePrefix: 'shared_prefix_' },
-          { id: 'card-bbb', filenamePrefix: 'shared_prefix_' },
+          { id: 'main-aaa', type: 'bank', filenamePrefix: 'shared_prefix_' },
+          { id: 'card-bbb', type: 'bank', filenamePrefix: 'shared_prefix_' },
         ],
       };
       // fails if parseRawConfig does not detect duplicate filenamePrefix values
@@ -234,7 +234,7 @@ describe('parseRawConfig', () => {
       // fails if parseRawConfig accepts an account with an empty id
       const raw = {
         ...minimalValid,
-        accounts: [{ id: '', filenamePrefix: '12345678901_' }],
+        accounts: [{ id: '', type: 'bank', filenamePrefix: '12345678901_' }],
       };
       const result = parseRawConfig(raw);
       expect(result.isFailure).toBe(true);
@@ -244,7 +244,7 @@ describe('parseRawConfig', () => {
       // fails if parseRawConfig accepts an account with an empty filenamePrefix
       const raw = {
         ...minimalValid,
-        accounts: [{ id: 'main-aaa', filenamePrefix: '' }],
+        accounts: [{ id: 'main-aaa', type: 'bank', filenamePrefix: '' }],
       };
       const result = parseRawConfig(raw);
       expect(result.isFailure).toBe(true);

--- a/tests/unit/infra/crypto/node-uuid-gen.test.ts
+++ b/tests/unit/infra/crypto/node-uuid-gen.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit tests for nodeUuidGen adapter.
+ *
+ * fails if: nodeUuidGen returns something that isn't a string, isn't unique across calls,
+ *   or doesn't match UUID v4 format.
+ */
+import { describe, it, expect } from 'vitest';
+import { nodeUuidGen } from '../../../../src/infra/crypto/node-uuid-gen.js';
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('nodeUuidGen', () => {
+  it('returns a string', () => {
+    // fails if nodeUuidGen does not return a string
+    expect(typeof nodeUuidGen()).toBe('string');
+  });
+
+  it('returns a UUID v4 formatted string', () => {
+    // fails if the underlying randomUUID call is swapped for a non-v4 generator
+    expect(nodeUuidGen()).toMatch(UUID_V4);
+  });
+
+  it('returns distinct values on successive calls', () => {
+    // fails if: a cached UUID is returned (idGen called once and reused)
+    const ids = Array.from({ length: 10 }, () => nodeUuidGen());
+    expect(new Set(ids).size).toBe(10);
+  });
+});


### PR DESCRIPTION
## 1. Story

[Epic 2, Story 2.3 — Transaction Builder & Auto-Tagging Domain Service](../blob/main/docs/epics.md#story-23-transaction-builder--auto-tagging-domain-service).

## 2. Intent

Convert each \`IngestItem\` (from Story 2.1's CSV parser, filtered by Story 2.2's idempotency) into a balanced double-entry \`Transaction\`. Auto-tags descriptions against a regex seed (8 categories) and classifies "PAIEMENT CARTE X####" lines on the main account as internal transfers (issue #26) to prevent double-counting against per-card granular statements. No persistence (Story 2.5), no CLI (Story 2.4).

## 3. Alternatives considered

- **Suffix-match on \`AccountConfig.id\` via \`endsWith(…)\` for card settlements** — rejected; Plan agent caught the collision case: a bank account id ending in the same 4 digits as a card's suffix would silently misclassify. Switched to an explicit \`AccountConfig.cardSuffix: string\` field with a Zod cross-field refinement (required iff \`type: 'card'\`).
- **Numeric confidence score (0–1)** — rejected; YAGNI. Story 2.4's interactive loop only branches on "prompt review or not" — a boolean in disguise. Binary \`'high' | 'low'\` is honest; converting later is mechanical.
- **YAML-loaded user-customisable auto-tag rules** — rejected for MVP; Story 2.4's interactive per-item tagging is a more ergonomic affordance than a YAML rule editor. Trigger condition documented: if Story 2.4 slips more than one iteration, file a YAML-override issue.
- **Optional \`AccountConfig.type\` with default 'bank'** — rejected; implicit-default would silently miscategorize a card as a bank account. Required enum keeps the user honest.
- **\`crypto.randomUUID\` hardcoded in Core** — rejected; breaks Core-has-no-Node-imports. Followed the Story 2.2 \`HashFn\`/\`NodeHashFn\` pattern: \`UuidGen\` port in Core, \`nodeUuidGen\` adapter in Infra.
- **\`buildAll\` returns \`Result<BuildOutcome[]>\`** — rejected; one bad item shouldn't abort a 150-row batch. Returns \`{ built, failed }\` split, mirroring Story 2.1's per-row parse-stage error pattern.
- **Mixing the card-settlement classifier into \`AutoTagRule[]\`** — rejected; classifier needs \`sourceAccount.type === 'bank'\` AND cross-ref against the accounts array. Structural not description-only; kept as a separate pre-tagging step.

## 4. Selected solution & rationale

**Config additions (Infra):** \`AccountConfig.type: 'bank' | 'card'\` (required enum) + \`AccountConfig.cardSuffix?: string\` (required iff \`type==='card'\`, regex \`/^\\d{4}$/\`). Zod \`superRefine\` for the cross-field rule. PII-safe error messages.

**Core helpers:**
- [\`src/core/ingest/account-names.ts\`](../blob/main/src/core/ingest/account-names.ts): pure helpers \`bankAccount(id)\`, \`cardAccount(id)\`, \`expenseAccount(cat)\`, \`incomeAccount(cat)\` for colon-delimited CoA-style account names.
- [\`src/core/ingest/auto-tag-rules.ts\`](../blob/main/src/core/ingest/auto-tag-rules.ts): \`AutoTagRule\` type + \`DEFAULT_RULES\` seed (8 categories: Transport, Groceries, Fuel, Restaurant, Utilities, BankingFees, Insurance, Subscriptions; French-biased based on BPCE data).

**Core service:** [\`TransactionBuilder\`](../blob/main/src/core/ingest/transaction-builder.ts) — constructor DI on \`(accounts, rules, idGen)\`. Methods \`build(item)\` and \`buildAll(items)\`. Pure; no IO. Card-settlement classifier runs before auto-tagging; on match (one card with matching \`cardSuffix\`), produces \`classification: 'internal-transfer'\`; on zero/multi-match, falls through to Uncategorized expense (never silent misclassification). The 4-row direction→debit/credit table is concentrated in a \`makeOutcome\` helper after a Phase-4 refactor pass.

**Core port:** \`UuidGen = () => string\`. Infra: \`nodeUuidGen\` wraps \`crypto.randomUUID\`.

**Transaction pass-through:** \`transaction.description\` === original \`IngestItem.description\` (original, not the matched category — audit trail). \`transaction.occurredAt\` === exact \`IngestItem.occurredAt\` string (Story 2.2's idempotency hash depends on it). Tests assert both.

## 5. Gherkin scenarios

Nine scenarios map 1:1 to unit tests (one \`describe\` per scenario) in [tests/unit/core/ingest/transaction-builder.test.ts](../blob/main/tests/unit/core/ingest/transaction-builder.test.ts). Full Gherkin text in the plan file ([docs/plans/story-2.3.md](../blob/main/docs/plans/story-2.3.md) § Gherkin scenarios). Summary:

- **AC1/AC2 — expense on bank account** → debit \`Expense:Transport\`, credit \`Assets:Bank:main-1\`
- **Expense on card account** → debit \`Expense:Groceries\`, credit \`Liabilities:CreditCard:card-1234\`
- **Inflow on card account (refund)** → sides reversed
- **Unmatched description** → \`Uncategorized\` + \`confidence: 'low'\`
- **AC#26 — PAIEMENT CARTE X1234 on bank** → internal-transfer, debit \`Liabilities:CreditCard:card-1234\`, credit \`Assets:Bank:main-1\`
- **Ambiguous suffix** → Uncategorized expense (never silent misclassification)
- **\`buildAll\` batch** → \`{ built, failed }\` split, preserves input order
- **Distinct UUIDs per item** (5 items → 5 distinct \`.id\`; Plan agent catch)
- **\`description\` + \`occurredAt\` pass-through** (Plan agent catches)

## 6. Plan for Sonnet

Full plan committed at [docs/plans/story-2.3.md](../blob/main/docs/plans/story-2.3.md) (convention from Story 2.2 retro action A — plan lives in repo alongside retrospective).

Commit sequence (10 commits total: 1 chore + 6 test/feat + 2 refactor + 1 retro):

1. \`chore(docs)\`: refresh CLAUDE.md § 1 + add Story 2.3 plan
2. \`test(config)\`: \`AccountConfig.type\` enum + \`cardSuffix\` cross-field validation — failing
3. \`feat(config)\`: \`AccountConfig.type\` + \`cardSuffix\` minimal green
4. \`test(ingest)\`: \`TransactionBuilder\` + auto-tagger obvious basics — failing
5. \`feat(ingest)\`: \`TransactionBuilder\` + auto-tagger minimal green
6. \`test(ingest)\`: card-settlement classifier — failing
7. \`feat(ingest)\`: card-settlement classifier minimal green
8. \`refactor(ingest)\`: tidy (defaultUuidGen IIFE)
9. \`refactor(ingest)\`: extract \`makeOutcome\` helper (Phase-4 retro-check finding)
10. \`chore(retro)\`: Story 2.3 retrospective + sonnet-implementer 60-LOC trigger

Adapter-story sizing per § 6.6. Zero green-on-landing (compare Story 2.1's 3 of 5). Phase 4 retro-check produced one refactor — \`build()\` at 84 LOC with 4-way duplication → \`makeOutcome\` extraction (commit \`df31b03\`). \`build()\` now ~33 LOC.

## 7. Suggestion log

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| Plan-stress | \`id.endsWith(suffix)\` for card classifier → explicit \`AccountConfig.cardSuffix\` field | adopted | Plan updated; collision case (\`bank-91234\` / \`card-1234\`) made explicit |
| Plan-stress | Binary \`confidence\` OK as planned | accepted | Numeric without scoring model would be false precision |
| Plan-stress | Hardcoded French auto-tag seed without YAML override | deferred trigger | No issue yet; trigger condition: file if Story 2.4 slips >1 iteration |
| Plan-stress | Required \`type\` enum OK as planned | accepted | Adding \`'savings'\` later is additive, not breaking |
| Plan-stress | \`UuidGen\` port OK as planned | accepted | Matches Story 2.2 \`HashFn\` precedent; Core-purity rule |
| Plan-stress P1 | Missing test: \`buildAll\` assigns distinct UUIDs per item | adopted | Plan + tests added |
| Plan-stress P2 | Missing test: \`transaction.description\` preserves original (not category) | adopted | Plan + tests added; audit-trail invariant |
| Plan-stress P2 | Missing test: \`occurredAt\` pass-through (no reformat) | adopted | Plan + tests added; determinism + idempotency-hash dependency |
| Phase-4 retro | \`TransactionBuilder.build()\` ~84 LOC with 4-way duplication | adopted | Extracted \`makeOutcome\` helper in commit \`df31b03\`; \`build()\` now ~33 LOC |
| Phase-4 retro | Sonnet's refactor slot deferred the \`build()\` extraction too quietly | adopted | CLAUDE.md-adjacent fix — \`.claude/agents/sonnet-implementer.md\` § 3 gains a 60-LOC + duplication trigger (retro action A) |

## 8. Sonnet's learnings

### Run 1 — full implementation (8 commits)

#### What was built

All 9 Gherkin scenarios pass. Core: \`account-names\` helpers, \`auto-tag-rules\` seed (8 categories), \`TransactionBuilder\` class with \`build()\` + \`buildAll()\` + card-settlement classifier. Port: \`UuidGen\`. Infra: \`nodeUuidGen\`. Config: \`AccountConfig.type\` + \`cardSuffix\` cross-field Zod validation.

#### Red → green sequence

- \`test(config)\` · \`49df52a\` · proved \`AccountConfigSchema\` didn't declare \`type\`
- \`feat(config)\` · \`4cf5ba7\` · Zod enum + superRefine cross-field rules work
- \`test(ingest)\` obvious basics · \`ed8573f\` · proved helpers/builder were skeleton-only
- \`feat(ingest)\` obvious basics · \`99e634b\` · all basic tests green
- \`test(ingest)\` card classifier · \`ec17f2c\` · proved classifier absent
- \`feat(ingest)\` card classifier · \`c19d31a\` · classifier green
- \`refactor(ingest)\` tidy · \`de2b1b5\` · defaultUuidGen IIFE simplification

#### Deviations from plan

- **\`node-uuid-gen\` test was green on landing** — adapter trivially correct; called out per retro rule.
- **Inline fixture updates in existing duplicate-detection tests** — \`AccountConfigSchema\` gaining \`type\` required existing \`minimalValid\` fixtures to include \`type: 'bank'\`; behaviour-preserving.
- **\`build()\` ~80 LOC** — slightly over the ~50 guideline; deferred extraction to Phase 4 refactor; see § 7.
- **\`defaultUuidGen\` IIFE simplified** during-green per § 6.5.

#### Proposed follow-ups

- \`build()\` direction-table extraction (done in Phase-4 refactor commit \`df31b03\`).
- Card-settlement classifier locale dependency (BPCE-specific) — note in #26 when second bank format lands.

### Run 2 — Phase-4 refactor (1 commit)

#### What was built

\`makeOutcome\` helper extracted. \`build()\` 84 LOC → 33 LOC. Zero behaviour change. All 151 tests green unchanged.

#### Red → green sequence

No new tests — refactor slot. Existing tests served as green guard.

#### Deviations

None substantive.

## 9. Retrospective

- **Keep:** (1) Plan agent caught a real correctness bug pre-implementation (id-endsWith → explicit \`cardSuffix\`) + three missing assertions (distinct UUIDs, description pass-through, occurredAt pass-through); (2) adapter-story sizing (§ 6.6) held for second consecutive story with zero green-on-landing; (3) plan-in-repo (Story 2.2 action A) worked — zero sensitive-path permission prompts during planning.
- **Change:** (1) first-draft \`build()\` was 84 LOC with 4-way duplication; Sonnet's initial refactor slot deferred the extraction too quietly; (2) refactor-slot commit message was too brief (didn't flag the deferred work).
- **Try:** Add "60 LOC + duplication ≥ 2 blocks = flag in Deviations" threshold to \`.claude/agents/sonnet-implementer.md\` § 3 — applied in this PR as action A.

Full retrospective: [docs/retrospectives/story-2.3.md](../blob/main/docs/retrospectives/story-2.3.md).

## 10. Merge checklist

- [x] \`lint\` / \`build\` / \`test\` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at \`docs/retrospectives/story-2.3.md\`
- [x] All suggestion-log items resolved (no blank \`Resolution\` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval
