### PR TITLE
feat(cli): interactive ingest command + filename-prefix matcher (Story 2.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Phases 1 and 2 compose DoR. Phases 3 and 4 drive to DoD. Phase 5 must complete b
 3. **Implement** (Sonnet via `Task` with the `sonnet-implementer` agent): writes failing acceptance scenario first, drives down to failing unit tests, makes green, commits per state. Returns the structured report (see 6.3). *Exit:* all tests green, report delivered, branch pushed. PR not yet marked ready.
 4. **Code review on the implementation + refactor plan** (Opus) — re-run P1/P2/P3 **against the actual code**:
    - P1 retro-check: acceptance scenarios + unit tests actually deliver the intent. Audit that each `this test fails if …` note identifies the production path it guards, not just any path (Story 1.3 retro action E validated on Story 2.2; codified here per Story 2.2 retro action B).
-   - P2 retro-check: walk QA doc against the diff.
+   - P2 retro-check: walk QA doc against the diff. **Mock diversity check (Story 2.4 retro action A):** when the diff includes structured output (JSON payloads, tables, machine-readable formats), spot-check that at least one test assertion runs against a non-default mock fixture — e.g. a `--json` test must cover `duplicates: [item]`, not only `duplicates: []`, to catch hardcoded-default regressions that pass a zero-mock test suite.
    - P3 retro-check: walk engineering-standards + security-checklist against the diff.
 
    Produce a refactor plan; blockers are fixed before merge, not deferred. Delegate execution to Sonnet. *Exit:* refactor merged back into the branch, CI green.

--- a/docs/plans/story-2.4.md
+++ b/docs/plans/story-2.4.md
@@ -1,0 +1,321 @@
+# Epic 2, Story 2.4 — Interactive Ingest Command (CLI)
+
+## Context
+
+Stories 2.1–2.3 shipped the Core+Infra pipeline: CSV → IngestItems → filtered for dups → built into balanced `Transaction`s with categories and a confidence signal. Story 2.4 is the **first user-facing command**: `accounting ingest -f <file.csv>`. It reads one CSV, runs it through the pipeline, displays a summary, prompts the user to confirm/fix any low-confidence auto-tag, and exits without writing. DB writes + snapshot + atomic commit are Story 2.5.
+
+**Why this story is bigger than the others.** Story 2.4 wraps four distinct concerns that previous stories kept isolated:
+- **File I/O boundary** — Latin-1 read of the BPCE CSV.
+- **Filename-to-source matching** (issue #25 comes home).
+- **Pipeline orchestration** (parse → dedup → build).
+- **Interactive UX** (table display, per-item prompt with arrow-key nav, final confirmation, `--non-interactive` / `--json` modes).
+
+Plus the quickpickle acceptance-test wiring (issue #24) for the first `.feature` file of the project. Expect ~10 commits — larger than Stories 2.1–2.3 (adapter stories) but defensible given scope. Splitting into 2.4a/2.4b was considered and rejected: the interactive flow is the whole point of the "Sunday Morning Audit" journey; shipping the orchestration without the interactivity would ship half a feature.
+
+**Maintenance sub-loop** (pre-planning, § 6.7): `npm audit` clean, zero Dependabot PRs, 14 open issues (#21, #22, #23, #24, #25, #26, #27, #29, plus older ones). Story 2.4 consumes **#24 (quickpickle)** and **#25 (filename matcher)**; does NOT consume #21 (dbPath traversal — its own security PR) or #22 (homedir fallback — its own PR). No CLAUDE.md § 1 refresh needed if Story 2.3's commit already set "Next story: 2.4" (it did — confirm in commit 1 and keep moving).
+
+## Story (verbatim from [docs/epics.md](docs/epics.md))
+
+> As a User, I want to interactively review and approve the tagged transactions in the terminal, so that I can fix incorrect auto-tags before they are committed.
+>
+> **AC1:** displays a summary table of "New Transactions Found".
+> **AC2:** iterates through low-confidence items asking me to confirm or change the tag.
+> **AC3:** supports keyboard navigation (arrows/enter) to select tags.
+> **AC4:** does NOT write to the DB until I explicitly confirm the final batch.
+
+FR coverage: **FR5** (interactive tagging), plus consumes and polishes FR4 (multi-bank ingest — via `pickSourceAccount`). Walks PRD § CLI-specific requirements (stdout/stderr separation, `--non-interactive`, `--json`, POSIX exit codes, "Conversational CFO" tone).
+
+## Selected solution
+
+A commander entry point that composes the Story 2.1–2.3 services, plus one new Infra helper and one new UX module.
+
+### New deps (authorised in commit 2)
+
+| Package | Version | Role | Rationale |
+| --- | --- | --- | --- |
+| `@inquirer/prompts` | ^5.x (or latest stable) | runtime | ESM-native, tree-shakable (`import { select, confirm }`), supports arrow-key `select` per AC3. Modern functional API beats `inquirer` monolith. |
+| `cli-table3` | ^0.6 | runtime | Battle-tested ASCII tables. PRD explicitly names it as a reference option. Lighter than bringing in `ink`. |
+| `quickpickle` | ^1.11 | dev | Vitest-native Gherkin runner — the first `.feature` lands with this story (closes #24). |
+
+One runtime-dep justification goes in the PR description per engineering-standards.md § "New dependencies".
+
+### CLI wiring
+
+```
+src/cli/
+├── program.ts                 # NEW — commander entry, defines `ingest` + (existing) `migrate`
+├── migrate.ts                 # existing — ported to a subcommand of the new program
+└── commands/
+    └── ingest-command.ts      # NEW — the orchestration + UX
+└── utils/
+    ├── printer.ts             # NEW — chalk helpers + cli-table3 table builder
+    └── interactive.ts         # NEW — thin wrapper around @inquirer/prompts (mockable)
+```
+
+The existing `migrate.ts` becomes a commander subcommand to consolidate the entry point. The `package.json` `migrate` script switches to `tsx src/cli/program.ts migrate`, and a new `ingest` script (or direct invocation) is documented.
+
+### New Infra module — `pickSourceAccount` (closes #25)
+
+```ts
+// src/infra/fs/pick-source-account.ts
+export function pickSourceAccount(
+  filePath: string,
+  accounts: readonly AccountConfig[],
+): Result<AccountConfig>;
+```
+
+- Takes the full path, computes `basename(filePath)`.
+- Returns the **longest-prefix** match against `accounts[].filenamePrefix`.
+- `Result.fail` with a PII-safe message for zero matches ("no account configured for this filename — add an entry to `accounts:` in accounting.yaml") or tied-length multi-match ("ambiguous filename — multiple account prefixes match").
+- Lives under `src/infra/fs/` (not `src/cli/utils/`) because it operates on a filesystem concept (basename) and has no CLI/UX concerns — reusable from a future non-CLI caller.
+
+### New Infra module — BPCE Latin-1 file reader
+
+```ts
+// src/infra/fs/read-bpce-csv.ts
+export function readBpceCsv(filePath: string): Result<string>;
+```
+
+- `fs.readFileSync(filePath, 'latin1')` — honors Story 2.1's documented contract.
+- Catches `ENOENT`, `EACCES`, etc. → `Result.fail` with user-friendly, PII-safe messages (name the path's basename, not the full absolute path, to avoid leaking home-directory structure into logs).
+- A dedicated module (not inline in the command) so a future non-CLI caller (a future web UI? a test harness?) can reuse it without pulling in commander.
+
+### Command handler signature
+
+```ts
+// src/cli/commands/ingest-command.ts
+export interface IngestCommandOptions {
+  readonly file: string;
+  readonly nonInteractive: boolean;
+  readonly json: boolean;
+}
+export interface IngestCommandDeps {
+  readonly configService: ConfigService;
+  readonly csvParser: CsvParser;
+  readonly idempotencyService: IdempotencyService;
+  readonly transactionBuilder: TransactionBuilder;
+  readonly pickSourceAccount: typeof pickSourceAccountImpl;
+  readonly readFile: typeof readBpceCsvImpl;
+  readonly prompt: InteractivePrompter;  // mockable in tests; the real one delegates to @inquirer/prompts
+  readonly stdout: Writable;
+  readonly stderr: Writable;                // honored for NON-prompt messages only (see note below)
+  readonly exitCode: (code: number) => void;
+}
+export async function runIngestCommand(opts: IngestCommandOptions, deps: IngestCommandDeps): Promise<void>;
+```
+
+The command is **async** (inquirer prompts are awaited) and takes a `deps` object so every collaborator is injectable in tests. The real `program.ts` wires production instances; tests inject fakes.
+
+**Caveat — inquirer + injected streams.** `@inquirer/prompts` writes prompt output directly to `process.stderr` / reads from `process.stdin`; it does **not** honour the injected `stderr` `Writable`. That's fine: the `InteractivePrompter` abstraction is the mock surface in tests, so the real prompt-side stream is irrelevant in test runs. The injected `stderr` is used **only** for non-prompt messages the handler writes itself (summary counts, error messages, conversational info). This is flagged per Plan agent pushback; unit tests for stderr assertions only cover non-prompt paths.
+
+### Interactive flow (per-item, matches AC2+AC3+AC4)
+
+Per the AC wording "iterates through low-confidence items asking me to confirm or change the tag" — this is a **per-item loop**, not review-all-then-confirm. Sequence:
+
+1. Parse + dedup + build (via Story 2.1–2.3 services).
+2. Print to stderr: `"Found N new transactions — M auto-tagged, K need review."` (Conversational CFO tone; message never appears on stdout.)
+3. Print to stdout the summary table of all N items: columns `Date | Description | Amount | Category | ✓`. High-confidence items get `✓`; low-confidence items show `?` in that column.
+4. For each low-confidence `BuildOutcome` (in input order): show a single-line prompt to stderr ("`? UBER TRIP → Transport (auto). Confirm or change?`") and an `@inquirer/prompts.select` with options `[Keep: Transport, Change to: Groceries, Change to: Restaurant, …, Change to: Uncategorized, Abort]`. User's selection updates that item's category + recomputes the `BuildOutcome`'s `category` and sets `confidence: 'high'`.
+5. After the loop, prompt via `@inquirer/prompts.confirm`: `"Commit these N transactions? (nothing will be written yet — Story 2.5 adds DB writes)"` — default **no**.
+6. Exit 0 on accept with a message naming the count of confirmed items; exit 1 on decline or mid-flow abort.
+
+### `--non-interactive` / `--ci` mode (PRD requirement)
+
+- Every low-confidence item is a fail condition in non-interactive mode. Print to stderr: `"K items need manual review. Run without --non-interactive to review them, or re-ingest after updating accounting.yaml's auto-tag-rules."` Exit with code 2 (invalid input semantics per POSIX). No prompts.
+- High-confidence-only batches succeed the same as interactive mode (but the final confirm is skipped — non-interactive implies auto-confirm).
+
+### `--json` output mode
+
+- Disables interactive prompts (implies `--non-interactive`).
+- Prints a single JSON object to stdout on success:
+  ```json
+  { "file": "…", "source_account": "main-…", "summary": { "total": N, "autoTagged": M, "needsReview": K, "duplicates": D, "parseErrors": E }, "items": [ { "id": "…", "occurredAt": "…", "description": "…", "amount_cents": …, "currency": "EUR", "debit": "Expense:…", "credit": "Assets:Bank:…", "category": "…", "classification": "…" }, … ] }
+  ```
+- `idempotencyHash` is **omitted from the output** — YAGNI (no caller today needs it, and Story 2.2 retro's invariant is that the hash is a DB-boundary concern, not a CLI-output concern). Add the field if/when a downstream tool asks for it. *(Revised per Plan agent pushback: earlier draft cited "leak-by-derivation" as the reason — that's bogus since SHA-256 is one-way. YAGNI is the real justification.)*
+- `--json` + non-high-confidence item → exit 2 + empty-items JSON + a `"needsReview"` array with item-ids.
+
+### Exit code map
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success — batch assembled and confirmed (or auto-confirmed). |
+| 1 | Runtime error — file not found / parse stage failed at file level / user aborted during interactive loop / final confirm declined. |
+| 2 | Invalid input — no matching account for filename, or `--non-interactive` with items needing review, or `--json` with items needing review. |
+
+Stderr carries all human-facing messages (prompts, errors, conversational info). Stdout is reserved for the summary table (human) OR the JSON payload (`--json`). This keeps piping clean.
+
+### Quickpickle wiring (closes #24)
+
+- `npm install --save-dev quickpickle`.
+- Add `tests/features/` directory + `tests/features/ingest.feature` with ONE happy-path scenario mirroring the Story 2.4 journey from the PRD's "Sunday Morning Audit" (read a synthetic CSV, inspect the summary, confirm — no real prompts, step defs stub `@inquirer/prompts` by injecting a deterministic `InteractivePrompter`).
+- Wire vitest config per quickpickle docs. Step definitions in `tests/features/steps/ingest.steps.ts`.
+- Strictly one `.feature` + one `.steps.ts` for this story. More scenarios are added in subsequent stories as CLI commands land.
+
+### Rationale (vs alternatives)
+
+- **`@inquirer/prompts` over `inquirer` / `prompts`.** ESM, tree-shakable, per-component import, active maintenance. `select` is the exact affordance AC3 requests.
+- **`cli-table3` over hand-rolled.** PRD explicitly names it. Handles column alignment, truncation, coloured cells — avoids reinventing string padding for wide multilingual descriptions.
+- **Quickpickle now, not later.** Closes #24; Story 2.4 is the first story with a user-visible behaviour that benefits from outside-in BDD.
+- **`pickSourceAccount` in `src/infra/fs/`** (not `src/cli/utils/`). It's a filesystem-concept helper (basename matching); lives where `readBpceCsv` lives. A future non-CLI caller (e.g., a planned PWA) can reuse it.
+- **Per-item prompt loop** (not review-all-then-confirm). AC literally says "iterates through" + "asking me to confirm or change". Per-item is also the journey ("Alex quickly tags them using arrow keys").
+- **Single file per invocation.** AC says "a list of proposed transactions" (singular batch). User with 5 CSVs runs 5 invocations. Multi-file in one call would widen scope + complicate per-item source tagging. Future story if needed.
+- **Runtime command-handler takes a `deps` object** (not a class). Two motivations: the command is fundamentally a script (not stateful domain logic), and `deps` is friendlier to vitest test doubles than constructor DI for async orchestration. Matches the `runMigrations(db)` style in `src/cli/migrate.ts`.
+- **`exitCode` injection + no direct `process.exit`.** Per security-checklist.md § "Core contains no … `process.exit`" — the CLI is not Core, but injecting the exit lets tests assert exit codes without killing vitest.
+
+## Critical files to create / touch
+
+| Path | Change |
+| --- | --- |
+| `docs/plans/story-2.4.md` | **new** — this file (committed in chore 1 with CLAUDE.md § 1 refresh) |
+| `package.json` | **edit** — add runtime deps (`@inquirer/prompts`, `cli-table3`) + dev dep (`quickpickle`); add `"ingest": "tsx src/cli/program.ts ingest"` script |
+| `vitest.config.ts` / `vitest.config.js` | **edit** — wire quickpickle per its docs |
+| `src/cli/program.ts` | **new** — commander entry: defines `ingest`, wraps existing `migrate` |
+| `src/cli/migrate.ts` | **edit** — extract a `runMigrate(dbPath)` function; guard the top-level execution with `if (import.meta.url === \`file://${process.argv[1]}\`)` so importing the module from `program.ts` doesn't re-run migrations. Missing this guard would cause `npm run migrate` and `program.ts migrate` to both trigger — or worse, an `ingest` invocation that transitively imports `migrate.ts` would run migrations as a side-effect. Explicit guard closes that off. *(Plan agent catch.)* |
+| `src/cli/commands/ingest-command.ts` | **new** — `runIngestCommand(opts, deps)` |
+| `src/cli/utils/printer.ts` | **new** — chalk colour helpers + `formatSummaryTable(items)` using `cli-table3` |
+| `src/cli/utils/interactive.ts` | **new** — `InteractivePrompter` interface + `inquirerPrompter` implementation |
+| `src/infra/fs/pick-source-account.ts` | **new** — closes #25 |
+| `src/infra/fs/read-bpce-csv.ts` | **new** — Latin-1 fs wrapper |
+| `tests/unit/infra/fs/pick-source-account.test.ts` | **new** — zero, one, longest-wins, tied cases |
+| `tests/unit/infra/fs/read-bpce-csv.test.ts` | **new** — happy path, ENOENT, EACCES |
+| `tests/unit/cli/commands/ingest-command.test.ts` | **new** — orchestration with mocked deps (parser/idempotency/builder stubs); interactive loop with mock prompter; `--non-interactive`, `--json`, exit-code assertions |
+| `tests/features/ingest.feature` | **new** — one happy-path scenario |
+| `tests/features/steps/ingest.steps.ts` | **new** — step definitions invoking `runIngestCommand` with stubbed deps |
+| `CLAUDE.md` | no edit (position line was refreshed in Story 2.3) |
+| `accounting.example.yaml` | no edit (accounts already have `type`/`cardSuffix`) |
+
+Reuses: `FileConfigService` ([src/infra/config/config-service.ts](src/infra/config/config-service.ts)), `NodeCsvParser` ([src/infra/csv/node-csv-parser.ts](src/infra/csv/node-csv-parser.ts)), `IdempotencyService` + `SqliteHashRepository` + `NodeHashFn` (Story 2.2), `TransactionBuilder` + `nodeUuidGen` (Story 2.3), `Result` ([src/core/shared/result.ts](src/core/shared/result.ts)).
+
+**Not in scope:** DB writes (Story 2.5), snapshot backup (Story 2.5), `--dry-run` flag (Story 2.5 — Story 2.4 is implicitly dry-run by not writing), multi-file ingest in one invocation, user-customisable auto-tag rules (YAML overrides), path-traversal validation on the `-f` argument (file #21's scope — filed separately so it can land independently). `--json` output is **in scope** for this story per PRD requirement that every command support it.
+
+## Gherkin scenarios
+
+Two lanes of tests:
+- **Acceptance (quickpickle / `.feature`):** one happy-path scenario wiring the full CLI with stubbed prompter.
+- **Unit:** `tests/unit/cli/commands/ingest-command.test.ts` for per-behaviour coverage, stubbing deps.
+
+```gherkin
+# tests/features/ingest.feature — ONE scenario for this story; more follow as commands land
+Feature: Ingest command — interactive tagging & confirmation
+
+  Scenario: AC1+AC4 — happy path through a 5-row BPCE CSV
+    Given an accounting.yaml with a bank account 'main-X' (filenamePrefix "X_") and a card account 'card-1234' (cardSuffix "1234")
+    And a 5-row BPCE CSV at /tmp/X_2026.csv with 3 high-confidence items + 2 low-confidence items
+    And the user's prompter is scripted to: keep the first low-confidence tag, change the second to 'Groceries', confirm the final batch
+    When I run `accounting ingest -f /tmp/X_2026.csv`
+    Then stderr shows "Found 5 new transactions — 3 auto-tagged, 2 need review."
+    And stdout shows a 5-row table including Date/Description/Amount/Category columns
+    And the second low-confidence item's category is 'Groceries' (not its original auto-tag)
+    And the final confirm prompt appears once
+    And the exit code is 0
+    And the database file is NOT modified (no writes — Story 2.5)
+    # fails if: the summary says a wrong count, the interactive loop is skipped entirely, the per-item
+    # change isn't applied to the BuildOutcome, or the command writes to the DB
+```
+
+Unit-test scenarios (each as one `describe`, one `it` per assertion):
+
+```gherkin
+  Scenario: --non-interactive with zero low-confidence items exits 0
+    Given the CLI run with --non-interactive and only high-confidence items
+    When I run it
+    Then exit code 0 and no prompts fire
+    # fails if: the command falsely flags high-confidence as needing review
+
+  Scenario: --non-interactive with low-confidence items exits 2 without hanging
+    Given the CLI run with --non-interactive and at least one low-confidence item
+    When I run it (test wrapped in vitest `{ timeout: 500 }`)
+    Then exit code 2 and stderr names the count needing review
+    # fails if: the command prompts anyway (hang risk in CI — the 500ms timeout would catch a regression
+    # that silently reintroduces the prompt call). Explicit timeout per Plan agent catch.
+
+  Scenario: --json with low-confidence items exits 2 and emits needsReview list
+    Given the CLI run with --json and low-confidence items
+    When I run it
+    Then stdout is a single JSON object including needsReview[] with the item ids
+    And exit code 2
+    # fails if: stdout is polluted with human-readable strings, or JSON is malformed
+
+  Scenario: --json success output includes debit/credit accounts, NO idempotency hashes
+    Given a successful ingest with --json and all high-confidence items
+    When I run it
+    Then stdout JSON.items[*] has debit/credit/category/classification fields
+    And NO items[*].idempotencyHash appears anywhere in the output
+    # fails if: JSON leaks hashes (leak-by-derivation from descriptions)
+
+  Scenario: filename with no matching account exits 2
+    Given an accounting.yaml with accounts whose prefixes do NOT match the file's basename
+    When I run `accounting ingest -f /tmp/orphan.csv`
+    Then exit code 2 and stderr says 'no account configured for this filename'
+    # fails if: exit is 1 (runtime-error semantics) or 0, or we silently pick any account
+
+  Scenario: ambiguous filename match exits 2
+    Given two accounts with tied-length prefixes that both match the file's basename
+    When I run ingest
+    Then exit code 2 and stderr says 'ambiguous filename'
+    # fails if: the command picks the first-declared account silently
+
+  Scenario: mid-loop abort exits 1 without writing
+    Given the user selects 'Abort' during the interactive loop
+    When I run ingest
+    Then exit code 1 and stderr shows a "ingest cancelled" message
+    # fails if: the partial state gets written (no DB writes expected anyway — Story 2.5 will enforce)
+
+  Scenario: final confirm declined exits 1
+    Given the user answers 'no' to the final confirm
+    When I run ingest
+    Then exit code 1 and stderr shows cancel message
+    # fails if: exit is 0 and the command claims success without commit
+
+  Scenario (#25): pickSourceAccount unit tests
+    Given: [1-prefix-match, 0-matches, 2-longest-wins, tied-length-multi-match, empty-accounts] cases
+    Then each produces the expected Result
+    # fails if: the longest-prefix-wins rule is implemented as first-wins, or ties don't fail
+```
+
+## Plan for Sonnet (commit slices)
+
+Story 2.4 is intrinsically bigger than an adapter story. Target **9–11 commits**; the adapter-story sizing rule from § 6.6 doesn't strictly apply (this is orchestration + UX + deps + acceptance-test framework bootstrap). Every subject carries `(Story 2.4)`.
+
+1. `chore(docs): add Story 2.4 plan + file/ingest script scaffolding (Story 2.4)` — commits the plan file and the new `ingest` script entry in `package.json` (empty `program.ts` stub that throws).
+2. `chore(deps): authorise @inquirer/prompts + cli-table3 + quickpickle (Story 2.4)` — `npm install` + commit `package.json` + `package-lock.json`. One-line justification per dep in the commit body (per engineering-standards.md). Wire `vitest.config.ts` for quickpickle.
+3. `test(fs): pickSourceAccount longest-prefix match — failing (Story 2.4)` — covers zero/one/longest-wins/tied cases. Closes part of #25.
+4. `feat(fs): pickSourceAccount + readBpceCsv minimal green (Story 2.4)` — implementations. Both helpers land together because they're the two small Infra/fs modules and tests for `readBpceCsv` are cheap to include in the same slice.
+5. `test(cli): ingest command orchestration + summary table — failing (Story 2.4)` — unit tests for the happy path with stubbed deps + the summary table output shape. Creates `runIngestCommand` signature, empty body returns `exit(99)`.
+6. `feat(cli): ingest command orchestration + printer + interactive loop minimal green (Story 2.4)` — implements `runIngestCommand`, `printer.ts`, `interactive.ts` wrapper. Wires `program.ts` commander routing (now covers `ingest` and the existing `migrate`).
+7. `test(cli): --non-interactive + --json modes + exit codes — failing (Story 2.4)` — unit tests for the flag-driven branches.
+8. `feat(cli): --non-interactive + --json minimal green (Story 2.4)` — implementation.
+9. `test(features): ingest.feature happy-path scenario — failing (Story 2.4)` — first `.feature` + step defs, quickpickle-wired. Closes #24.
+10. `feat(features): wire steps to runIngestCommand — minimal green (Story 2.4)` — step definitions construct stub deps and assert outputs. Proves the wiring works end-to-end through the quickpickle runner.
+11. `refactor(cli): tidy ingest command (Story 2.4)` — or empty-refactor per § 6.4 if nothing to clean.
+
+### Deps pre-authorised
+
+- `@inquirer/prompts ^5` — runtime — rationale: ESM-native select prompt for AC3 arrow-key navigation; tree-shakable vs `inquirer` monolith.
+- `cli-table3 ^0.6` — runtime — rationale: PRD-recommended table rendering; battle-tested.
+- `quickpickle ^1.11` — dev — rationale: closes #24; Vitest-native Gherkin runner to land the first `.feature` file.
+
+### Verification (end-to-end)
+
+- `npm run lint && npm run build && npm test` all green.
+- Every Gherkin scenario has a corresponding test.
+- 100% branch coverage on `src/core/*` (unchanged by this story); pragmatic coverage on `src/cli/*` (every exit code path, every flag branch).
+- **Manual smoke test (recommended, not blocking):** build + `node dist/cli/program.js ingest -f tests/fixtures/csv/bpce-valid.csv` against a local accounting.yaml referencing the fixture. Expected: summary table + interactive loop triggers on the synthetic low-confidence row if the fixture has one. Do NOT run against real `~/Downloads` data in CI.
+
+## Risks & deferrals
+
+- **Path-traversal validation on `-f`** (related to #21) — not in scope. #21 covers dbPath; a future PR can harden the CSV path too. For MVP, Node's own `fs.readFileSync` errors are acceptable.
+- **homedir fallback (#22)** — not touched; independent fix in its own PR.
+- **Multi-file ingest in one invocation** — deferred; user runs the command once per file. If ergonomics become painful after first-week usage, a future story can add `-f <file> -f <file>`. If the real-data run surfaces >15 low-confidence items per file (tedium risk on the per-item prompt), file a "batch-review mode" follow-up story (Story 2.4b).
+- **User-customisable auto-tag rules (YAML overrides)** — still deferred (trigger condition from Story 2.3's plan — hasn't fired). Story 2.4's interactive per-item change is the MVP affordance.
+- **Commit-stage atomicity + snapshot** — Story 2.5's scope. Story 2.4 deliberately ends at "confirmed batch" — no DB write, no backup.
+- **Rich JSON output schema** — this story's `--json` is functional but minimal. Later stories (reports, explain) will expand.
+- **Performance NFR (#27)** — the benchmark belongs after Story 2.5's full pipeline; Story 2.4's CLI already runs all of parse + dedup + build, so anecdotally we can note timing in the retro, but the gated NFR test lands with 2.5.
+- **Quickpickle wiring fallback plan.** Slices 9–11 install and wire quickpickle + land the first `.feature` scenario. If quickpickle's vitest integration turns out to be fragile (config surprises, ESM-loader quirks, TS strict interop), Sonnet should **STOP at slice 8 and return with a clear note** — Story 2.4 then ships without quickpickle (the unit tests already cover every scenario) and #24 gets handled in a dedicated follow-up PR. Do NOT burn an hour wrestling quickpickle inside this story if the first wiring attempt doesn't take cleanly.
+
+## Carryovers resolved
+
+- Story 2.2 retro action B — Phase 4 will audit "this test fails if …" notes against production paths (applies to the unit tests introduced here).
+- Story 2.3 retro action A — sonnet-implementer § 3 60-LOC-trigger already landed; applies to `runIngestCommand` which is likely to brush 50–80 LOC before extraction.
+- #24 (quickpickle wiring) closes with slices 9–10.
+- #25 (filename matcher) closes with slices 3–4.

--- a/docs/retrospectives/story-2.4.md
+++ b/docs/retrospectives/story-2.4.md
@@ -1,0 +1,55 @@
+# Story 2.4 retrospective
+
+**PR:** _pending_ (will be linked on draft PR open)  **Closed:** pending merge
+
+Sixth end-to-end run of the product development loop. First genuinely *wide* story of the project — wraps file I/O + filename matching + pipeline orchestration + interactive UX + new CLI entry point into one PR. Nine commits plus a Phase-4 correctness fix (`--json` `source_account: null` bug). Story 2.4 ships at slice 8 of 11 planned; the final three slices (quickpickle install + `.feature` wiring) were stopped cleanly at the plan's explicit fallback checkpoint when quickpickle's published package turned out to have a broken transitive dependency. Zero blockers of our own making — all findings traced back to either upstream bugs or prior-story choices.
+
+## Keep
+
+- **Plan agent's "split quickpickle out" recommendation was almost right — and the plan's fallback clause made it safely moot.** The stress-test flagged bundling `@inquirer/prompts + cli-table3 + quickpickle` as over-scoping. Plan adopted a middle path: keep quickpickle as slices 9–11 at the end + a fallback clause ("if wiring fails, stop at slice 8 and file a follow-up"). When Sonnet discovered `quickpickle@1.11` unconditionally imports `pixelmatch` without declaring it as a dep (ERR_MODULE_NOT_FOUND at vitest config load), the fallback fired without drama. Story still ships its 8 planned CLI slices + the #25 filename matcher. #24 quickpickle reopens as a genuine upstream bug, not a missed scope. This is the contingency design paying off.
+- **Plan agent flipped 2 of 6 decisions + caught 3 concrete bugs pre-implementation.**
+  1. `--json`-omits-`idempotencyHash` rationale changed from bogus "leak defence" (SHA-256 is one-way) to honest YAGNI — prevents a wrong security model from cargo-culting into future `--json` schemas.
+  2. `migrate.ts` double-execution risk (the top-level-side-effecting version would re-run migrations when `program.ts` imports it) → explicit `import.meta.url` guard + `runMigrate()` extraction. Caught before landing.
+  3. `@inquirer/prompts`-writes-to-`process.stderr`-directly caveat — the injected `stderr: Writable` was advertised as honoured for all messages; agent flagged it as a lie for the prompt path. Plan pivoted to "honoured only for non-prompt messages; prompts are tested via the `InteractivePrompter` mock."
+  4. `--non-interactive` no-hang assertion — added explicit `{ timeout: 500 }` to the vitest test so a future regression that reintroduces a prompt call can't hang CI for a full default timeout.
+- **Sonnet flagged the 97-LOC `runIngestCommand` in Deviations per Story 2.3 retro action A.** Not by accident — the retro rule ("60 LOC + duplication ≥ 2 blocks = flag in Deviations") is explicitly cited. No duplication was identified (linear pipeline with orthogonal error paths per step), so extraction was rejected with reasoning. Opus's Phase 4 review accepted the reasoning. This is exactly the contract the retro rule was meant to create.
+- **Phase 4 caught real correctness bugs that all 172 tests missed.** Two hardcoded values in `runNonInteractive`'s JSON output: `source_account: null` (should be `account.id`) and `summary.parseErrors/duplicates: 0` (should be the actual counts). Tests asserted the hardcoded values because the mock setups had zero duplicates + zero parse errors. The Phase 4 "walk the QA doc against the diff" pass caught what the unit-test suite didn't. Fix landed in `da83aa1`.
+- **Deps authorisation pattern from Story 1.4 worked for 3 libraries at once.** One `chore(deps)` commit, one-line rationale per dep in the body. Clean revert-boundary if `@inquirer/prompts` or `cli-table3` had turned out fragile.
+- **Adapter-story sizing (§ 6.6) gracefully didn't apply here** — and the plan called that out. Story 2.4 is CLI orchestration + UX + framework bootstrap, not an adapter. 11 planned slices, 9 delivered + 1 fix = 10 commits total. Larger than Stories 2.1–2.3 (5–9 commits) but still one session.
+
+## Change
+
+- **Test-suite blind spot: all 172 tests passed while `--json` output was factually wrong on two fields.** The flags tests asserted hardcoded output values because the mocks set `duplicates: []` and `parseErrors: []`. A less brittle test would have used a mock with non-zero counts from the start. **Next time:** when a test asserts a field value, the fixture should include at least one non-trivial case for that field (no-zero-count stubs, no-null-account stubs). Test doubles are the most common source of "test passes but output is wrong" — the fix-forward (adding the `>0 duplicates + >0 parseErrors` scenario) is now in place. Lesson: mock fixtures should vary, not default.
+- **Quickpickle@1.11 has a broken package.json on npm.** It imports `pixelmatch` at ESM module-load time without declaring it. This is an upstream bug, not ours — but if we'd split quickpickle into its own pre-Story-2.4 PR as the Plan agent suggested, it would have blocked Story 2.4's start rather than being cleanly deferred from Story 2.4's tail. The plan's fallback clause was actually *better* than the agent's split recommendation because it preserved forward momentum. Trade-off documented: for deps with unclear stability, inline + fallback > pre-PR.
+- **`@inquirer/prompts` writes directly to `process.stderr`** — the plan captured this caveat mid-draft but the `stderr: Writable` injection lives on in the deps object for non-prompt writes. The split (mock `prompter` for prompt output, injected `stderr` for everything else) works, but future reviewers may find the split non-obvious. A comment in [src/cli/commands/ingest-command.ts](src/cli/commands/ingest-command.ts) would help.
+
+## Try
+
+- **Add a "mock diversity" line to the Phase 4 audit checklist.** CLAUDE.md § 6.1 phase 4 currently audits `this test fails if …` notes against production paths. Extend: when the diff includes structured output (JSON, tables, protobuf, etc.), Phase 4 must spot-check at least one assertion against a non-default-value mock — i.e. the test uses `duplicates: [item1]` rather than `duplicates: []`. Catches the Story 2.4 JSON bug class. Action item A.
+- **Issue #24 update: record upstream quickpickle bug.** Add a comment summarising the `pixelmatch` discovery so a future attempt at wiring doesn't relearn. Not an action item in this PR (comment lives on #24); note here.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| A. CLAUDE.md § 6.1 phase 4 — "mock diversity" audit step | `CLAUDE.md` in this PR | in same commit as this retro |
+| B. Update issue #24 with the `pixelmatch` discovery + link this PR as the attempt trail | `gh issue comment 24` | after PR opens |
+
+## Loop metrics (sixth run)
+
+- **Plan phase:** 1 maintenance Explore + 1 landscape Explore + 1 Plan agent (stress-test, 6 decisions interrogated) + Opus 3-pass critical review.
+- **Implementation:** 1 Sonnet task (8 commits of 11 planned; quickpickle slices 9–11 stopped per plan's fallback) + 1 Sonnet fix task (1 commit, `--json` field corrections). Total 9 story commits + 1 retro = 10.
+- **Phase-4 retro-check:** 2 findings — (a) `runIngestCommand` 97 LOC (non-blocker, defensible), (b) `--json` hardcoded `null`/`0` bugs (blocker, fixed in `da83aa1`).
+- **Deferred at plan:** 0 new issues filed (#24 and #25 were already filed; #25 closes here, #24 remains open for upstream fix).
+- **Closed by this story:** issue #25 (filename-prefix matcher). Partial progress on #24 (install completed, wiring blocked by upstream).
+- **Total commits on branch:** 10 (1 chore-docs + 1 chore-deps + 2 test/feat fs + 2 test/feat cli + 2 test/feat flags + 1 refactor-cli + 1 fix-cli + 1 retro, once committed).
+- **Test count:** 172 (was 151 after Story 2.3).
+- **New runtime deps:** 2 (`@inquirer/prompts`, `cli-table3`). **New dev dep:** 1 (`quickpickle`, currently unused pending #24 upstream fix).
+- **Time-to-DoD:** one working session.
+
+## Carryovers resolved
+
+- Story 2.2 retro action B (Phase 4 `this test fails if …` audit) → paid off: the audit surfaced the JSON `null` hardcoding when cross-checking against PRD "every command supports `--json`" requirements.
+- Story 2.3 retro action A (60-LOC + duplication trigger) → working as designed: Sonnet proactively flagged the 97-LOC `runIngestCommand` in Deviations with reasoning. No duplication → no extraction, but the signal reached Opus cleanly.
+- Issue #24 (quickpickle): install completed (slice 2), wiring blocked (slice 9) by upstream `pixelmatch` missing-dep bug. Issue stays open; this PR's retro + issue comment document the state for a future attempt.
+- Issue #25 (filename-prefix matcher): CLOSED by slices 3–4 of this story.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@inquirer/prompts": "^5.5.0",
         "better-sqlite3": "^12.6.2",
         "chalk": "^5.6.2",
+        "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
         "csv-parse": "^6.1.0",
         "dinero.js": "^1.9.1",
@@ -25,11 +27,72 @@
         "eslint": "^9.39.2",
         "fast-check": "^4.7.0",
         "prettier": "^3.8.3",
+        "quickpickle": "^1.11.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.59.0",
         "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@a11y-tools/aria-roles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@a11y-tools/aria-roles/-/aria-roles-1.0.0.tgz",
+      "integrity": "sha512-9rLDOQxgwJ6l9zhikwPx1L3fmsCO1aR19C0mBY5Zfdge9HmpbRNksynEjckqY8uSL/58mRTfSfZ3/uLWGUCwoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cucumber/cucumber-expressions": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-18.1.0.tgz",
+      "integrity": "sha512-9yc+wForrn15FaqLWNjYb19iQ/gPXhcq1kc4X1Ex1lR7NcJpa5pGnCow3bc1HERVM5IoYH+gwwrcJogSMsf+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-match-indices": "1.0.2"
+      }
+    },
+    "node_modules/@cucumber/gherkin": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-32.2.0.tgz",
+      "integrity": "sha512-X8xuVhSIqlUjxSRifRJ7t0TycVWyX58fygJH3wDNmHINLg9sYEkvQT0SO2G5YlRZnYc11TIFr4YPenscvdlBIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=19.1.4 <28"
+      }
+    },
+    "node_modules/@cucumber/messages": {
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
+      "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "11.0.5"
+      }
+    },
+    "node_modules/@cucumber/tag-expressions": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.2.0.tgz",
+      "integrity": "sha512-KIF0eLcafHbWOuSDWFw0lMmgJOLdDRWjEL1kfXEWrqHmx2119HxVAr35WuEd9z542d3Yyg+XNqSr+81rIKqEdg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
@@ -716,6 +779,261 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.5.0.tgz",
+      "integrity": "sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/figures": "^1.0.5",
+        "@inquirer/type": "^1.5.3",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
+      "integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.5.5",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@inquirer/type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.2.0.tgz",
+      "integrity": "sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.3.0.tgz",
+      "integrity": "sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.3.0.tgz",
+      "integrity": "sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
+      "integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.5.0.tgz",
+      "integrity": "sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^2.5.0",
+        "@inquirer/confirm": "^3.2.0",
+        "@inquirer/editor": "^2.2.0",
+        "@inquirer/expand": "^2.3.0",
+        "@inquirer/input": "^2.3.0",
+        "@inquirer/number": "^1.1.0",
+        "@inquirer/password": "^2.2.0",
+        "@inquirer/rawlist": "^2.3.0",
+        "@inquirer/search": "^1.1.0",
+        "@inquirer/select": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.3.0.tgz",
+      "integrity": "sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/type": "^1.5.3",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.1.0.tgz",
+      "integrity": "sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/figures": "^1.0.5",
+        "@inquirer/type": "^1.5.3",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.5.0.tgz",
+      "integrity": "sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.1.0",
+        "@inquirer/figures": "^1.0.5",
+        "@inquirer/type": "^1.5.3",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
+      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1101,15 +1419,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.0",
@@ -1546,6 +1885,21 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -1562,7 +1916,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1719,11 +2072,24 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "license": "MIT"
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -1752,11 +2118,69 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1769,7 +2193,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -1882,6 +2305,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -2154,6 +2583,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/fast-check": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
@@ -2361,6 +2804,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2390,6 +2845,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/image-crop-or-pad": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/image-crop-or-pad/-/image-crop-or-pad-1.0.1.tgz",
+      "integrity": "sha512-0Gu+rHoFyKLZ14oaj+CJCElQz/5EOlMHvO9WwsANukerPSGG4MFpC81oDbvsN1wMbSzAhsgTPvgbBICl7ecazg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -2438,6 +2900,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2831,6 +3302,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2922,6 +3407,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3042,6 +3536,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3132,6 +3635,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {
@@ -3252,6 +3765,54 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quickpickle": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/quickpickle/-/quickpickle-1.11.1.tgz",
+      "integrity": "sha512-AtgAxwh7NUTheHPgTZhioN6FqRmGOfLKMzNFM64ucJuE5tzq49vLaR1d8OfzYoUtHAxZT6bRvcGyYG7DHSenvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@a11y-tools/aria-roles": "^1.0.0",
+        "@cucumber/cucumber-expressions": "^18.0.1",
+        "@cucumber/gherkin": "^32.1.0",
+        "@cucumber/messages": "^27.2.0",
+        "@cucumber/tag-expressions": "^6.1.2",
+        "buffer": "^6.0.3",
+        "image-crop-or-pad": "^1.0.1",
+        "js-yaml": "^4.1.1",
+        "lodash": "^4.17.23",
+        "lodash-es": "^4.17.23",
+        "pngjs": "^7.0.0"
+      },
+      "peerDependencies": {
+        "vitest": "^1.0.0 || >=2.0.0"
+      }
+    },
+    "node_modules/quickpickle/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -3279,6 +3840,33 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/regexp-match-indices": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz",
+      "integrity": "sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "regexp-tree": "^0.1.11"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
       }
     },
     "node_modules/resolve-from": {
@@ -3369,6 +3957,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -3640,6 +4234,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -3706,6 +4312,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3748,7 +4366,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -3766,6 +4383,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.9",
@@ -3978,6 +4609,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4016,6 +4696,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "vitest run",
     "lint": "eslint .",
     "build": "tsc && cp -R src/infra/db/migrations dist/infra/db/",
-    "migrate": "tsx src/cli/migrate.ts"
+    "migrate": "tsx src/cli/program.ts migrate",
+    "ingest": "tsx src/cli/program.ts ingest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   },
   "homepage": "https://github.com/xavierbriand/accounting#readme",
   "dependencies": {
+    "@inquirer/prompts": "^5.5.0",
     "better-sqlite3": "^12.6.2",
     "chalk": "^5.6.2",
+    "cli-table3": "^0.6.5",
     "commander": "^14.0.3",
     "csv-parse": "^6.1.0",
     "dinero.js": "^1.9.1",
@@ -39,6 +41,7 @@
     "eslint": "^9.39.2",
     "fast-check": "^4.7.0",
     "prettier": "^3.8.3",
+    "quickpickle": "^1.11.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.0",

--- a/src/cli/commands/ingest-command.ts
+++ b/src/cli/commands/ingest-command.ts
@@ -1,0 +1,234 @@
+import type { Writable } from 'stream';
+import type { ConfigService } from '@core/ports/config-service.js';
+import type { CsvParser } from '@core/ports/csv-parser.js';
+import type { IdempotencyService } from '@core/ingest/idempotency-service.js';
+import type { TransactionBuilder } from '@core/ingest/transaction-builder.js';
+import type { BuildOutcome } from '@core/ingest/types.js';
+import type { AccountConfig } from '@core/config/app-config.js';
+import type { Result } from '@core/shared/result.js';
+import type { InteractivePrompter } from '../utils/interactive.js';
+import type { pickSourceAccount as PickSourceAccountFn } from '../../infra/fs/pick-source-account.js';
+import type { readBpceCsv as ReadBpceCsvFn } from '../../infra/fs/read-bpce-csv.js';
+import { formatSummaryTable } from '../utils/printer.js';
+
+export interface IngestCommandOptions {
+  readonly file: string;
+  readonly nonInteractive: boolean;
+  readonly json: boolean;
+}
+
+export interface IngestCommandDeps {
+  readonly configService: Pick<ConfigService, 'load'>;
+  readonly csvParser: Pick<CsvParser, 'parse'>;
+  readonly idempotencyService: Pick<IdempotencyService, 'filterNew'>;
+  readonly transactionBuilder: Pick<TransactionBuilder, 'buildAll'>;
+  readonly pickSourceAccount: typeof PickSourceAccountFn;
+  readonly readFile: typeof ReadBpceCsvFn;
+  readonly prompt: InteractivePrompter;
+  readonly stdout: Writable;
+  readonly stderr: Writable;
+  readonly exitCode: (code: number) => void;
+}
+
+function writeln(stream: Writable, msg: string): void {
+  stream.write(msg + '\n');
+}
+
+export async function runIngestCommand(
+  opts: IngestCommandOptions,
+  deps: IngestCommandDeps,
+): Promise<void> {
+  const { configService, csvParser, idempotencyService, transactionBuilder, pickSourceAccount, readFile, prompt, stdout, stderr, exitCode } = deps;
+
+  const configResult = configService.load();
+  if (configResult.isFailure) {
+    writeln(stderr, `Configuration error: ${configResult.error}`);
+    exitCode(1);
+    return;
+  }
+  const config = configResult.value;
+
+  const accountResult = pickSourceAccount(opts.file, config.accounts);
+  if (accountResult.isFailure) {
+    writeln(stderr, accountResult.error);
+    exitCode(2);
+    return;
+  }
+  const account: AccountConfig = accountResult.value;
+
+  const readResult = readFile(opts.file);
+  if (readResult.isFailure) {
+    writeln(stderr, readResult.error);
+    exitCode(1);
+    return;
+  }
+
+  const parseResult = csvParser.parse(readResult.value, {
+    format: 'bpce',
+    currency: config.defaultCurrency,
+    timezone: config.timezone,
+    sourceAccount: account.id,
+  });
+  if (parseResult.isFailure) {
+    writeln(stderr, `Parse error: ${parseResult.error}`);
+    exitCode(1);
+    return;
+  }
+  const parseOutcome = parseResult.value;
+
+  if (parseOutcome.errors.length > 0) {
+    for (const e of parseOutcome.errors) {
+      writeln(stderr, `  Row ${e.line}: ${e.reason}`);
+    }
+  }
+
+  const idempotencyResult = idempotencyService.filterNew(parseOutcome.items);
+  if (idempotencyResult.isFailure) {
+    writeln(stderr, `Idempotency check failed: ${idempotencyResult.error}`);
+    exitCode(1);
+    return;
+  }
+  const { fresh, duplicates } = idempotencyResult.value;
+
+  const buildResult = transactionBuilder.buildAll(fresh);
+  if (buildResult.isFailure) {
+    writeln(stderr, `Build error: ${buildResult.error}`);
+    exitCode(1);
+    return;
+  }
+  const { built, failed } = buildResult.value;
+
+  if (failed.length > 0) {
+    for (const f of failed) {
+      writeln(stderr, `  Build failed for "${f.item.description}": ${f.reason}`);
+    }
+  }
+
+  const lowConfidence = built.filter((o) => o.confidence === 'low');
+  const highConfidence = built.filter((o) => o.confidence === 'high');
+
+  writeln(stderr, `Found ${built.length} new transactions — ${highConfidence.length} auto-tagged, ${lowConfidence.length} need review.`);
+  if (duplicates.length > 0) {
+    writeln(stderr, `  (${duplicates.length} duplicate(s) skipped)`);
+  }
+
+  if (opts.nonInteractive || opts.json) {
+    return runNonInteractive(opts, built, lowConfidence, stdout, stderr, exitCode);
+  }
+
+  const resolvedOutcomes = await runInteractiveLoop(built, lowConfidence, prompt, stderr, exitCode);
+  if (resolvedOutcomes === null) return;
+
+  writeln(stdout, formatSummaryTable(resolvedOutcomes));
+
+  const confirmed = await prompt.confirmBatch(resolvedOutcomes.length);
+  if (!confirmed) {
+    writeln(stderr, 'Ingest cancelled.');
+    exitCode(1);
+    return;
+  }
+
+  writeln(stderr, `${resolvedOutcomes.length} transaction(s) confirmed. (DB writes pending — Story 2.5)`);
+  exitCode(0);
+}
+
+async function runInteractiveLoop(
+  built: readonly BuildOutcome[],
+  lowConfidence: readonly BuildOutcome[],
+  prompt: InteractivePrompter,
+  stderr: Writable,
+  exitCode: (code: number) => void,
+): Promise<BuildOutcome[] | null> {
+  const resolved: BuildOutcome[] = [...built];
+
+  const categories = Array.from(new Set(built.map((o) => o.category)));
+  if (!categories.includes('Uncategorized')) categories.push('Uncategorized');
+
+  for (const outcome of lowConfidence) {
+    const answer = await prompt.selectCategory(
+      outcome.transaction.description,
+      outcome.category,
+      categories,
+    );
+
+    if (answer.action === 'abort') {
+      writeln(stderr, 'Ingest cancelled.');
+      exitCode(1);
+      return null;
+    }
+
+    if (answer.action === 'change') {
+      const idx = resolved.findIndex((o) => o === outcome);
+      if (idx !== -1) {
+        resolved[idx] = { ...outcome, category: answer.category, confidence: 'high' };
+      }
+    }
+  }
+
+  return resolved;
+}
+
+function runNonInteractive(
+  opts: IngestCommandOptions,
+  built: readonly BuildOutcome[],
+  lowConfidence: readonly BuildOutcome[],
+  stdout: Writable,
+  stderr: Writable,
+  exitCode: (code: number) => void,
+): void {
+  if (lowConfidence.length > 0) {
+    writeln(
+      stderr,
+      `${lowConfidence.length} item(s) need manual review. Run without --non-interactive to review them, ` +
+        `or re-ingest after updating accounting.yaml's auto-tag-rules.`,
+    );
+
+    if (opts.json) {
+      const needsReview = lowConfidence.map((o) => o.transaction.id);
+      stdout.write(
+        JSON.stringify({
+          file: opts.file,
+          source_account: null,
+          summary: { total: built.length, autoTagged: built.length - lowConfidence.length, needsReview: lowConfidence.length, duplicates: 0, parseErrors: 0 },
+          items: [],
+          needsReview,
+        }) + '\n',
+      );
+    }
+
+    exitCode(2);
+    return;
+  }
+
+  if (opts.json) {
+    const items = built.map((o) => {
+      const debitEntry = o.transaction.entries.find((e) => e.side === 'debit');
+      const creditEntry = o.transaction.entries.find((e) => e.side === 'credit');
+      return {
+        id: o.transaction.id,
+        occurredAt: o.transaction.occurredAt,
+        description: o.transaction.description,
+        amount_cents: debitEntry?.amount.amount ?? 0,
+        currency: debitEntry?.amount.currency ?? '',
+        debit: debitEntry?.account ?? '',
+        credit: creditEntry?.account ?? '',
+        category: o.category,
+        classification: o.classification,
+      };
+    });
+
+    stdout.write(
+      JSON.stringify({
+        file: opts.file,
+        source_account: null,
+        summary: { total: built.length, autoTagged: built.length, needsReview: 0, duplicates: 0, parseErrors: 0 },
+        items,
+      }) + '\n',
+    );
+    exitCode(0);
+    return;
+  }
+
+  stdout.write(formatSummaryTable(built) + '\n');
+  exitCode(0);
+}

--- a/src/cli/commands/ingest-command.ts
+++ b/src/cli/commands/ingest-command.ts
@@ -5,7 +5,6 @@ import type { IdempotencyService } from '@core/ingest/idempotency-service.js';
 import type { TransactionBuilder } from '@core/ingest/transaction-builder.js';
 import type { BuildOutcome } from '@core/ingest/types.js';
 import type { AccountConfig } from '@core/config/app-config.js';
-import type { Result } from '@core/shared/result.js';
 import type { InteractivePrompter } from '../utils/interactive.js';
 import type { pickSourceAccount as PickSourceAccountFn } from '../../infra/fs/pick-source-account.js';
 import type { readBpceCsv as ReadBpceCsvFn } from '../../infra/fs/read-bpce-csv.js';

--- a/src/cli/commands/ingest-command.ts
+++ b/src/cli/commands/ingest-command.ts
@@ -112,7 +112,7 @@ export async function runIngestCommand(
   }
 
   if (opts.nonInteractive || opts.json) {
-    return runNonInteractive(opts, built, lowConfidence, stdout, stderr, exitCode);
+    return runNonInteractive(opts, account, built, lowConfidence, duplicates.length, parseOutcome.errors.length, stdout, stderr, exitCode);
   }
 
   const resolvedOutcomes = await runInteractiveLoop(built, lowConfidence, prompt, stderr, exitCode);
@@ -169,8 +169,11 @@ async function runInteractiveLoop(
 
 function runNonInteractive(
   opts: IngestCommandOptions,
+  account: AccountConfig,
   built: readonly BuildOutcome[],
   lowConfidence: readonly BuildOutcome[],
+  duplicatesCount: number,
+  parseErrorsCount: number,
   stdout: Writable,
   stderr: Writable,
   exitCode: (code: number) => void,
@@ -187,8 +190,8 @@ function runNonInteractive(
       stdout.write(
         JSON.stringify({
           file: opts.file,
-          source_account: null,
-          summary: { total: built.length, autoTagged: built.length - lowConfidence.length, needsReview: lowConfidence.length, duplicates: 0, parseErrors: 0 },
+          source_account: account.id,
+          summary: { total: built.length, autoTagged: built.length - lowConfidence.length, needsReview: lowConfidence.length, duplicates: duplicatesCount, parseErrors: parseErrorsCount },
           items: [],
           needsReview,
         }) + '\n',
@@ -219,8 +222,8 @@ function runNonInteractive(
     stdout.write(
       JSON.stringify({
         file: opts.file,
-        source_account: null,
-        summary: { total: built.length, autoTagged: built.length, needsReview: 0, duplicates: 0, parseErrors: 0 },
+        source_account: account.id,
+        summary: { total: built.length, autoTagged: built.length, needsReview: 0, duplicates: duplicatesCount, parseErrors: parseErrorsCount },
         items,
       }) + '\n',
     );

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -2,11 +2,17 @@ import path from 'path';
 import { getDb } from '../infra/db/sqlite-client.js';
 import { runMigrations } from '../infra/db/migrator.js';
 
-const db = getDb(path.resolve('accounting.db'));
-try {
-  runMigrations(db);
-  console.log('Migration completed successfully.');
-} catch (error) {
-  console.error('Migration failed:', error);
-  process.exit(1);
+export function runMigrate(dbPath: string): void {
+  const db = getDb(path.resolve(dbPath));
+  try {
+    runMigrations(db);
+    console.log('Migration completed successfully.');
+  } catch (error) {
+    console.error('Migration failed:', error);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runMigrate('accounting.db');
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,0 +1,1 @@
+throw new Error('program.ts: not yet implemented — Story 2.4 implementation in progress');

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,1 +1,65 @@
-throw new Error('program.ts: not yet implemented — Story 2.4 implementation in progress');
+import { Command } from 'commander';
+import path from 'path';
+import { getDb } from '../infra/db/sqlite-client.js';
+import { FileConfigService } from '../infra/config/config-service.js';
+import { NodeCsvParser } from '../infra/csv/node-csv-parser.js';
+import { IdempotencyService } from '../core/ingest/idempotency-service.js';
+import { TransactionBuilder } from '../core/ingest/transaction-builder.js';
+import { SqliteHashRepository } from '../infra/db/repositories/sqlite-hash-repository.js';
+import { nodeHashFn } from '../infra/crypto/node-hash-fn.js';
+import { nodeUuidGen } from '../infra/crypto/node-uuid-gen.js';
+import { pickSourceAccount } from '../infra/fs/pick-source-account.js';
+import { readBpceCsv } from '../infra/fs/read-bpce-csv.js';
+import { inquirerPrompter } from './utils/interactive.js';
+import { runIngestCommand } from './commands/ingest-command.js';
+import { runMigrate } from './migrate.js';
+
+const program = new Command();
+
+program
+  .name('accounting')
+  .description('Couples expense sharing CLI')
+  .version('1.0.0');
+
+program
+  .command('migrate')
+  .description('Run database migrations')
+  .option('--db-path <path>', 'Path to the SQLite database', 'accounting.db')
+  .action((options: { dbPath: string }) => {
+    runMigrate(options.dbPath);
+  });
+
+program
+  .command('ingest')
+  .description('Ingest a bank CSV file and interactively tag transactions')
+  .requiredOption('-f, --file <path>', 'Path to the bank CSV file')
+  .option('--non-interactive', 'Fail if any item needs review (CI mode)', false)
+  .option('--json', 'Output JSON instead of a table', false)
+  .option('--db-path <path>', 'Path to the SQLite database', 'accounting.db')
+  .action(async (options: { file: string; nonInteractive: boolean; json: boolean; dbPath: string }) => {
+    const resolvedDb = path.resolve(options.dbPath);
+    const db = getDb(resolvedDb);
+    const configService = new FileConfigService({ projectDir: process.cwd() });
+    const csvParser = new NodeCsvParser();
+    const hashRepo = new SqliteHashRepository(db);
+    const idempotencyService = new IdempotencyService(nodeHashFn, hashRepo);
+    const transactionBuilder = new TransactionBuilder([], undefined, nodeUuidGen);
+
+    await runIngestCommand(
+      { file: options.file, nonInteractive: options.nonInteractive, json: options.json },
+      {
+        configService,
+        csvParser,
+        idempotencyService,
+        transactionBuilder,
+        pickSourceAccount,
+        readFile: readBpceCsv,
+        prompt: inquirerPrompter,
+        stdout: process.stdout,
+        stderr: process.stderr,
+        exitCode: (code) => process.exit(code),
+      },
+    );
+  });
+
+program.parse(process.argv);

--- a/src/cli/utils/interactive.ts
+++ b/src/cli/utils/interactive.ts
@@ -1,0 +1,45 @@
+import { select, confirm } from '@inquirer/prompts';
+
+export type SelectCategoryResult =
+  | { action: 'keep' }
+  | { action: 'change'; category: string }
+  | { action: 'abort' };
+
+export interface InteractivePrompter {
+  selectCategory(
+    description: string,
+    currentCategory: string,
+    availableCategories: readonly string[],
+  ): Promise<SelectCategoryResult>;
+
+  confirmBatch(count: number): Promise<boolean>;
+}
+
+export const inquirerPrompter: InteractivePrompter = {
+  async selectCategory(description, currentCategory, availableCategories) {
+    const keepLabel = `Keep: ${currentCategory}`;
+    const choices = [
+      { name: keepLabel, value: keepLabel },
+      ...availableCategories
+        .filter((c) => c !== currentCategory)
+        .map((c) => ({ name: `Change to: ${c}`, value: c })),
+      { name: 'Abort', value: '__abort__' },
+    ];
+
+    const answer = await select({
+      message: `${description} → ${currentCategory} (auto). Confirm or change?`,
+      choices,
+    });
+
+    if (answer === '__abort__') return { action: 'abort' };
+    if (answer === keepLabel) return { action: 'keep' };
+    return { action: 'change', category: answer };
+  },
+
+  async confirmBatch(count) {
+    return confirm({
+      message: `Commit these ${count} transactions? (nothing will be written yet — Story 2.5 adds DB writes)`,
+      default: false,
+    });
+  },
+};

--- a/src/cli/utils/printer.ts
+++ b/src/cli/utils/printer.ts
@@ -1,0 +1,31 @@
+import Table from 'cli-table3';
+import chalk from 'chalk';
+import type { BuildOutcome } from '@core/ingest/types.js';
+
+function formatAmount(outcome: BuildOutcome): string {
+  const entry = outcome.transaction.entries.find((e) => e.side === 'debit');
+  if (!entry) return '';
+  const amount = entry.amount;
+  const euros = (amount.amount / 100).toFixed(2);
+  return `${euros} ${amount.currency}`;
+}
+
+function confidenceMark(outcome: BuildOutcome): string {
+  return outcome.confidence === 'high' ? chalk.green('✓') : chalk.yellow('?');
+}
+
+export function formatSummaryTable(outcomes: readonly BuildOutcome[]): string {
+  const table = new Table({
+    head: ['Date', 'Description', 'Amount', 'Category', 'Conf'],
+    style: { head: [], border: [] },
+  });
+
+  for (const o of outcomes) {
+    const tx = o.transaction;
+    const date = tx.occurredAt.slice(0, 10);
+    const desc = tx.description.slice(0, 40);
+    table.push([date, desc, formatAmount(o), o.category, confidenceMark(o)]);
+  }
+
+  return table.toString();
+}

--- a/src/infra/fs/pick-source-account.ts
+++ b/src/infra/fs/pick-source-account.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+import type { AccountConfig } from '@core/config/app-config.js';
+import { Result } from '@core/shared/result.js';
+
+export function pickSourceAccount(
+  filePath: string,
+  accounts: readonly AccountConfig[],
+): Result<AccountConfig> {
+  const base = path.basename(filePath);
+
+  const matches = accounts.filter((a) => base.startsWith(a.filenamePrefix));
+
+  if (matches.length === 0) {
+    return Result.fail(
+      `no account configured for this filename — ` +
+        `add an entry to \`accounts:\` in accounting.yaml (file: ${base})`,
+    );
+  }
+
+  const maxLen = Math.max(...matches.map((a) => a.filenamePrefix.length));
+  const longestMatches = matches.filter((a) => a.filenamePrefix.length === maxLen);
+
+  if (longestMatches.length > 1) {
+    return Result.fail(
+      `ambiguous filename — multiple account prefixes match (file: ${base})`,
+    );
+  }
+
+  return Result.ok(longestMatches[0]);
+}

--- a/src/infra/fs/read-bpce-csv.ts
+++ b/src/infra/fs/read-bpce-csv.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import { Result } from '@core/shared/result.js';
+
+export function readBpceCsv(filePath: string): Result<string> {
+  const base = path.basename(filePath);
+  try {
+    const content = fs.readFileSync(filePath, 'latin1');
+    return Result.ok(content);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return Result.fail(`File not found: ${base}`);
+    }
+    if (code === 'EACCES') {
+      return Result.fail(`Permission denied reading file: ${base}`);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return Result.fail(`Could not read file ${base}: ${msg}`);
+  }
+}

--- a/tests/unit/cli/commands/ingest-command-flags.test.ts
+++ b/tests/unit/cli/commands/ingest-command-flags.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Writable } from 'stream';
+import { PassThrough } from 'stream';
+import { runIngestCommand } from '../../../../src/cli/commands/ingest-command.js';
+import type { IngestCommandDeps } from '../../../../src/cli/commands/ingest-command.js';
+import { Result } from '@core/shared/result.js';
+import type { AppConfig, AccountConfig } from '@core/config/app-config.js';
+import type { BuildOutcome } from '@core/ingest/types.js';
+
+// fails if: --non-interactive falsely flags high-confidence as needing review,
+//           or the command hangs waiting for a prompt in CI mode (timeout guards this),
+//           or --json output contains idempotencyHash,
+//           or exit codes are wrong for any flag combination
+
+const EUR = { amount: 1000, currency: 'EUR' };
+
+function makeAccount(id: string, prefix: string): AccountConfig {
+  return { id, type: 'bank', filenamePrefix: prefix };
+}
+
+const baseConfig: AppConfig = {
+  dbPath: './test.db',
+  defaultCurrency: 'EUR',
+  timezone: 'Europe/Paris',
+  splits: [{ partner: 'Alex', ratio: 0.5 }, { partner: 'Sam', ratio: 0.5 }],
+  buffers: [],
+  accounts: [makeAccount('main-X', 'X_')],
+};
+
+function makeHighOutcome(description: string, category: string): BuildOutcome {
+  return {
+    transaction: {
+      id: `tx-${description}`,
+      occurredAt: '2026-04-20T00:00:00+02:00',
+      description,
+      entries: [
+        { account: 'Expense:Groceries', side: 'debit', amount: EUR },
+        { account: 'Assets:Bank:main-X', side: 'credit', amount: EUR },
+      ],
+    } as unknown as BuildOutcome['transaction'],
+    category,
+    classification: 'expense',
+    confidence: 'high',
+  };
+}
+
+function makeLowOutcome(description: string, category: string): BuildOutcome {
+  return { ...makeHighOutcome(description, category), confidence: 'low' };
+}
+
+function makeStreams(): { stdout: Writable & { captured: string }; stderr: Writable & { captured: string } } {
+  function makeCapture(): Writable & { captured: string } {
+    const buf: string[] = [];
+    const stream = new PassThrough() as Writable & { captured: string };
+    stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
+    Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
+    return stream;
+  }
+  return { stdout: makeCapture(), stderr: makeCapture() };
+}
+
+function makeDeps(
+  outcomes: readonly BuildOutcome[],
+  overrides: Partial<IngestCommandDeps> = {},
+): IngestCommandDeps & { stdout: Writable & { captured: string }; stderr: Writable & { captured: string }; exitCodes: number[] } {
+  const { stdout, stderr } = makeStreams();
+  const exitCodes: number[] = [];
+  return {
+    configService: { load: () => Result.ok(baseConfig) },
+    csvParser: {
+      parse: () => Result.ok({
+        items: outcomes.map((o) => ({
+          sourceAccount: 'main-X',
+          occurredAt: o.transaction.occurredAt,
+          description: o.transaction.description,
+          direction: 'outflow' as const,
+          amount: EUR,
+        })),
+        errors: [],
+      }),
+    },
+    idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+    transactionBuilder: { buildAll: () => Result.ok({ built: outcomes as BuildOutcome[], failed: [] }) },
+    pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+    readFile: () => Result.ok('csv-content'),
+    prompt: { selectCategory: vi.fn(), confirmBatch: vi.fn() },
+    stdout: stdout as Writable,
+    stderr: stderr as Writable,
+    exitCode: (code) => exitCodes.push(code),
+    ...overrides,
+    // Expose captured streams and exit codes as non-interface extras
+    get captured() { return null; },
+  } as unknown as IngestCommandDeps & { stdout: Writable & { captured: string }; stderr: Writable & { captured: string }; exitCodes: number[] };
+}
+
+describe('--non-interactive mode', () => {
+  it({ timeout: 500 }, 'exits 0 with only high-confidence items — no prompts fired', async () => {
+    const outcomes = [makeHighOutcome('CARREFOUR', 'Groceries'), makeHighOutcome('EDF', 'Utilities')];
+    const { stdout, stderr } = makeStreams();
+    const exitCodes: number[] = [];
+    const prompter = { selectCategory: vi.fn(), confirmBatch: vi.fn() };
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: { parse: () => Result.ok({ items: outcomes.map(o => ({ sourceAccount: 'main-X', occurredAt: o.transaction.occurredAt, description: o.transaction.description, direction: 'outflow' as const, amount: EUR })), errors: [] }) },
+      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+      transactionBuilder: { buildAll: () => Result.ok({ built: outcomes, failed: [] }) },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok('csv-content'),
+      prompt: prompter,
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => exitCodes.push(code),
+    };
+
+    await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: true, json: false }, deps);
+
+    expect(exitCodes).toContain(0);
+    expect(prompter.selectCategory).not.toHaveBeenCalled();
+    expect(prompter.confirmBatch).not.toHaveBeenCalled();
+  }, { timeout: 500 });
+
+  it({ timeout: 500 }, 'exits 2 with low-confidence items — stderr names the count, no hang', async () => {
+    const outcomes = [makeHighOutcome('CARREFOUR', 'Groceries'), makeLowOutcome('UBER TRIP', 'Transport')];
+    const { stdout, stderr } = makeStreams();
+    const exitCodes: number[] = [];
+    const prompter = { selectCategory: vi.fn(), confirmBatch: vi.fn() };
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: { parse: () => Result.ok({ items: outcomes.map(o => ({ sourceAccount: 'main-X', occurredAt: o.transaction.occurredAt, description: o.transaction.description, direction: 'outflow' as const, amount: EUR })), errors: [] }) },
+      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+      transactionBuilder: { buildAll: () => Result.ok({ built: outcomes, failed: [] }) },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok('csv-content'),
+      prompt: prompter,
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => exitCodes.push(code),
+    };
+
+    await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: true, json: false }, deps);
+
+    expect(exitCodes).toContain(2);
+    expect((stderr as unknown as { captured: string }).captured).toContain('1 item');
+    expect(prompter.selectCategory).not.toHaveBeenCalled();
+  }, { timeout: 500 });
+});
+
+describe('--json mode', () => {
+  it('emits JSON to stdout with debit/credit/category fields and no idempotencyHash — all high-confidence exits 0', async () => {
+    const outcomes = [makeHighOutcome('CARREFOUR', 'Groceries')];
+    const { stdout, stderr } = makeStreams();
+    const exitCodes: number[] = [];
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: outcomes[0].transaction.description, direction: 'outflow' as const, amount: EUR }], errors: [] }) },
+      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+      transactionBuilder: { buildAll: () => Result.ok({ built: outcomes, failed: [] }) },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok('csv-content'),
+      prompt: { selectCategory: vi.fn(), confirmBatch: vi.fn() },
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => exitCodes.push(code),
+    };
+
+    await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: true }, deps);
+
+    const captured = (stdout as unknown as { captured: string }).captured;
+    const parsed = JSON.parse(captured.trim()) as {
+      items: Array<{ debit: string; credit: string; category: string; classification: string; idempotencyHash?: string }>;
+    };
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0]).toHaveProperty('debit');
+    expect(parsed.items[0]).toHaveProperty('credit');
+    expect(parsed.items[0]).toHaveProperty('category', 'Groceries');
+    expect(parsed.items[0]).toHaveProperty('classification', 'expense');
+    expect(parsed.items[0]).not.toHaveProperty('idempotencyHash');
+    expect(exitCodes).toContain(0);
+  });
+
+  it('exits 2 with needsReview list when low-confidence items present', async () => {
+    const outcomes = [makeLowOutcome('UBER TRIP', 'Transport')];
+    const { stdout, stderr } = makeStreams();
+    const exitCodes: number[] = [];
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: outcomes[0].transaction.description, direction: 'outflow' as const, amount: EUR }], errors: [] }) },
+      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+      transactionBuilder: { buildAll: () => Result.ok({ built: outcomes, failed: [] }) },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok('csv-content'),
+      prompt: { selectCategory: vi.fn(), confirmBatch: vi.fn() },
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => exitCodes.push(code),
+    };
+
+    await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: true }, deps);
+
+    const captured = (stdout as unknown as { captured: string }).captured;
+    const parsed = JSON.parse(captured.trim()) as { needsReview: string[]; items: unknown[] };
+
+    expect(exitCodes).toContain(2);
+    expect(parsed.needsReview).toHaveLength(1);
+    expect(parsed.needsReview[0]).toBe('tx-UBER TRIP');
+    expect(parsed.items).toHaveLength(0);
+  });
+
+  it('ambiguous filename match exits 2', async () => {
+    const { stdout, stderr } = makeStreams();
+    const exitCodes: number[] = [];
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: { parse: vi.fn() },
+      idempotencyService: { filterNew: vi.fn() },
+      transactionBuilder: { buildAll: vi.fn() },
+      pickSourceAccount: () => Result.fail('ambiguous filename — multiple account prefixes match'),
+      readFile: () => Result.ok('csv-content'),
+      prompt: { selectCategory: vi.fn(), confirmBatch: vi.fn() },
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => exitCodes.push(code),
+    };
+
+    await runIngestCommand({ file: '/tmp/ambig.csv', nonInteractive: false, json: false }, deps);
+
+    expect(exitCodes).toContain(2);
+    expect((stderr as unknown as { captured: string }).captured).toContain('ambiguous filename');
+  });
+});

--- a/tests/unit/cli/commands/ingest-command-flags.test.ts
+++ b/tests/unit/cli/commands/ingest-command-flags.test.ts
@@ -59,40 +59,6 @@ function makeStreams(): { stdout: Writable & { captured: string }; stderr: Writa
   return { stdout: makeCapture(), stderr: makeCapture() };
 }
 
-function makeDeps(
-  outcomes: readonly BuildOutcome[],
-  overrides: Partial<IngestCommandDeps> = {},
-): IngestCommandDeps & { stdout: Writable & { captured: string }; stderr: Writable & { captured: string }; exitCodes: number[] } {
-  const { stdout, stderr } = makeStreams();
-  const exitCodes: number[] = [];
-  return {
-    configService: { load: () => Result.ok(baseConfig) },
-    csvParser: {
-      parse: () => Result.ok({
-        items: outcomes.map((o) => ({
-          sourceAccount: 'main-X',
-          occurredAt: o.transaction.occurredAt,
-          description: o.transaction.description,
-          direction: 'outflow' as const,
-          amount: EUR,
-        })),
-        errors: [],
-      }),
-    },
-    idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
-    transactionBuilder: { buildAll: () => Result.ok({ built: outcomes as BuildOutcome[], failed: [] }) },
-    pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
-    readFile: () => Result.ok('csv-content'),
-    prompt: { selectCategory: vi.fn(), confirmBatch: vi.fn() },
-    stdout: stdout as Writable,
-    stderr: stderr as Writable,
-    exitCode: (code) => exitCodes.push(code),
-    ...overrides,
-    // Expose captured streams and exit codes as non-interface extras
-    get captured() { return null; },
-  } as unknown as IngestCommandDeps & { stdout: Writable & { captured: string }; stderr: Writable & { captured: string }; exitCodes: number[] };
-}
-
 describe('--non-interactive mode', () => {
   it({ timeout: 500 }, 'exits 0 with only high-confidence items — no prompts fired', async () => {
     const outcomes = [makeHighOutcome('CARREFOUR', 'Groceries'), makeHighOutcome('EDF', 'Utilities')];

--- a/tests/unit/cli/commands/ingest-command-flags.test.ts
+++ b/tests/unit/cli/commands/ingest-command-flags.test.ts
@@ -118,13 +118,15 @@ describe('--json mode', () => {
     const outcomes = [makeHighOutcome('CARREFOUR', 'Groceries')];
     const { stdout, stderr } = makeStreams();
     const exitCodes: number[] = [];
+    const dupItem = { sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: 'DUP', direction: 'outflow' as const, amount: EUR };
+    const parseErrorRow = { line: 1, reason: 'bad date', raw: 'x' };
 
     const deps: IngestCommandDeps = {
       configService: { load: () => Result.ok(baseConfig) },
-      csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: outcomes[0].transaction.description, direction: 'outflow' as const, amount: EUR }], errors: [] }) },
-      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+      csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: outcomes[0].transaction.description, direction: 'outflow' as const, amount: EUR }], errors: [parseErrorRow] }) },
+      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [dupItem] }) },
       transactionBuilder: { buildAll: () => Result.ok({ built: outcomes, failed: [] }) },
-      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      pickSourceAccount: () => Result.ok(makeAccount('acct-42', 'X_')),
       readFile: () => Result.ok('csv-content'),
       prompt: { selectCategory: vi.fn(), confirmBatch: vi.fn() },
       stdout: stdout as Writable,
@@ -136,6 +138,8 @@ describe('--json mode', () => {
 
     const captured = (stdout as unknown as { captured: string }).captured;
     const parsed = JSON.parse(captured.trim()) as {
+      source_account: string;
+      summary: { duplicates: number; parseErrors: number };
       items: Array<{ debit: string; credit: string; category: string; classification: string; idempotencyHash?: string }>;
     };
 
@@ -145,6 +149,9 @@ describe('--json mode', () => {
     expect(parsed.items[0]).toHaveProperty('category', 'Groceries');
     expect(parsed.items[0]).toHaveProperty('classification', 'expense');
     expect(parsed.items[0]).not.toHaveProperty('idempotencyHash');
+    expect(parsed.source_account).toBe('acct-42');
+    expect(parsed.summary.duplicates).toBe(1);
+    expect(parsed.summary.parseErrors).toBe(1);
     expect(exitCodes).toContain(0);
   });
 
@@ -152,13 +159,15 @@ describe('--json mode', () => {
     const outcomes = [makeLowOutcome('UBER TRIP', 'Transport')];
     const { stdout, stderr } = makeStreams();
     const exitCodes: number[] = [];
+    const dupItem = { sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: 'DUP', direction: 'outflow' as const, amount: EUR };
+    const parseErrorRow = { line: 2, reason: 'missing amount', raw: 'y' };
 
     const deps: IngestCommandDeps = {
       configService: { load: () => Result.ok(baseConfig) },
-      csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: outcomes[0].transaction.description, direction: 'outflow' as const, amount: EUR }], errors: [] }) },
-      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+      csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: outcomes[0].transaction.description, direction: 'outflow' as const, amount: EUR }], errors: [parseErrorRow, parseErrorRow] }) },
+      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [dupItem, dupItem] }) },
       transactionBuilder: { buildAll: () => Result.ok({ built: outcomes, failed: [] }) },
-      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      pickSourceAccount: () => Result.ok(makeAccount('acct-77', 'X_')),
       readFile: () => Result.ok('csv-content'),
       prompt: { selectCategory: vi.fn(), confirmBatch: vi.fn() },
       stdout: stdout as Writable,
@@ -169,12 +178,20 @@ describe('--json mode', () => {
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: true }, deps);
 
     const captured = (stdout as unknown as { captured: string }).captured;
-    const parsed = JSON.parse(captured.trim()) as { needsReview: string[]; items: unknown[] };
+    const parsed = JSON.parse(captured.trim()) as {
+      source_account: string;
+      summary: { duplicates: number; parseErrors: number };
+      needsReview: string[];
+      items: unknown[];
+    };
 
     expect(exitCodes).toContain(2);
     expect(parsed.needsReview).toHaveLength(1);
     expect(parsed.needsReview[0]).toBe('tx-UBER TRIP');
     expect(parsed.items).toHaveLength(0);
+    expect(parsed.source_account).toBe('acct-77');
+    expect(parsed.summary.duplicates).toBe(2);
+    expect(parsed.summary.parseErrors).toBe(2);
   });
 
   it('ambiguous filename match exits 2', async () => {

--- a/tests/unit/cli/commands/ingest-command.test.ts
+++ b/tests/unit/cli/commands/ingest-command.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Writable } from 'stream';
+import { PassThrough } from 'stream';
+import { runIngestCommand } from '../../../../src/cli/commands/ingest-command.js';
+import type { IngestCommandDeps, IngestCommandOptions } from '../../../../src/cli/commands/ingest-command.js';
+import type { InteractivePrompter } from '../../../../src/cli/utils/interactive.js';
+import { Result } from '@core/shared/result.js';
+import type { AppConfig, AccountConfig } from '@core/config/app-config.js';
+import type { BuildOutcome } from '@core/ingest/types.js';
+
+// fails if: the summary table is not written to stdout,
+//           or the interactive loop is skipped for low-confidence items,
+//           or a per-item change is not applied to the BuildOutcome,
+//           or exit code is wrong for any case
+
+const EUR = { amount: 1000, currency: 'EUR' };
+
+function makeAccount(id: string, prefix: string): AccountConfig {
+  return { id, type: 'bank', filenamePrefix: prefix };
+}
+
+const baseConfig: AppConfig = {
+  dbPath: './test.db',
+  defaultCurrency: 'EUR',
+  timezone: 'Europe/Paris',
+  splits: [{ partner: 'Alex', ratio: 0.5 }, { partner: 'Sam', ratio: 0.5 }],
+  buffers: [],
+  accounts: [makeAccount('main-X', 'X_')],
+};
+
+function makeHighOutcome(description: string, category: string): BuildOutcome {
+  return {
+    transaction: {
+      id: `tx-${description}`,
+      occurredAt: '2026-04-20T00:00:00+02:00',
+      description,
+      entries: [
+        { account: 'Expense:Groceries', side: 'debit', amount: EUR },
+        { account: 'Assets:Bank:main-X', side: 'credit', amount: EUR },
+      ],
+    } as unknown as BuildOutcome['transaction'],
+    category,
+    classification: 'expense',
+    confidence: 'high',
+  };
+}
+
+function makeLowOutcome(description: string, category: string): BuildOutcome {
+  return { ...makeHighOutcome(description, category), confidence: 'low' };
+}
+
+function makeStdout(): Writable & { captured: string } {
+  const buf: string[] = [];
+  const stream = new PassThrough() as Writable & { captured: string };
+  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
+  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
+  return stream;
+}
+
+function makeStderr(): Writable & { captured: string } {
+  return makeStdout();
+}
+
+function noop(_code: number): void {}
+
+describe('runIngestCommand — happy path (interactive)', () => {
+  it('writes summary table to stdout and calls final confirm once', async () => {
+    const stdout = makeStdout();
+    const stderr = makeStderr();
+    const capturedExitCode: number[] = [];
+
+    const outcomes = [makeHighOutcome('CARREFOUR', 'Groceries'), makeLowOutcome('UBER TRIP', 'Transport')];
+
+    const prompter: InteractivePrompter = {
+      selectCategory: vi.fn().mockResolvedValue({ action: 'keep' }),
+      confirmBatch: vi.fn().mockResolvedValue(true),
+    };
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: {
+        parse: () => Result.ok({
+          items: [
+            { sourceAccount: 'main-X', occurredAt: '2026-04-20T00:00:00+02:00', description: 'CARREFOUR', direction: 'outflow', amount: EUR },
+            { sourceAccount: 'main-X', occurredAt: '2026-04-20T00:00:00+02:00', description: 'UBER TRIP', direction: 'outflow', amount: EUR },
+          ],
+          errors: [],
+        }),
+      },
+      idempotencyService: {
+        filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }),
+      },
+      transactionBuilder: {
+        buildAll: () => Result.ok({ built: outcomes, failed: [] }),
+      },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok('csv-content'),
+      prompt: prompter,
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => capturedExitCode.push(code),
+    };
+
+    const opts: IngestCommandOptions = {
+      file: '/tmp/X_2026.csv',
+      nonInteractive: false,
+      json: false,
+    };
+
+    await runIngestCommand(opts, deps);
+
+    expect(stdout.captured).toContain('CARREFOUR');
+    expect(stdout.captured).toContain('UBER TRIP');
+    expect(prompter.confirmBatch).toHaveBeenCalledTimes(1);
+    expect(prompter.selectCategory).toHaveBeenCalledTimes(1);
+    expect(capturedExitCode).toContain(0);
+  });
+
+  it('applies category change from per-item prompt to the displayed outcome', async () => {
+    const stdout = makeStdout();
+    const stderr = makeStderr();
+    const capturedExitCode: number[] = [];
+
+    const outcomes = [makeLowOutcome('UBER TRIP', 'Transport')];
+
+    const prompter: InteractivePrompter = {
+      selectCategory: vi.fn().mockResolvedValue({ action: 'change', category: 'Groceries' }),
+      confirmBatch: vi.fn().mockResolvedValue(true),
+    };
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: {
+        parse: () => Result.ok({
+          items: [{ sourceAccount: 'main-X', occurredAt: '2026-04-20T00:00:00+02:00', description: 'UBER TRIP', direction: 'outflow', amount: EUR }],
+          errors: [],
+        }),
+      },
+      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+      transactionBuilder: { buildAll: () => Result.ok({ built: outcomes, failed: [] }) },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok('csv-content'),
+      prompt: prompter,
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => capturedExitCode.push(code),
+    };
+
+    await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
+
+    expect(stdout.captured).toContain('Groceries');
+    expect(capturedExitCode).toContain(0);
+  });
+
+  it('exits 1 when the final confirm is declined', async () => {
+    const stdout = makeStdout();
+    const stderr = makeStderr();
+    const capturedExitCode: number[] = [];
+
+    const outcomes = [makeHighOutcome('CARREFOUR', 'Groceries')];
+
+    const prompter: InteractivePrompter = {
+      selectCategory: vi.fn(),
+      confirmBatch: vi.fn().mockResolvedValue(false),
+    };
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: '2026-04-20T00:00:00+02:00', description: 'CARREFOUR', direction: 'outflow', amount: EUR }], errors: [] }) },
+      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+      transactionBuilder: { buildAll: () => Result.ok({ built: outcomes, failed: [] }) },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok('csv-content'),
+      prompt: prompter,
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => capturedExitCode.push(code),
+    };
+
+    await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
+
+    expect(capturedExitCode).toContain(1);
+    expect(stderr.captured).toMatch(/cancel|abort|declined/i);
+  });
+
+  it('exits 1 when the user aborts during per-item interactive loop', async () => {
+    const stdout = makeStdout();
+    const stderr = makeStderr();
+    const capturedExitCode: number[] = [];
+
+    const outcomes = [makeLowOutcome('UBER TRIP', 'Transport')];
+
+    const prompter: InteractivePrompter = {
+      selectCategory: vi.fn().mockResolvedValue({ action: 'abort' }),
+      confirmBatch: vi.fn(),
+    };
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: '2026-04-20T00:00:00+02:00', description: 'UBER TRIP', direction: 'outflow', amount: EUR }], errors: [] }) },
+      idempotencyService: { filterNew: (items) => Result.ok({ fresh: [...items], duplicates: [] }) },
+      transactionBuilder: { buildAll: () => Result.ok({ built: outcomes, failed: [] }) },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok('csv-content'),
+      prompt: prompter,
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => capturedExitCode.push(code),
+    };
+
+    await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
+
+    expect(capturedExitCode).toContain(1);
+    expect(stderr.captured).toMatch(/cancel|abort/i);
+    expect(prompter.confirmBatch).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 when pickSourceAccount fails (no account match)', async () => {
+    const stdout = makeStdout();
+    const stderr = makeStderr();
+    const capturedExitCode: number[] = [];
+
+    const deps: IngestCommandDeps = {
+      configService: { load: () => Result.ok(baseConfig) },
+      csvParser: { parse: vi.fn() },
+      idempotencyService: { filterNew: vi.fn() },
+      transactionBuilder: { buildAll: vi.fn() },
+      pickSourceAccount: () => Result.fail('no account configured for this filename'),
+      readFile: () => Result.ok('csv-content'),
+      prompt: { selectCategory: vi.fn(), confirmBatch: vi.fn() },
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => capturedExitCode.push(code),
+    };
+
+    await runIngestCommand({ file: '/tmp/orphan.csv', nonInteractive: false, json: false }, deps);
+
+    expect(capturedExitCode).toContain(2);
+    expect(stderr.captured).toContain('no account configured for this filename');
+  });
+});

--- a/tests/unit/cli/commands/ingest-command.test.ts
+++ b/tests/unit/cli/commands/ingest-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { Writable } from 'stream';
 import { PassThrough } from 'stream';
 import { runIngestCommand } from '../../../../src/cli/commands/ingest-command.js';
@@ -60,8 +60,6 @@ function makeStdout(): Writable & { captured: string } {
 function makeStderr(): Writable & { captured: string } {
   return makeStdout();
 }
-
-function noop(_code: number): void {}
 
 describe('runIngestCommand — happy path (interactive)', () => {
   it('writes summary table to stdout and calls final confirm once', async () => {

--- a/tests/unit/infra/fs/pick-source-account.test.ts
+++ b/tests/unit/infra/fs/pick-source-account.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { pickSourceAccount } from '../../../../src/infra/fs/pick-source-account.js';
+import type { AccountConfig } from '@core/config/app-config.js';
+
+// fails if: the longest-prefix-wins rule is implemented as first-wins,
+//           or ties don't return Result.fail,
+//           or zero-match doesn't return Result.fail
+
+const bankAccount = (id: string, prefix: string): AccountConfig => ({
+  id,
+  type: 'bank',
+  filenamePrefix: prefix,
+});
+
+describe('pickSourceAccount', () => {
+  describe('zero matches', () => {
+    it('returns failure when no account prefix matches the basename', () => {
+      const accounts = [bankAccount('main', 'MAIN_'), bankAccount('savings', 'SAV_')];
+      const result = pickSourceAccount('/tmp/OTHER_2026.csv', accounts);
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('no account configured for this filename');
+    });
+
+    it('returns failure for empty accounts list', () => {
+      const result = pickSourceAccount('/tmp/X_2026.csv', []);
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('no account configured for this filename');
+    });
+  });
+
+  describe('single match', () => {
+    it('returns the matching account when exactly one prefix matches', () => {
+      const accounts = [bankAccount('main', 'X_'), bankAccount('savings', 'SAV_')];
+      const result = pickSourceAccount('/tmp/X_2026.csv', accounts);
+      expect(result.isSuccess).toBe(true);
+      expect(result.value.id).toBe('main');
+    });
+
+    it('matches on basename, not full path', () => {
+      const accounts = [bankAccount('main', 'X_')];
+      const result = pickSourceAccount('/home/user/downloads/X_2026.csv', accounts);
+      expect(result.isSuccess).toBe(true);
+      expect(result.value.id).toBe('main');
+    });
+  });
+
+  describe('longest prefix wins', () => {
+    it('selects the account with the longer matching prefix over a shorter one', () => {
+      const accounts = [
+        bankAccount('short', 'X_'),
+        bankAccount('long', 'X_2026_'),
+      ];
+      const result = pickSourceAccount('/tmp/X_2026_jan.csv', accounts);
+      expect(result.isSuccess).toBe(true);
+      expect(result.value.id).toBe('long');
+    });
+  });
+
+  describe('tied-length multi-match', () => {
+    it('returns failure when two accounts have the same prefix and both match', () => {
+      // Duplicate prefixes are prevented by config schema validation, but we test
+      // the runtime guard directly here using raw AccountConfig objects.
+      const tiedAccounts = [
+        bankAccount('acct-a', 'FILE'),
+        bankAccount('acct-b', 'FILE'),
+      ];
+      const result = pickSourceAccount('/tmp/FILE_2026.csv', tiedAccounts);
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('ambiguous filename');
+    });
+  });
+
+  describe('PII safety', () => {
+    it('error messages do not contain the full path (home dir leak defence)', () => {
+      const accounts = [bankAccount('main', 'MAIN_')];
+      const result = pickSourceAccount('/home/alice/sensitive/OTHER_2026.csv', accounts);
+      expect(result.isFailure).toBe(true);
+      expect(result.error).not.toContain('/home/alice/sensitive');
+    });
+  });
+});

--- a/tests/unit/infra/fs/read-bpce-csv.test.ts
+++ b/tests/unit/infra/fs/read-bpce-csv.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readBpceCsv } from '../../../../src/infra/fs/read-bpce-csv.js';
+import * as fs from 'fs';
+
+// fails if: the function returns a success result on ENOENT,
+//           or error messages leak the full absolute path (home dir),
+//           or the function throws instead of returning Result.fail
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+describe('readBpceCsv', () => {
+  describe('happy path', () => {
+    it('returns success with the file content as a string', () => {
+      mockReadFileSync.mockReturnValueOnce('header\nrow1\n' as unknown as Buffer);
+      const result = readBpceCsv('/tmp/X_2026.csv');
+      expect(result.isSuccess).toBe(true);
+      expect(result.value).toBe('header\nrow1\n');
+      expect(mockReadFileSync).toHaveBeenCalledWith('/tmp/X_2026.csv', 'latin1');
+    });
+  });
+
+  describe('ENOENT', () => {
+    it('returns failure with a user-friendly message when file does not exist', () => {
+      const err = Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' });
+      mockReadFileSync.mockImplementationOnce(() => { throw err; });
+      const result = readBpceCsv('/home/alice/X_2026.csv');
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('X_2026.csv');
+      expect(result.error).not.toContain('/home/alice');
+    });
+  });
+
+  describe('EACCES', () => {
+    it('returns failure with a permission-error message', () => {
+      const err = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+      mockReadFileSync.mockImplementationOnce(() => { throw err; });
+      const result = readBpceCsv('/home/alice/X_2026.csv');
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('X_2026.csv');
+      expect(result.error).not.toContain('/home/alice');
+    });
+  });
+
+  describe('unknown error', () => {
+    it('returns failure for unexpected errors', () => {
+      mockReadFileSync.mockImplementationOnce(() => { throw new Error('something unexpected'); });
+      const result = readBpceCsv('/tmp/X_2026.csv');
+      expect(result.isFailure).toBe(true);
+    });
+  });
+});

--- a/tests/unit/infra/fs/read-bpce-csv.test.ts
+++ b/tests/unit/infra/fs/read-bpce-csv.test.ts
@@ -1,55 +1,69 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { readBpceCsv } from '../../../../src/infra/fs/read-bpce-csv.js';
-import * as fs from 'fs';
+import { writeFileSync, mkdirSync, chmodSync, unlinkSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 // fails if: the function returns a success result on ENOENT,
 //           or error messages leak the full absolute path (home dir),
 //           or the function throws instead of returning Result.fail
 
-vi.mock('fs', () => ({
-  readFileSync: vi.fn(),
-}));
-
-const mockReadFileSync = vi.mocked(fs.readFileSync);
+const TMP = tmpdir();
 
 describe('readBpceCsv', () => {
   describe('happy path', () => {
-    it('returns success with the file content as a string', () => {
-      mockReadFileSync.mockReturnValueOnce('header\nrow1\n' as unknown as Buffer);
-      const result = readBpceCsv('/tmp/X_2026.csv');
-      expect(result.isSuccess).toBe(true);
-      expect(result.value).toBe('header\nrow1\n');
-      expect(mockReadFileSync).toHaveBeenCalledWith('/tmp/X_2026.csv', 'latin1');
+    it('returns success with the file content as a string (latin1 encoding)', () => {
+      const filePath = join(TMP, 'test-read-bpce-happy.csv');
+      writeFileSync(filePath, 'header\nrow1\n', 'latin1');
+      try {
+        const result = readBpceCsv(filePath);
+        expect(result.isSuccess).toBe(true);
+        expect(result.value).toBe('header\nrow1\n');
+      } finally {
+        if (existsSync(filePath)) unlinkSync(filePath);
+      }
     });
   });
 
   describe('ENOENT', () => {
     it('returns failure with a user-friendly message when file does not exist', () => {
-      const err = Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' });
-      mockReadFileSync.mockImplementationOnce(() => { throw err; });
-      const result = readBpceCsv('/home/alice/X_2026.csv');
+      const fakePath = join(TMP, 'definitely-does-not-exist-xyz.csv');
+      const result = readBpceCsv(fakePath);
       expect(result.isFailure).toBe(true);
-      expect(result.error).toContain('X_2026.csv');
-      expect(result.error).not.toContain('/home/alice');
+      expect(result.error).toContain('definitely-does-not-exist-xyz.csv');
+      expect(result.error).not.toContain(TMP);
     });
   });
 
   describe('EACCES', () => {
-    it('returns failure with a permission-error message', () => {
-      const err = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
-      mockReadFileSync.mockImplementationOnce(() => { throw err; });
-      const result = readBpceCsv('/home/alice/X_2026.csv');
-      expect(result.isFailure).toBe(true);
-      expect(result.error).toContain('X_2026.csv');
-      expect(result.error).not.toContain('/home/alice');
+    it('returns failure with a permission-error message for unreadable file', () => {
+      const filePath = join(TMP, 'test-read-bpce-noaccess.csv');
+      writeFileSync(filePath, 'content', 'latin1');
+      chmodSync(filePath, 0o000);
+      try {
+        const result = readBpceCsv(filePath);
+        if (process.getuid && process.getuid() === 0) {
+          // root can always read — skip EACCES on root
+          expect(result.isSuccess || result.isFailure).toBe(true);
+        } else {
+          expect(result.isFailure).toBe(true);
+          expect(result.error).toContain('test-read-bpce-noaccess.csv');
+          expect(result.error).not.toContain(TMP);
+        }
+      } finally {
+        chmodSync(filePath, 0o644);
+        if (existsSync(filePath)) unlinkSync(filePath);
+      }
     });
   });
 
-  describe('unknown error', () => {
-    it('returns failure for unexpected errors', () => {
-      mockReadFileSync.mockImplementationOnce(() => { throw new Error('something unexpected'); });
-      const result = readBpceCsv('/tmp/X_2026.csv');
+  describe('PII safety', () => {
+    it('error messages use only the basename, never the full path', () => {
+      const filePath = join(TMP, 'nonexistent-pii-test.csv');
+      const result = readBpceCsv(filePath);
       expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('nonexistent-pii-test.csv');
+      expect(result.error).not.toContain(TMP);
     });
   });
 });

--- a/tests/unit/infra/fs/read-bpce-csv.test.ts
+++ b/tests/unit/infra/fs/read-bpce-csv.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readBpceCsv } from '../../../../src/infra/fs/read-bpce-csv.js';
-import { writeFileSync, mkdirSync, chmodSync, unlinkSync, existsSync } from 'fs';
+import { writeFileSync, chmodSync, unlinkSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 


### PR DESCRIPTION
## 1. Story

[Epic 2, Story 2.4 — Interactive Ingest Command (CLI)](../blob/main/docs/epics.md#story-24-interactive-ingest-command-cli).

## 2. Intent

Ship the first user-facing command: \`accounting ingest -f <file.csv>\`. Wire Stories 2.1 (CSV parser) + 2.2 (idempotency) + 2.3 (transaction builder) behind a commander entry point, add the filename→source-account matcher (#25), a Latin-1 file reader for BPCE, a summary table, and an interactive per-item tagging loop with arrow-key navigation. DB writes are Story 2.5; Story 2.4 stops at "confirmed batch."

## 3. Alternatives considered

- **Review-all-then-confirm UX** — rejected; AC2 wording ("iterates through low-confidence items asking me to confirm or change") + the PRD's Sunday-Morning-Audit journey both specify per-item iteration.
- **\`inquirer\` (v10) or \`prompts\`** — rejected; \`@inquirer/prompts\` v5+ is ESM-native, tree-shakable, and has the modern functional \`select\` API matching AC3's arrow-key navigation.
- **Hand-rolled summary table** — rejected; \`cli-table3\` handles column alignment/truncation for wide descriptions out of the box (PRD names it as a reference option).
- **Multi-file per invocation (\`-f a -f b …\`)** — rejected for MVP; single file keeps per-item source tagging simple. User runs 5 invocations across their 5 BPCE files. Future story if tedium surfaces.
- **\`pickSourceAccount\` in \`src/cli/utils/\`** — rejected; basename matching is a filesystem concept, not a CLI concern. Lives in \`src/infra/fs/\` for non-CLI reuse.
- **Constructor-DI class for the command handler** — rejected; CLI handlers are scripts not stateful domain logic. Plain \`async (opts, deps) => void\` mirrors \`runMigrations(db)\` precedent.
- **\`--json\` output including \`idempotencyHash\`** — rejected on YAGNI grounds (no caller today needs it). Plan draft originally cited "leak defence"; Plan agent correctly flagged that as bogus reasoning (SHA-256 is one-way) and the plan now documents YAGNI as the real reason.
- **Split quickpickle install into a pre-2.4 PR** — Plan agent recommended this as de-risking. Rejected in favour of keeping quickpickle as Story 2.4's tail-end slices + an explicit fallback ("if wiring fails, stop at slice 8, file follow-up"). The fallback fired cleanly when upstream bug discovered — see § 7 + [#24 comment](https://github.com/xavierbriand/accounting/issues/24).

## 4. Selected solution & rationale

**CLI entry:** [\`src/cli/program.ts\`](../blob/main/src/cli/program.ts) — commander program with \`ingest\` and \`migrate\` subcommands.

**Handler:** [\`src/cli/commands/ingest-command.ts\`](../blob/main/src/cli/commands/ingest-command.ts) — \`runIngestCommand(opts, deps): Promise<void>\`. Deps object contains every collaborator (ConfigService, CsvParser, IdempotencyService, TransactionBuilder, pickSourceAccount fn, readFile fn, InteractivePrompter, stdout/stderr, exitCode callback) — mockable in tests.

**Interactive:** [\`src/cli/utils/interactive.ts\`](../blob/main/src/cli/utils/interactive.ts) — \`InteractivePrompter\` interface + \`inquirerPrompter\` production impl using \`@inquirer/prompts.select\` + \`confirm\`. Caveat: inquirer writes directly to \`process.stderr\`, bypassing the injected stream; the abstraction makes this moot in tests via the mock prompter.

**Printer:** [\`src/cli/utils/printer.ts\`](../blob/main/src/cli/utils/printer.ts) — \`formatSummaryTable(outcomes)\` via \`cli-table3\`; columns Date/Description/Amount/Category/Confidence.

**Infra/fs:**
- [\`pick-source-account.ts\`](../blob/main/src/infra/fs/pick-source-account.ts) — longest-prefix match on \`basename(filePath)\`; \`Result.fail\` with PII-safe messages for zero/tied multi-match (closes [#25](https://github.com/xavierbriand/accounting/issues/25)).
- [\`read-bpce-csv.ts\`](../blob/main/src/infra/fs/read-bpce-csv.ts) — \`fs.readFileSync(path, 'latin1')\` with basename-only error messages (no full path leak).

**\`migrate.ts\` refactor:** extracted \`runMigrate(dbPath)\` + guarded top-level with \`import.meta.url\` comparison so \`program.ts\` importing \`migrate.ts\` does not double-run migrations. Plan agent catch — would have been an invisible bug.

**Modes:**
- **Interactive (default):** per-item prompt on low-confidence outcomes + final confirm.
- **\`--non-interactive\`:** fails fast with exit 2 on any low-confidence item (no prompt, \`{ timeout: 500 }\` asserted in tests).
- **\`--json\`:** emits structured output to stdout; implies non-interactive; no \`idempotencyHash\` field (YAGNI); \`source_account\` + \`duplicates\` + \`parseErrors\` threaded correctly (Phase-4 fix \`da83aa1\`).

**Exit codes:** 0 success, 1 runtime/abort/decline, 2 invalid input (no match, ambiguous match, needs-review + --non-interactive/--json).

## 5. Gherkin scenarios

Per [docs/plans/story-2.4.md § Gherkin scenarios](../blob/main/docs/plans/story-2.4.md). Mapped to unit tests (one \`describe\` per scenario) in:
- [tests/unit/cli/commands/ingest-command.test.ts](../blob/main/tests/unit/cli/commands/ingest-command.test.ts) — happy path, interactive loop, abort, no-account-match
- [tests/unit/cli/commands/ingest-command-flags.test.ts](../blob/main/tests/unit/cli/commands/ingest-command-flags.test.ts) — --non-interactive + --json; includes non-zero-duplicates + non-zero-parseErrors mock scenario (retro action A — Mock diversity check)
- [tests/unit/infra/fs/pick-source-account.test.ts](../blob/main/tests/unit/infra/fs/pick-source-account.test.ts) — zero/one/longest/tied cases (closes #25)
- [tests/unit/infra/fs/read-bpce-csv.test.ts](../blob/main/tests/unit/infra/fs/read-bpce-csv.test.ts) — happy path, ENOENT, EACCES, PII-safety

Quickpickle \`.feature\` acceptance test NOT present — see § 7 quickpickle row.

## 6. Plan for Sonnet

Full plan: [docs/plans/story-2.4.md](../blob/main/docs/plans/story-2.4.md). 11 slices planned; 8 delivered + fallback-stop at slice 8 per plan's explicit clause when quickpickle wiring hit upstream bug. Phase-4 JSON-output bug fix added as \`fix(cli)\` commit. Total 9 story commits + 1 retro = 10 commits.

1. \`chore(docs)\`: add Story 2.4 plan + ingest script scaffolding
2. \`chore(deps)\`: authorise @inquirer/prompts + cli-table3 + quickpickle
3. \`test(fs)\`: pickSourceAccount + readBpceCsv suite — failing
4. \`feat(fs)\`: pickSourceAccount + readBpceCsv minimal green
5. \`test(cli)\`: ingest command orchestration + interactive loop — failing
6. \`feat(cli)\`: ingest command orchestration + printer + interactive loop minimal green
7. \`test(cli)\`: --non-interactive + --json mode suite
8. _(green-on-landing — flags already correct by slice 6)_
9. \`refactor(cli)\`: tidy ingest command
10. \`fix(cli)\`: thread source_account + parseErrors + duplicates into --json output (Phase-4 finding)
11. \`chore(retro)\`: Story 2.4 retrospective + CLAUDE.md mock-diversity audit

## 7. Suggestion log

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| Plan-stress | \`--json\` excluding \`idempotencyHash\` on "leak defence" grounds → switch to YAGNI reasoning | adopted | Plan updated; avoids cargo-culting wrong security model |
| Plan-stress | Split quickpickle install into pre-2.4 PR | rejected | Kept in-story with explicit fallback clause; fallback fired cleanly when upstream bug found — preserved forward momentum |
| Plan-stress | \`@inquirer/prompts\` writes directly to \`process.stderr\` — injected stream is a lie for prompts | adopted | Plan clarified: stream injection applies only to non-prompt messages; prompts tested via mock |
| Plan-stress | \`migrate.ts\` side-effecting top-level + \`program.ts\` import would double-run migrations | adopted | Extracted \`runMigrate()\` + \`import.meta.url\` guard |
| Plan-stress | No-hang test for --non-interactive needs explicit timeout | adopted | Added \`{ timeout: 500 }\` to vitest test |
| Plan-stress | Per-item vs review-all-then-confirm | flag-and-accept | Per-item per AC wording; retro trigger if real-run reveals tedium |
| Phase-4 QA walk | \`--json\` \`source_account: null\` + \`parseErrors/duplicates: 0\` hardcoded; tests passed because mocks were zero | adopted | Fixed in \`da83aa1\`; added non-zero-mock test case; retro action A codifies the P2 audit step in CLAUDE.md |
| Phase-4 P3 walk | \`runIngestCommand\` ~97 LOC (over ~50 guideline) | rejected | Linear pipeline, no duplication identified per-step; Sonnet flagged in Deviations per Story 2.3 retro rule. Splitting would scatter the sequential flow |
| Implementation | quickpickle@1.11 ships with missing \`pixelmatch\` dep; ERR_MODULE_NOT_FOUND at vitest config load | deferred | [#24 updated](https://github.com/xavierbriand/accounting/issues/24) — install completed, wiring blocked pending upstream fix |

## 8. Sonnet's learnings

### Run 1 — 8-slice partial delivery (quickpickle stopped per fallback)

**What was built:** \`pickSourceAccount\` + \`readBpceCsv\` (closes #25); \`runIngestCommand\` orchestrating the full pipeline; interactive \`select\` + final \`confirm\` via \`@inquirer/prompts\`; \`cli-table3\` summary; \`--non-interactive\` and \`--json\` flag modes; \`migrate.ts\` refactored to \`runMigrate()\` + \`import.meta.url\` guard; commander \`program.ts\` entry wiring \`ingest\` + \`migrate\` subcommands.

**Red→green:** 186c56b → 251740f (fs) · c9efc1a → a48009a (cli orchestration) · 76003d1 (flags green-on-landing) · 54f1ba2 (refactor/tidy).

**Deviations:**
- Summary table printed **after** interactive loop (not before) so it reflects resolved categories. Plan said before; test forced the change.
- Flags tests (slice 7–8) green-on-landing because slice 6's minimal green covered both paths.
- \`vi.spyOn(fs.readFileSync)\` fails in ESM (TypeError: Cannot redefine property); switched to real temp files — more robust.
- Quickpickle 9–11 stopped per plan fallback: \`quickpickle@1.11\` unconditionally imports \`pixelmatch\` without declaring it as a dep.
- \`runIngestCommand\` ~97 LOC. No duplication in the linear pipeline — extraction rejected with reasoning.
- 4 low + 4 moderate \`npm audit\` advisories via transitive deps of \`@inquirer/editor\` and \`@cucumber/messages\` (quickpickle). Security checklist blocks only high/critical.

### Run 2 — Phase-4 JSON fix

**What was built:** threaded \`account.id\` + \`duplicatesCount\` + \`parseErrorsCount\` through \`runNonInteractive\`; updated flags tests to use non-zero mocks; SHA \`da83aa1\`.

**Deviations:** opted NOT to extract a shared JSON-builder helper — the two emission sites differ structurally (\`needsReview\` array present/absent; \`autoTagged\` computed differently) and a shared helper would require a conditional-shape arg that adds complexity without real DRY.

## 9. Retrospective

- **Keep:** Plan agent flipped 2 decisions + caught 3 real bugs pre-implementation; 60-LOC + duplication trigger (Story 2.3 retro action A) surfaced the 97-LOC \`runIngestCommand\` cleanly; Phase-4 QA walk caught the \`--json\` hardcoded-field bug that 172 tests missed; plan's fallback clause for quickpickle preserved story delivery when upstream bug surfaced.
- **Change:** test mocks were too uniformly zero-valued → bug passed the test suite; plan-agent's "split quickpickle" recommendation was right in principle but the fallback path served better in practice (preserved momentum vs. blocking on upstream).
- **Try:** Mock diversity check — added to CLAUDE.md § 6.1 phase 4 as Story 2.4 retro action A. Issue #24 updated with upstream-bug trail for the next quickpickle attempt.

Full retrospective: [docs/retrospectives/story-2.4.md](../blob/main/docs/retrospectives/story-2.4.md).

## 10. Merge checklist

- [x] \`lint\` / \`build\` / \`test\` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at \`docs/retrospectives/story-2.4.md\`
- [x] All suggestion-log items resolved (no blank \`Resolution\` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval
