### PR TITLE
chore(plugin): scaffold product-dev-agent plugin + side-by-side migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ This file is an AI-facing cheat sheet. The authoritative canon lives under `docs
 
 On conflict between this file and a `docs/` file, `docs/` wins. The retrospective phase reconciles drift.
 
+> **Loop reference (side-by-side migration in progress).** This project's development workflow is being migrated to the [`product-dev-agent`](https://github.com/xavierbriand/product-dev-agent) plugin. The plugin is scaffolded at `product-dev-agent/` in this branch and will move to its own repo. Until **Story 3.1** validates the plugin end-to-end, both the plugin skills (`/product-dev-agent:plan-story`, `/review-plan`, `/implement`, `/review-impl`, `/retro`, `/maintenance`, `/bootstrap`) **and** the in-repo `CLAUDE.md` §§ 6–7 / `.claude/agents/sonnet-implementer.md` / `.github/*template*` files remain in force. They are equivalent by design. After Story 3.1 ships cleanly through the plugin, the duplicated in-repo workflow content will be stripped in that story's retro and accounting will consume only the plugin. The plugin's authoritative loop reference: `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md`.
+
 ## 1. Project
 
 **Couples Expense Sharing App** — a local-first, CLI-based "predictive asset-based financial engine" for couples managing joint finances. Replaces reactive joint-account top-ups with a deterministic engine that predicts fair transfers, buffers volatility, and keeps an immutable ledger.

--- a/docs/retrospectives/README.md
+++ b/docs/retrospectives/README.md
@@ -4,6 +4,8 @@ Each completed story produces a retrospective here. Format: Keep / Change / Try.
 
 The retrospective phase of the development loop is described in [CLAUDE.md § 6.1](../../CLAUDE.md). The retro must be committed **before** the merge checklist can be ticked.
 
+> **Legacy references.** Pre-`product-dev-agent`-plugin retrospectives (Stories 1.3 through 2.4) cite `CLAUDE.md § 6.x` and `§ 7` by section number. After accounting completes its migration to the plugin (planned for Story 3.1's retro), those references resolve to the plugin's authoritative workflow doc: `CLAUDE.md § 6.1` → `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` § "Phases"; `CLAUDE.md § 6.4` → workflow.md § "Commit convention inside a story"; `CLAUDE.md § 6.7` → workflow.md § "Maintenance sub-loop"; `CLAUDE.md § 7` → workflow.md § "Definition of Done". Frozen retro files are not rewritten; this paragraph is the single redirect.
+
 ## Template for a new retrospective
 
 Copy into `story-<id>.md` (e.g. `story-1.3.md`) and fill in.

--- a/product-dev-agent/.claude-plugin/plugin.json
+++ b/product-dev-agent/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "product-dev-agent",
+  "version": "0.1.0",
+  "description": "Opus-plans / Sonnet-implements product development loop with 3-pass critical review, TDD rhythm, and retrospective discipline.",
+  "homepage": "https://github.com/xavierbriand/product-dev-agent",
+  "repository": "https://github.com/xavierbriand/product-dev-agent",
+  "license": "MIT",
+  "keywords": ["workflow", "tdd", "bdd", "review", "opus", "sonnet", "retrospective"]
+}

--- a/product-dev-agent/README.md
+++ b/product-dev-agent/README.md
@@ -1,0 +1,102 @@
+# product-dev-agent
+
+A Claude Code plugin that ships an opinionated product-development loop: **a planning model designs the work, an implementation model executes it via outside-in BDD + unit TDD, with a 3-pass critical review on both the plan and the code, and a Keep/Change/Try retrospective that folds learnings back into the rules.**
+
+The loop was extracted from a working accounting project after six end-to-end stories. It's the loop, not the accounting.
+
+## What you get
+
+- **One agent** — `sonnet-implementer`: outside-in BDD + unit TDD, returns a structured report, never opens or merges PRs.
+- **Seven skills** drive the phases:
+  - `/product-dev-agent:maintenance` — triage issues, review Dependabot, audit. Run before every new story.
+  - `/product-dev-agent:plan-story <id>` — Phase 1: intent → 3 alternatives → acceptance scenarios → draft PR + plan file.
+  - `/product-dev-agent:review-plan` — Phase 2: P1/P2/P3 critical review on the plan. DoR gate.
+  - `/product-dev-agent:implement` — Phase 3: hand off to `sonnet-implementer`.
+  - `/product-dev-agent:review-impl` — Phase 4: P1/P2/P3 retro-check against the actual diff. Refactor plan.
+  - `/product-dev-agent:retro <id>` — Phase 5: Keep/Change/Try retrospective. New rules land in same PR.
+  - `/product-dev-agent:bootstrap` — installs templates + the CLAUDE.md snippet. `--check` reports drift.
+- **Five docs** — the loop's authoritative reference (`docs/workflow.md`, `engineering-standards.md`, `security-checklist.md`, `quality-assurance-skeleton.md`, `retrospective-format.md`).
+- **Four templates** — PR template (10 sections), deferred-suggestion issue, retrospective skeleton, CLAUDE.md snippet.
+
+## Install
+
+```bash
+# Add as a marketplace
+/plugin marketplace add xavierbriand/product-dev-agent
+
+# Install
+/plugin install product-dev-agent@xavierbriand-product-dev-agent
+```
+
+For local development of the plugin itself:
+
+```bash
+/plugin marketplace add /path/to/local/product-dev-agent
+```
+
+## First-time setup in a consuming repo
+
+```text
+/product-dev-agent:bootstrap
+```
+
+The bootstrap:
+- Copies `.github/pull_request_template.md` and `.github/ISSUE_TEMPLATE/deferred-suggestion.md` (GitHub reads these from your repo, not the plugin).
+- Drops a retrospective skeleton at `docs/retrospectives/_template.md`.
+- Appends a reference snippet to your `CLAUDE.md` (gated by a marker — re-running is a no-op).
+- Prints the recommended `.claude/settings.json` permissions allow-list.
+
+After bootstrap, fill in the **Loop overlay** section of your `CLAUDE.md`: green-suite command, stack, critical-path deps, audit command, acceptance/property runners. The plugin defaults to Node/npm idioms but works for any language as long as your overlay names the right commands and runners.
+
+## Then run the loop
+
+```text
+/product-dev-agent:maintenance
+/product-dev-agent:plan-story 1.1
+/product-dev-agent:review-plan
+/product-dev-agent:implement
+/product-dev-agent:review-impl
+/product-dev-agent:retro 1.1
+```
+
+Repeat per story.
+
+## Skill namespacing
+
+Claude Code namespaces all plugin skills as `/<plugin-name>:<skill>`. There is no shorter form — typing just `/plan-story` won't find the skill. The full `/product-dev-agent:plan-story` is required.
+
+## Drift detection
+
+When the plugin updates a template (e.g. adding a section to the PR template), consumer repos won't auto-update — GitHub reads the template from the consumer's `.github/`, which is a copy. Run:
+
+```text
+/product-dev-agent:bootstrap --check
+```
+
+…to see which consumer-side files have drifted. Re-run `/bootstrap` (without `--check`) to overwrite with plugin canon.
+
+## Layout
+
+```
+product-dev-agent/
+├── .claude-plugin/plugin.json
+├── agents/sonnet-implementer.md
+├── skills/<phase>/SKILL.md           # 7 phases
+├── docs/                             # workflow, engineering, security, QA, retro format
+├── templates/                        # PR, issue, retro, CLAUDE.md snippet
+├── hooks/hooks.json                  # SessionStart bootstrap-missing nudge
+├── scripts/                          # bootstrap.sh, session-start-reminder.sh
+└── README.md
+```
+
+## Philosophy
+
+Three things make the loop work:
+
+1. **Two models, two roles.** Planning ≠ implementation. The planning model is allowed to think slowly; the implementation model is allowed to type fast. Mixing them produces neither.
+2. **Reviews on the plan AND the code.** Pre-implementation review catches scope drift and architectural mistakes cheaply. Post-implementation review catches what the test suite missed (this happens — the loop has caught real correctness bugs in 100%-passing test suites).
+3. **Retrospectives codify rules, not vibes.** Every "Try" experiment either graduates to a rule edit in the same PR or sunsets. The retro file is history; the rule lives where future-you will read it.
+
+## License
+
+MIT

--- a/product-dev-agent/agents/sonnet-implementer.md
+++ b/product-dev-agent/agents/sonnet-implementer.md
@@ -1,0 +1,87 @@
+---
+name: sonnet-implementer
+description: Execute a planned story via outside-in BDD + unit TDD. Use when the planning model (typically Opus) hands off a fully-specified plan and needs the implementation phase carried out. Returns a structured report; does not open or merge the PR.
+model: sonnet
+tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
+---
+
+You are the implementation leg of a two-model development loop. The planning model planned the work; you execute it. The PR already exists (draft). Your job is to take the plan to "all tests green, report written, branch pushed" and nothing more.
+
+## 1. Operating rules
+
+- The plan you were handed is **authoritative**. Do not expand scope.
+- Read these first, in this order, before touching code:
+  1. `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` — the loop's authoritative phases, DoR/DoD, commit convention.
+  2. `${CLAUDE_PLUGIN_ROOT}/docs/engineering-standards.md` — Clean Architecture, SOLID, KISS/YAGNI, testing tiers, style.
+  3. `${CLAUDE_PLUGIN_ROOT}/docs/security-checklist.md` — generic attack surface.
+  4. The consuming project's `CLAUDE.md` — project-specific overlays (stack, green-suite command, domain invariants).
+  5. The consuming project's project-specific docs referenced from CLAUDE.md (architecture, QA, security additions).
+  6. The PR description — sections 1 through 6 are your full spec.
+- If something in the plan genuinely blocks progress, stop and ask. Do not guess at intent.
+- Small judgment-call deviations are allowed (e.g., a helper name, a minor reorder) as long as you record them in the return report. Structural deviations (new modules, new dependencies, different public API) require stopping and asking.
+- **Tool / library substitutions must appear under "Deviations"**, not only in commit messages. If the plan named a specific tool (e.g., "per-row Zod row schema") and you chose a different mechanism (e.g., regex + manual validation), record it — what, why, and what the planned alternative would have been. A substitution at this layer is structural enough to surface explicitly.
+
+## 2. TDD rhythm (strict, outside-in)
+
+Commit on every state transition. Conventional Commits with the story id in the subject.
+
+1. **Red (acceptance).** Write the failing acceptance scenario (Gherkin or equivalent) and step definitions. Confirm it fails for the right reason. Commit: `test(<scope>): <scenario> — failing (Story <id>)`.
+2. **Red (unit).** Drop one level: write the failing unit tests for the first slice needed to drive toward green. Commit: `test(<scope>): <unit area> — failing (Story <id>)`.
+3. **Green (minimal).** Write the smallest code that turns the unit tests green without regressing anything. Commit: `feat(<scope>): <slice> — minimal green (Story <id>)`. Repeat steps 2–3 until the acceptance scenario also goes green.
+4. **Refactor.** Behaviour-preserving cleanup only. Commit: `refactor(<scope>): <what> (Story <id>)`.
+
+Never combine red and green in one commit. Never write implementation before the tests exist.
+
+## 3. Refactor-during-green allowance
+
+You may do local, behaviour-preserving cleanups while tests are green: rename a variable, extract a small helper, collapse a duplicated literal. Everything else — new abstractions, cross-module moves, touching >~20 LOC of existing code — defers to the post-review refactor phase. When you use the allowance, call it out in the "Deviations" section of the return.
+
+**60 LOC + duplication trigger.** If a newly-written function ends up over ~60 LOC with ≥2 duplicated blocks (same payload shape, different arguments), call it out explicitly in "Deviations" as a post-green refactor candidate — do not silently ship the bloat. The initial refactor slot may still defer the extraction (if it'd exceed the 20-LOC-touch rule against the just-written code), but the *signal* must be surfaced. Otherwise the planning model's Phase 4 review discovers it by eyeball, adding a round-trip.
+
+## 4. Return format (mandatory)
+
+When you finish, return **exactly** this structure. No preamble, no trailing commentary.
+
+```
+## What was built
+<3–6 lines: the acceptance scenario(s) that now pass, and the layer touches that made it happen.>
+
+## Red → green sequence
+<One bullet per test, in the order it was introduced. Each bullet: test name · commit SHA · what it proved.>
+
+## Deviations from plan
+<Each deviation in one bullet: what · why · what the alternative would have been.
+If none, write "None.">
+
+## Unknowns encountered
+<Things you couldn't resolve from the plan + docs alone. If none, write "None.">
+
+## Proposed follow-ups
+<Work you noticed but did not do because it was out of scope. Each becomes a candidate
+for a deferred-suggestion issue. If none, write "None.">
+
+## Files touched
+<Path · one-line purpose, for every file changed or created.>
+```
+
+## 5. Stop conditions
+
+You are done when **all** of:
+
+- The consuming project's declared green-suite command is green locally. (Defined in the project's `CLAUDE.md` loop-overlay section. Default if unspecified: `npm run lint && npm run build && npm test`.)
+- All commits follow the TDD rhythm rules above.
+- The return report is written (section 4).
+- The branch is pushed to `origin`.
+- The draft PR is **not** marked ready — the planning model reviews first.
+
+Do **not**: open the PR (it already exists), mark it ready, merge anything, or close suggestions. Those are the planning model's job.
+
+## 6. Never
+
+- Install new dependencies without calling it out in "Deviations" and waiting for explicit sign-off. A new dependency is a non-trivial decision (see `${CLAUDE_PLUGIN_ROOT}/docs/engineering-standards.md` § "Minimizing attack surface").
+- Refactor beyond the "during-green" allowance.
+- Add files outside the plan's declared scope.
+- Bypass pre-commit hooks (`--no-verify`, etc.).
+- Commit `.env`, credentials, real PII, or anything matching `.gitignore`.
+- Violate the consuming project's declared layer boundary (Core / Infra / CLI or equivalent — see the project's `docs/architecture.md`).
+- Use language-specific anti-patterns the consuming project's standards forbid (e.g., `any` in TypeScript-strict, float math on money in financial domains, bare `except` in Python).

--- a/product-dev-agent/docs/engineering-standards.md
+++ b/product-dev-agent/docs/engineering-standards.md
@@ -1,0 +1,110 @@
+# Engineering Standards
+
+How product-dev-agent expects code to be built. Authoritative reference for **P3** of `/product-dev-agent:review-plan` and the P3 retro-check of `/product-dev-agent:review-impl`. On conflict with a project-specific override, the consuming project's `docs/engineering-standards.md` (or CLAUDE.md loop-overlay) wins for that project.
+
+The distinction from `quality-assurance-skeleton.md` and `security-checklist.md`: engineering is about *how the code is structured and defended*; quality is about *what it promises to users*; security is about *attack surface*. P3 reviewers walk this doc plus the security checklist.
+
+## Architecture principles
+
+- **Clean Architecture (or the project's equivalent layered architecture).** Core / Infra / Adapter (the consuming project may name layers differently — Domain/Application/Infrastructure, Hexagonal Inside/Outside, etc.). The point is a strict dependency rule: business logic depends on nothing outside itself; outside dependencies plug in via interfaces the business logic owns.
+- **Ports & Adapters.** Every external dependency (database, filesystem, network, parsers, clock) is expressed as an abstraction the core owns and implemented as an adapter the core does not import. Core never imports from Infra.
+- **`Result<T, E>` over exceptions** — or the language's idiomatic equivalent (Rust `Result`, Go `(T, error)`, F#/Scala `Either`, TypeScript `Result` types). Core methods return result values; exceptions only at the outermost interface boundary, for truly unexpected failures.
+- **Constructor DI only.** Dependencies enter via the constructor (or the language's equivalent — function arguments, struct fields, etc.). No service locators, no DI containers — manual wiring at the entry point is fine for most projects.
+
+## SOLID — applied pragmatically
+
+Use SOLID where it concretely buys readability, testability, or flexibility actually needed. Violations are flagged in P3 only when they hurt something real. Ceremonial application (an interface per class, "just in case") is itself a violation of KISS.
+
+- **SRP.** A class or module does one thing. If a reviewer needs "and" to describe its responsibility, split it.
+- **OCP.** New behaviour preferably arrives as a new type implementing an existing abstraction, not as edits to existing core classes. Edit core only when the contract itself changes.
+- **LSP.** Any implementation of an abstraction behaves in all the ways core relies on, including failure modes. An adapter that throws where the abstraction says "return failure" violates this.
+- **ISP.** Abstractions are small and cohesive. A repository abstraction with methods for five unrelated queries is probably two or three abstractions wearing a trench coat.
+- **DIP.** Core depends on abstractions, not on concretions. If core imports a concrete database driver, something is wrong.
+
+## KISS
+
+The simplest thing that makes the tests green is the default. If a reviewer can propose a simpler implementation that passes the same tests, the current version loses.
+
+- No "just in case" abstractions.
+- No frameworks the project doesn't need today.
+- No configurability where a hard-coded value works and isn't a user-facing concern.
+
+## YAGNI
+
+Don't build for tomorrow's hypothetical requirement.
+
+- No speculative features.
+- No hooks, extension points, or plugin systems until at least two concrete callers exist.
+- No generics, no overloads, no configuration flags without a present user.
+
+## Minimizing attack surface
+
+Every new external input, file path, query, or dependency is scrutinized at P3. Walk `${CLAUDE_PLUGIN_ROOT}/docs/security-checklist.md` in full during every P3. A new dependency is a non-trivial decision, not a reflex.
+
+- Prefer parameterised queries / prepared statements. Never interpolate user input into query text.
+- Validate every external input at the boundary; never inside core.
+- Least-privilege file permissions on data the project owns.
+- New runtime dependencies require a one-line rationale in the PR; dev dependencies have a lower bar than runtime.
+
+## Testing tiers
+
+Every project has at least four tiers, even if the runners differ:
+
+| Tier | Purpose |
+| --- | --- |
+| Acceptance | One scenario per user-visible behaviour. Outside-in BDD: drives the design from the user's vantage. |
+| Unit | AAA pattern. Mock all abstractions for core. Tests behaviour, not implementation. |
+| Property | Invariants the domain must always satisfy (allocation conservation, associativity, ordering, etc.). |
+| Integration | Exercise adapters against the real outside thing (real DB, real filesystem). |
+
+The consuming project's CLAUDE.md loop-overlay names the specific runners (e.g., `vitest` + `quickpickle` + `fast-check` for a Node project; `pytest` + `behave` + `hypothesis` for Python; `cargo test` + `proptest` for Rust).
+
+## Coverage
+
+- **100% branch coverage on the project's domain core.** Non-negotiable. (The "core" is whatever the project's `docs/architecture.md` declares as its pure-business layer.)
+- Adapters and interface layers lower, but every branch (happy path, error path) is still exercised with intent. No "covered by accident" lines.
+- Coverage reports are advisory; the review looks at *which branches aren't covered*, not just the percentage.
+
+## TDD rhythm
+
+Outside-in, strict sequence:
+
+1. Write the failing acceptance scenario first — `test:` commit.
+2. Drop to failing unit tests for the first slice — `test:` commit.
+3. Implement the minimum to go green at the unit level — `feat:` commit.
+4. Work your way up until the acceptance scenario also goes green — more `feat:` commits as needed.
+5. Refactor while all tests stay green — `refactor:` commit.
+
+No "tests and implementation together" commits. No "write the tests after the code".
+
+## Style
+
+The consuming project's CLAUDE.md or its own engineering-standards override names the language-specific style rules (file naming, type naming, variable naming, comment policy, function-length budget). The plugin's universal rules:
+
+- **No anti-patterns the project's standards forbid.** Examples by language: TypeScript `any`, Python bare `except`, Go ignored errors, Rust `unwrap()` in non-test code, JavaScript `==`, financial code's `+ - * /` on monetary values.
+- **No comments** except when the *why* is non-obvious. Well-named identifiers are the documentation.
+- **Functions under ~50 LOC**, pure where possible.
+- **External-input validation at boundaries only**, never inside core.
+
+## Refactor-during-green allowance
+
+Obvious local cleanups — rename a variable, extract a tiny helper, collapse a duplicated literal — are allowed while tests are green, so long as behaviour is preserved and all tests still pass.
+
+Anything structural is deferred to the post-review refactor phase:
+
+- Introducing a new abstraction (interface, base class, factory).
+- Cross-module moves.
+- Touching more than ~20 LOC of existing (not newly-written) code.
+
+When the implementation agent uses the allowance, it calls it out in the return report's "Deviations" section.
+
+## Maintainability indicators used in P3
+
+Reviewers actively look for these:
+
+- **Duplication** that represents the same intent (DRY), not just coincidental resemblance.
+- **Coupling spikes** — a new cross-layer import; a Core file suddenly importing from Infra.
+- **Naming drift** — the name no longer describes what the code does after the change.
+- **Dead code** — unused exports, commented-out blocks, orphan TODOs.
+- **Over-abstraction** — a single implementation behind an interface that "might grow" (usually it won't; collapse it).
+- **Premature concurrency or caching** (YAGNI).

--- a/product-dev-agent/docs/quality-assurance-skeleton.md
+++ b/product-dev-agent/docs/quality-assurance-skeleton.md
@@ -1,0 +1,56 @@
+# Quality Assurance — Skeleton
+
+Skeleton for the consuming project's QA invariants. Walked during every **P2** of `/product-dev-agent:review-plan` (against the plan) and again at the P2 retro-check of `/product-dev-agent:review-impl` (against the implementation).
+
+The plugin owns the **framing** and the **observability + non-goals** sections — universal to any product. The consuming project owns the **domain invariants**: what its product promises to its users.
+
+The distinction from `engineering-standards.md` and `security-checklist.md`: QA is about *what the product promises to its users*, not *how the code is structured* or *how we defend against attackers*.
+
+## Domain invariants (consuming project fills in)
+
+Each invariant should be:
+
+- A user-visible promise (not an implementation detail).
+- Checkable — there's a way to assert it from outside the code.
+- Tied to a class of bug it prevents.
+
+Examples by domain:
+
+- **Financial / accounting.** Sum of debits equals sum of credits. Currency consistency per account. Allocations conserve to the cent. Determinism of historical recalculations. Validity-window correctness.
+- **Identity / auth.** No user can read another user's data via any API path. Credentials never appear in logs. Sessions invalidate on password change.
+- **Medical / health.** PHI redacted in error paths. Patient ID resolves consistently across services. Audit trail covers every read.
+- **Messaging / chat.** Messages are delivered at-least-once. Read receipts arrive in order with the messages they reference.
+
+The consuming project's `docs/quality-assurance.md` enumerates its own invariants in the same shape.
+
+## Privacy & data sovereignty (consuming project may add)
+
+Generic baseline:
+
+- The product's data-sovereignty promises are explicit. If the product claims "local-only", no network egress under any flag. If the product is multi-tenant, tenant isolation is a P2 invariant.
+- PII is never logged verbatim. Redaction is the default; plaintext requires explicit opt-in. Test fixtures contain synthetic data only.
+- The user (or tenant) can export every byte of their data at any time, in a documented and re-importable format. Export is complete — no "admin-only" fields, no opaque blobs.
+- Files the product creates with sensitive data have least-privilege permissions.
+
+## Observability of failures
+
+- **Human-readable error messages at the interface boundary.** A user never sees a raw stack trace, a raw failure payload, or a type name. Errors translate to a sentence the user can act on.
+- **Exit codes / HTTP status codes reflect outcome.** `0` for full success, non-zero for any failure (or appropriate HTTP status for web). Scripts and clients can branch on it reliably.
+- **Logs are structured and searchable.** A failure that doesn't surface in the logs is a failure that didn't happen, from operations' perspective.
+
+## Coherence with the product brief
+
+- **User journeys reachable.** Every journey documented in the project's product brief must remain achievable through the project's interface. A refactor that orphans a journey is a P2 blocker, not a deferred item.
+- **Truthfulness of human-readable output.** Where the product summarises numerical results in prose ("you'll be short €240 in March", "3 alerts triggered"), the prose must match the underlying calculation the user can reproduce.
+- **Audit trail.** Every user action that changes state leaves a traceable entry. "What changed and why" must be answerable from the project's own data.
+
+## Non-goals (to preempt false-positive reviews)
+
+The consuming project enumerates these explicitly so reviewers don't flag missing features that were intentionally out of scope. Common examples:
+
+- "Single-user local tool — no multi-user concurrency."
+- "Best-effort delivery — no guaranteed exactly-once."
+- "Self-hosted — no cloud-managed SLAs."
+- "Audit trail, not regulatory compliance — the tool records but isn't a notary."
+
+Without explicit non-goals, P2 review can drift into "you should add X" critiques for things the project deliberately doesn't promise.

--- a/product-dev-agent/docs/retrospective-format.md
+++ b/product-dev-agent/docs/retrospective-format.md
@@ -1,0 +1,63 @@
+# Retrospective Format
+
+The format for the per-story retrospective written by `/product-dev-agent:retro`. The retrospective is the loop's mechanism for surfacing lessons and folding them back into the rules.
+
+The retrospective file lives at `docs/retrospectives/story-<id>.md` in the consuming repo. The template lives at `${CLAUDE_PLUGIN_ROOT}/templates/retrospective-template.md` and is also installed by `/bootstrap` to `docs/retrospectives/_template.md`.
+
+## Structure
+
+```markdown
+# Story <id> retrospective
+
+**PR:** <url>  **Closed:** YYYY-MM-DD
+
+## Keep
+-
+
+## Change
+-
+
+## Try
+-
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+|      |                |        |
+```
+
+Optional sections (use when relevant):
+
+- **Loop metrics.** Counts: agents invoked, commits, blockers caught at Phase 4, tests added, deps added.
+- **Carryovers resolved.** Did the previous story's "Try" items prove out?
+
+## Field guidance
+
+- **Keep** — what worked and should be repeated on the next story. Be specific about *what* worked, not vague approval.
+- **Change** — something that happened this story and should be different next time. Be concrete: "the plan under-specified the migration rollback path" beats "better planning". A "Change" without a concrete next-time action is venting, not a retrospective.
+- **Try** — an experiment for the *next* story only. If it proves itself, it graduates to "Keep" (and usually into CLAUDE.md / a `docs/` file). If it doesn't, it sunsets — don't carry failed experiments forward.
+- **Action items** — concrete and assignable. `Where it lands` is one of: in-PR edit (which file), or an issue link. `Status` is `done`, `open`, or a link.
+
+## The "no rule in retro alone" principle
+
+If the retro identifies a new rule, that rule must land in CLAUDE.md, a `docs/*.md` file, a template, or — when it's generic — be filed as a follow-up against the plugin. Rules that live only in the retro file are inert: future-you reads CLAUDE.md, not retro/story-2.4.md.
+
+`/product-dev-agent:retro` enforces this by requiring any "graduating Try" or new-rule "Change" to come with a same-PR edit to the relevant file.
+
+## Carryover discipline
+
+Each retro must report on the previous story's "Try" items. Three outcomes:
+
+- **Worked.** Graduate to "Keep" + a CLAUDE.md / `docs/` rule.
+- **Didn't work.** Note why; the experiment sunsets.
+- **Inconclusive.** Carry forward as a "Try" again, or sunset if it's been carried twice.
+
+This prevents the retros from becoming a graveyard of forgotten experiments.
+
+## What the retro is *not*
+
+- Not a place for venting without action items.
+- Not a place to relitigate plan decisions that were ratified in Phase 2.
+- Not a substitute for the suggestion log — that's for plan-time suggestions; the retro is for execution-time learnings.
+- Not a rule storage location — rules go where they will be read.

--- a/product-dev-agent/docs/security-checklist.md
+++ b/product-dev-agent/docs/security-checklist.md
@@ -1,0 +1,52 @@
+# Security Checklist
+
+Walkable attack-surface checklist. Part of the **P3** critical review (`/product-dev-agent:review-plan`), run against the plan, and again against the implementation diff (`/product-dev-agent:review-impl`). Cross-referenced by `${CLAUDE_PLUGIN_ROOT}/docs/engineering-standards.md`.
+
+A failure of any item at P3-retro is a **merge blocker**, not a deferred suggestion.
+
+The consuming project layers domain-specific items on top via its own `docs/security-checklist.md` (e.g. money-precision rules for financial apps, PHI handling for medical apps, KYC for identity systems).
+
+## Data integrity
+
+- [ ] Domain invariants the project enforces (e.g. balance equations, foreign-key constraints, optimistic concurrency tokens) are checked **at write time**, before the data reaches the persistence layer.
+- [ ] All persisted operations execute via parameterised queries / prepared statements / equivalent. No string concatenation or template-literal interpolation into query text.
+- [ ] Migrations are numbered and idempotent. Running the migrator twice on a fresh data store is a no-op after the first run.
+- [ ] No primary key relies on client-supplied data for uniqueness.
+- [ ] If the project has append-only / audit-log tables, no `UPDATE` or `DELETE` statements anywhere against them. Corrections are new entries.
+
+## Validation & boundaries
+
+- [ ] Every external input is validated at the boundary: CLI args, HTTP request bodies, file reads, message-queue payloads, configuration parsing. Validation happens before the data reaches core business logic.
+- [ ] Core business logic contains no calls to external systems (filesystem, network, OS-process, time-of-day) — those go through the project's port abstractions.
+- [ ] No user-controlled path strings reach filesystem APIs without prior normalisation; no path traversal (`../`) possible via user input.
+- [ ] Interface layer (CLI/HTTP/RPC) refuses unknown inputs (unknown flags, unknown fields).
+
+## Secrets & PII
+
+- [ ] Logs and error messages redact PII (names, identifiers, account numbers, email addresses, anything personally identifying in the project's domain). Redaction is the default; plaintext logging requires an explicit per-call opt-in.
+- [ ] No `.env`, credentials files, API tokens, or production data committed in any branch. `.gitignore` covers them.
+- [ ] Test fixtures contain synthetic data only. No real personal data in source control.
+- [ ] Files the project creates that hold sensitive data are created with least-privilege permissions (e.g. `0600` on POSIX). The consuming project's CLAUDE.md names the specific paths.
+- [ ] No logging of raw external-input rows (CSV rows, request bodies, etc.) without PII redaction.
+
+## Supply chain
+
+- [ ] Project's audit command is clean of `high` and `critical` advisories. Moderate findings are noted; anything higher becomes an immediate fix issue.
+- [ ] New runtime dependencies require a one-line justification in the PR.
+- [ ] Dependency-update PRs (Dependabot or equivalent) walk this full checklist before merge.
+- [ ] Lock file / pinned dependency manifest is committed and consistent with the dependency declaration.
+
+## Error handling
+
+- [ ] Core returns result-typed values; no thrown exceptions inside core.
+- [ ] Adapters catch only exceptions they can translate to a result value; others propagate.
+- [ ] No bare `catch` / `except` blocks that swallow errors.
+- [ ] Interface boundary converts result failures to a human-readable message plus a non-zero exit code (or appropriate HTTP status, etc.).
+
+## Review cadence
+
+- Run this checklist **in full** at:
+  - P3 of the pre-implementation critical review (against the plan).
+  - P3 retro-check of the post-implementation review (against the diff).
+- At every Dependabot PR review (short-form: supply chain only is mandatory, full walk if the bump touches a critical-path dep).
+- Any box that cannot be ticked must either be fixed or resolved via a documented exception (GitHub issue referenced in the suggestion log).

--- a/product-dev-agent/docs/workflow.md
+++ b/product-dev-agent/docs/workflow.md
@@ -1,0 +1,127 @@
+# product-dev-agent — Workflow
+
+The authoritative reference for the loop. All skills (`/product-dev-agent:*`) defer to this document on any question of phases, gates, model tiers, or commit conventions. Consuming projects override only what their `CLAUDE.md` loop-overlay explicitly names.
+
+## Loop overview
+
+Two formal gates:
+
+- **Definition of Ready (DoR)** — met when phases 1 and 2 below are complete.
+- **Definition of Done (DoD)** — met when phases 3, 4, 5, and the merge checklist are all complete (see § "Definition of Done").
+
+## Phases
+
+Phases 1 and 2 compose DoR. Phases 3 and 4 drive to DoD. Phase 5 must complete before merge.
+
+### Phase 1 — Plan
+
+Driven by `/product-dev-agent:plan-story <id>`. Run by the planning model (typically Opus).
+
+- Collect intent (2–4 questions to the user).
+- Diverge on at least 3 solutions.
+- Converge on one with explicit rationale.
+- Capture acceptance behaviour (Gherkin or project equivalent).
+- Open draft PR with sections 1–6 of the PR template filled.
+- Commit plan file at `docs/plans/story-<id>.md` mirroring the PR plus a "Plan for Sonnet" subsection.
+
+**Exit:** draft PR exists with template sections 1–6 filled.
+
+### Phase 2 — Critical review on the plan
+
+Driven by `/product-dev-agent:review-plan`. Run by the planning model. Three independent passes before implementation:
+
+- **P1 — Functional.** Plan satisfies target FR/NFRs in the consuming project's PRD; acceptance scenarios complete and unambiguous.
+- **P2 — Product Quality / QA.** Walk `${CLAUDE_PLUGIN_ROOT}/docs/quality-assurance-skeleton.md` + the project's domain QA doc.
+- **P3 — Engineering.** Walk `${CLAUDE_PLUGIN_ROOT}/docs/engineering-standards.md` + `${CLAUDE_PLUGIN_ROOT}/docs/security-checklist.md` + the project's `docs/architecture.md`.
+
+Each suggestion tagged `adopted` / `deferred` / `rejected` in the Suggestion Log (PR section 7). `deferred` items must link a GitHub issue from the deferred-suggestion template. `rejected` items carry a one-line reason.
+
+**Exit (DoR gate):** no un-tagged suggestions; plan rewritten to incorporate every `adopted`; every `deferred` has an issue link.
+
+### Phase 3 — Implement
+
+Driven by `/product-dev-agent:implement`. Hands off to the `sonnet-implementer` agent (executed by the implementation model, typically Sonnet).
+
+The agent writes a failing acceptance scenario first, drives down to failing unit tests, makes green, commits per state. Returns the structured report (see `${CLAUDE_PLUGIN_ROOT}/agents/sonnet-implementer.md` § 4).
+
+**Exit:** all tests green, report delivered, branch pushed. PR not yet marked ready.
+
+### Phase 4 — Code review on the implementation
+
+Driven by `/product-dev-agent:review-impl`. Run by the planning model. Re-run P1/P2/P3 **against the actual code** (not the plan):
+
+- **P1 retro-check** — acceptance scenarios + unit tests actually deliver the intent. Audit each `this test fails if …` claim against the production path it guards, not just any path.
+- **P2 retro-check** — walk QA doc against the diff. **Mock diversity check:** when the diff includes structured output (JSON, tables, machine-readable formats), spot-check at least one assertion against a non-default mock fixture.
+- **P3 retro-check** — walk engineering-standards + security-checklist against the diff.
+
+Produce a refactor plan; blockers are fixed before merge, not deferred. Delegate execution back to the implementation agent.
+
+**Exit:** refactor merged back into the branch, CI green.
+
+### Phase 5 — Retrospective
+
+Driven by `/product-dev-agent:retro <id>`. Keep/Change/Try at `docs/retrospectives/story-<id>.md`. Action items either land in the same PR or become follow-up issues. New rules land in CLAUDE.md / `docs/` in the same PR — never in a retro file alone.
+
+**Exit:** file committed; PR section 9 filled; merge checklist (section 10) ready for the user. Merge is user-gated.
+
+## Model tier
+
+- **Planning model (default: Opus)** — planning, 3-phase critical review, code review, refactor planning, retrospective synthesis.
+- **Implementation model (default: Sonnet)** — failing tests, implementation, refactor execution.
+- **Cheaper tier (default: Haiku)** — not used in v0.
+
+Consuming projects can override via their CLAUDE.md loop-overlay if budget or capability constraints differ.
+
+## Commit convention inside a story
+
+State transitions. Story id in every subject, e.g. `(Story 1.3)`.
+
+- `test(<scope>): <scenario> — failing` (red)
+- `feat(<scope>): <scenario> — minimal green` (green)
+- `refactor(<scope>): <what>` (behaviour-preserving cleanup)
+
+**Green-on-landing `test:` commits are acceptable** when the earlier `feat:` commit already covered the tested branches and the subsequent `test:` is adding coverage for a sibling condition. Call it out in the return report's "Deviations" — the TDD-by-intent invariant (the test *would* have failed against a stripped-down implementation) still holds.
+
+**Empty `refactor:` commit with a justification message** is an acceptable pattern when the refactor slot has nothing to clean up. Keeps the commit sequence aligned with the plan and documents the review.
+
+**Commit subjects: summary over enumeration.** Prefer a summary verb in the subject rather than listing every scenario the commit covers. Scenario details belong in the commit body, not the subject.
+
+**Plan in slices, not tests-per-commit.** When drafting the TDD commit sequence, one slice = one behaviour + its tests + the minimal code to make them green (often one acceptance scenario). Over-decomposing into per-assertion commits invites green-on-landing collapses that divorce the plan from execution. Target 6–10 commits per story; only split further when a slice's failing test genuinely cannot turn green without an intermediate `feat:` step.
+
+Squash on merge is optional.
+
+## Refactor-during-green policy
+
+Obvious local cleanups (rename, extract small helper, collapse a duplicated literal) are allowed while tests are green if behaviour is preserved. Structural changes — new abstractions, cross-module moves, touching >~20 LOC of existing code — defer to the refactor phase. The implementation agent calls this out in the return report.
+
+## Story sizing
+
+One PR per story. More than ~3 acceptance scenarios, or work likely to exceed one implementation round → split.
+
+**Adapter stories need coarser slices, not finer.** For a bank-CSV adapter, file-format reader, export target, or any boundary adapter, the minimum-viable implementation *intrinsically* includes a bundle of behaviours — encoding tolerance, per-row isolation, header validation, delimiter handling, basic invariants. Planning a separate `test:` + `feat:` pair for each invites green-on-landing collapses, because the first `feat:` that satisfies the happy path already covers the others. Pattern: **one slice for the adapter's "obvious basics"** (happy path + the invariants any correct implementation satisfies) + **one slice per deliberately-counterintuitive rule** (e.g., a sign-inversion, a locale quirk, a boundary edge case). Target 5–7 commits for adapter stories; finer slicing is for stories with genuinely independent behaviours.
+
+## Maintenance sub-loop
+
+Driven by `/product-dev-agent:maintenance`. Runs **before the planning phase of every new story**. Unconditional.
+
+- **Triage open issues:** re-prioritise, close stale, confirm `deferred-suggestion` items still relevant.
+- **Review open Dependabot PRs:** CI + diff + changelog. Routine bumps (patch or minor, any dep) → merge directly after CI + changelog check, no DoR/DoD/retro. **Major bumps** of runtime deps, **critical-path major bumps**, or any **breaking change** flagged in a changelog → issue + full story through the main loop. Minor/patch bumps of critical-path deps still merge routinely, but with a slightly closer changelog read; if anything looks non-trivial, escalate.
+- **Audit:** language-specific (e.g. `npm audit`). `high`/`critical` → immediate issue, fix before the next story.
+
+Lighter than feature work. Aggregate learnings surface at the next per-story retrospective.
+
+## Definition of Done
+
+A story is merge-ready only when **all** of:
+
+1. Consuming project's green-suite command — green on CI.
+2. Migrations idempotent (where applicable).
+3. Every new invariant in the project's domain core has a property test (or domain equivalent).
+4. No language-specific anti-patterns left behind (the project's CLAUDE.md names them).
+5. Commits follow the `test:` / `feat:` / `refactor:` rhythm. Each subject references the story id.
+6. All 10 sections of the PR template are filled — no `TBD` at merge.
+7. Suggestion log has no un-tagged items. Every `deferred` row links a GitHub issue.
+8. P1 / P2 / P3 retro-checks (Phase 4) all pass.
+9. Retrospective file committed at `docs/retrospectives/story-<id>.md`.
+10. Any new rule or constraint from the retrospective lands in the same PR as a CLAUDE.md / `docs/` / template edit.
+11. User has ticked the merge checklist.

--- a/product-dev-agent/hooks/hooks.json
+++ b/product-dev-agent/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/session-start-reminder.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/product-dev-agent/scripts/bootstrap.sh
+++ b/product-dev-agent/scripts/bootstrap.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# product-dev-agent bootstrap
+#
+# Installs plugin templates into the consumer repo at GitHub-required paths
+# and appends a reference snippet to CLAUDE.md. Idempotent.
+#
+# Usage:
+#   bash bootstrap.sh "<consumer-repo-root>"
+#   bash bootstrap.sh --check "<consumer-repo-root>"
+#
+# --check: report drift between consumer copies and plugin canon. Writes nothing.
+#          Exits non-zero if anything is drifted or missing.
+
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+CHECK_MODE=0
+if [ "${1:-}" = "--check" ]; then
+  CHECK_MODE=1
+  shift
+fi
+
+REPO_ROOT="${1:-$(pwd)}"
+
+if [ ! -d "${REPO_ROOT}/.git" ]; then
+  echo "ERROR: ${REPO_ROOT} is not a git repository (no .git/ directory)." >&2
+  echo "       Run from the consumer repo root, or pass it as the first arg." >&2
+  exit 2
+fi
+
+# Source → destination mapping. Edit here when adding new templates.
+declare -a MAPPINGS=(
+  "templates/pull_request_template.md::.github/pull_request_template.md"
+  "templates/deferred-suggestion-issue.md::.github/ISSUE_TEMPLATE/deferred-suggestion.md"
+  "templates/retrospective-template.md::docs/retrospectives/_template.md"
+)
+
+SNIPPET_SRC="${PLUGIN_ROOT}/templates/claude-md-snippet.md"
+SNIPPET_MARKER="<!-- product-dev-agent:snippet -->"
+CLAUDE_MD="${REPO_ROOT}/CLAUDE.md"
+
+drift_count=0
+written_count=0
+unchanged_count=0
+
+report() {
+  local file="$1"
+  local status="$2"
+  printf "  %-50s %s\n" "${file}" "${status}"
+}
+
+for mapping in "${MAPPINGS[@]}"; do
+  src="${PLUGIN_ROOT}/${mapping%%::*}"
+  rel_dst="${mapping##*::}"
+  dst="${REPO_ROOT}/${rel_dst}"
+
+  if [ ! -f "${src}" ]; then
+    echo "ERROR: plugin template missing: ${src}" >&2
+    exit 3
+  fi
+
+  if [ ! -f "${dst}" ]; then
+    if [ "${CHECK_MODE}" -eq 1 ]; then
+      report "${rel_dst}" "MISSING"
+      drift_count=$((drift_count + 1))
+    else
+      mkdir -p "$(dirname "${dst}")"
+      cp "${src}" "${dst}"
+      report "${rel_dst}" "installed"
+      written_count=$((written_count + 1))
+    fi
+    continue
+  fi
+
+  if cmp -s "${src}" "${dst}"; then
+    report "${rel_dst}" "up-to-date"
+    unchanged_count=$((unchanged_count + 1))
+  else
+    if [ "${CHECK_MODE}" -eq 1 ]; then
+      report "${rel_dst}" "DRIFTED (consumer differs from plugin canon)"
+      drift_count=$((drift_count + 1))
+    else
+      cp "${src}" "${dst}"
+      report "${rel_dst}" "updated (overwritten)"
+      written_count=$((written_count + 1))
+    fi
+  fi
+done
+
+# CLAUDE.md snippet
+if [ ! -f "${CLAUDE_MD}" ]; then
+  if [ "${CHECK_MODE}" -eq 1 ]; then
+    report "CLAUDE.md (snippet)" "MISSING (no CLAUDE.md)"
+    drift_count=$((drift_count + 1))
+  else
+    cp "${SNIPPET_SRC}" "${CLAUDE_MD}"
+    report "CLAUDE.md (snippet)" "created from snippet"
+    written_count=$((written_count + 1))
+  fi
+elif grep -qF "${SNIPPET_MARKER}" "${CLAUDE_MD}"; then
+  report "CLAUDE.md (snippet)" "already present"
+  unchanged_count=$((unchanged_count + 1))
+else
+  if [ "${CHECK_MODE}" -eq 1 ]; then
+    report "CLAUDE.md (snippet)" "MISSING (no marker found)"
+    drift_count=$((drift_count + 1))
+  else
+    {
+      echo
+      cat "${SNIPPET_SRC}"
+    } >> "${CLAUDE_MD}"
+    report "CLAUDE.md (snippet)" "appended"
+    written_count=$((written_count + 1))
+  fi
+fi
+
+echo
+
+if [ "${CHECK_MODE}" -eq 1 ]; then
+  echo "check: ${unchanged_count} up-to-date, ${drift_count} drifted/missing"
+  if [ "${drift_count}" -gt 0 ]; then
+    echo "Re-run without --check to overwrite consumer copies with plugin canon," >&2
+    echo "or reconcile manually if the consumer has intentional local modifications." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+echo "bootstrap: ${written_count} written, ${unchanged_count} unchanged"
+echo
+echo "Next steps:"
+echo "  1. Review the appended CLAUDE.md snippet — fill in the loop-overlay placeholders."
+echo "  2. Add the recommended permissions allow-list to .claude/settings.json (see snippet)."
+echo "  3. Run /product-dev-agent:maintenance, then /product-dev-agent:plan-story <id>."

--- a/product-dev-agent/scripts/session-start-reminder.sh
+++ b/product-dev-agent/scripts/session-start-reminder.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# product-dev-agent SessionStart reminder
+#
+# Non-blocking. Prints a one-line nudge if the consumer repo is missing
+# the plugin's bootstrapped templates. Stays quiet otherwise.
+#
+# Stdout from a hook is shown to the user; we keep it minimal.
+
+set -eu
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Only nudge if we're inside a git repo. Avoids noise in scratch dirs.
+if [ ! -d "${REPO_ROOT}/.git" ]; then
+  exit 0
+fi
+
+# Quick tri-state check.
+missing=0
+[ ! -f "${REPO_ROOT}/.github/pull_request_template.md" ] && missing=$((missing + 1))
+[ ! -f "${REPO_ROOT}/.github/ISSUE_TEMPLATE/deferred-suggestion.md" ] && missing=$((missing + 1))
+
+if [ -f "${REPO_ROOT}/CLAUDE.md" ]; then
+  if ! grep -qF "<!-- product-dev-agent:snippet -->" "${REPO_ROOT}/CLAUDE.md"; then
+    missing=$((missing + 1))
+  fi
+else
+  missing=$((missing + 1))
+fi
+
+if [ "${missing}" -gt 0 ]; then
+  echo "[product-dev-agent] ${missing} bootstrap artifact(s) missing or unreferenced. Run /product-dev-agent:bootstrap to install."
+fi

--- a/product-dev-agent/skills/bootstrap/SKILL.md
+++ b/product-dev-agent/skills/bootstrap/SKILL.md
@@ -1,0 +1,58 @@
+---
+description: Install product-dev-agent's templates and CLAUDE.md snippet into a consuming project. One-shot per project. Supports --check to detect drift between consumer copies and plugin canon. Use when a user installs the plugin in a new repo or runs "/bootstrap".
+---
+
+# /product-dev-agent:bootstrap
+
+You are running the **one-shot bootstrap** for product-dev-agent in a new consumer project. Use `${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.sh` as the executor.
+
+`$ARGUMENTS` may contain `--check` to run drift detection without writing.
+
+## What bootstrap does
+
+Copies plugin canon into the consumer's repo at GitHub-required paths and appends a reference snippet to the consumer's CLAUDE.md. Idempotent: re-running on an already-bootstrapped repo is a no-op.
+
+### Files installed
+
+| Source (in plugin) | Destination (in consumer) |
+| --- | --- |
+| `${CLAUDE_PLUGIN_ROOT}/templates/pull_request_template.md` | `.github/pull_request_template.md` |
+| `${CLAUDE_PLUGIN_ROOT}/templates/deferred-suggestion-issue.md` | `.github/ISSUE_TEMPLATE/deferred-suggestion.md` |
+| `${CLAUDE_PLUGIN_ROOT}/templates/retrospective-template.md` | `docs/retrospectives/_template.md` |
+| `${CLAUDE_PLUGIN_ROOT}/templates/claude-md-snippet.md` (appended) | `CLAUDE.md` (appended once) |
+
+GitHub reads PR and issue templates from the consumer's `.github/` directory — that's why the plugin can't host them itself; it can only ship canon and copy on demand.
+
+## Default workflow
+
+1. Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.sh "<consumer-repo-root>"`.
+2. The script:
+   - Creates `.github/` and `.github/ISSUE_TEMPLATE/` if missing.
+   - Copies each template to its destination, with a checksum header marking it as plugin-sourced.
+   - Appends the CLAUDE.md snippet **only if** the marker `<!-- product-dev-agent:snippet -->` is not already present.
+   - Reports each file it touched.
+3. Tell the user:
+   - What was installed / what was already up to date.
+   - The recommended `permissions` allow-list to add to `.claude/settings.json` (printed by the script — don't try to edit settings.json yourself, that's a user decision).
+   - The next command to run: `/product-dev-agent:maintenance` then `/product-dev-agent:plan-story <id>`.
+
+## --check mode
+
+Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.sh --check "<consumer-repo-root>"`.
+
+The script:
+- Diffs each consumer-side template against the plugin's canon.
+- Reports per-file: `up-to-date`, `drifted (consumer modified)`, `outdated (plugin newer)`, or `missing`.
+- Exits non-zero if anything is drifted or missing.
+- Writes nothing.
+
+If drift is reported, ask the user how to resolve:
+- Re-run `/bootstrap` to overwrite with plugin canon.
+- Manually reconcile if the consumer has intentional local modifications.
+
+## Guardrails
+
+- **Idempotent only via the marker.** The CLAUDE.md snippet is appended once and gated by `<!-- product-dev-agent:snippet -->`. Removing the marker manually will cause a duplicate append on next run.
+- **Don't edit consumer's `.claude/settings.json`.** Plugins shouldn't write to a consumer's permissions file. Print the recommended allow-list and let the user decide.
+- **Don't overwrite without `--check` first** if templates already exist. The script defaults to overwrite, but you should run `--check` first when bootstrapping a repo that may have customised templates.
+- **Run from the consumer repo root.** The script expects to find a `.git/` directory there as a sanity check.

--- a/product-dev-agent/skills/implement/SKILL.md
+++ b/product-dev-agent/skills/implement/SKILL.md
@@ -1,0 +1,65 @@
+---
+description: Phase 3 of the product-dev-agent loop. Hand off the reviewed plan to the sonnet-implementer agent for outside-in BDD + unit TDD execution. Use after /review-plan passes its exit gate, or when the user says "implement", "hand off to sonnet", or "/implement".
+---
+
+# /product-dev-agent:implement
+
+You are running **Phase 3** of the product-dev-agent loop. Read `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` § "Phase 3 — Implement" before starting.
+
+## Pre-flight check
+
+Before invoking the agent, verify the **Definition of Ready** is met (from Phase 2):
+
+1. Draft PR exists with sections 1–6 filled (no `TBD`).
+2. Suggestion log (PR section 7) has no untagged rows.
+3. Every `deferred` row links a GitHub issue.
+4. Plan file at `docs/plans/story-<id>.md` is committed.
+
+If any check fails, stop and tell the user which gate is open. Do not proceed.
+
+## Your job
+
+Invoke the `sonnet-implementer` agent (shipped at `${CLAUDE_PLUGIN_ROOT}/agents/sonnet-implementer.md`) via the `Agent` tool, with the PR as its full spec.
+
+### Invocation
+
+Preferred: `subagent_type: "sonnet-implementer"`.
+
+Harness fallback: if the harness doesn't register custom plugin agents as `subagent_type` values (a known limitation observed in some Claude Code versions), fall back to:
+- `subagent_type: "general-purpose"`
+- `model: "sonnet"` override
+- Inline the full content of `${CLAUDE_PLUGIN_ROOT}/agents/sonnet-implementer.md` § 1–6 into the agent prompt as the operating brief.
+
+### Prompt template
+
+```
+You are the sonnet-implementer for product-dev-agent. Story id: <id>. PR: <url>.
+
+Operating brief (read in full):
+- ${CLAUDE_PLUGIN_ROOT}/agents/sonnet-implementer.md
+- ${CLAUDE_PLUGIN_ROOT}/docs/workflow.md
+- ${CLAUDE_PLUGIN_ROOT}/docs/engineering-standards.md
+- ${CLAUDE_PLUGIN_ROOT}/docs/security-checklist.md
+- The consuming project's CLAUDE.md (loop overlay + project-specific rules).
+
+Your spec is PR sections 1–6 plus the plan file at docs/plans/story-<id>.md.
+
+Stop conditions: see ${CLAUDE_PLUGIN_ROOT}/agents/sonnet-implementer.md § 5.
+
+Return format: see ${CLAUDE_PLUGIN_ROOT}/agents/sonnet-implementer.md § 4. Emit it
+verbatim, no preamble, no trailing commentary.
+```
+
+## After the agent returns
+
+1. Capture the agent's structured return report verbatim.
+2. Append it as PR section 8 (Sonnet's learnings).
+3. Verify the agent's stop conditions held: green-suite passed, branch pushed, PR still draft.
+4. Hand off to `/product-dev-agent:review-impl` next.
+
+## Guardrails
+
+- **Do not edit production code yourself.** Phase 3 is delegation. If you find yourself reaching for `Edit`, you've drifted into Phase 4.
+- **Do not mark the PR ready.** That's a merge-checklist item, gated by Phase 4.
+- **Do not summarise or rewrite the agent's return report.** Paste it verbatim into PR section 8 — the structure is the contract.
+- **Block on missing DoR.** A missing suggestion-log row, an unfilled PR section, or an unlinked deferred issue means Phase 2 isn't done. Send the user back to `/review-plan`, don't paper over it.

--- a/product-dev-agent/skills/maintenance/SKILL.md
+++ b/product-dev-agent/skills/maintenance/SKILL.md
@@ -1,0 +1,73 @@
+---
+description: The product-dev-agent maintenance sub-loop. Triage open issues, review Dependabot PRs, and walk npm audit. Runs unconditionally before every new story's planning phase. Use when starting a new story or when the user says "maintenance", "/maintenance", or "before we plan the next story".
+---
+
+# /product-dev-agent:maintenance
+
+You are running the **maintenance sub-loop** of the product-dev-agent loop. Read `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` § "Maintenance sub-loop" before starting.
+
+This sub-loop runs **unconditionally before the planning phase of every new story**. It is lighter than feature work; aggregate learnings surface at the next per-story retrospective.
+
+## Three passes
+
+### 1. Triage open issues
+
+Use the GitHub MCP tools to list open issues on the consuming project's repo.
+
+For each:
+- **Re-prioritise.** Is it still relevant given recent stories?
+- **Close stale.** Issues whose context has changed and are no longer valid → close with a reason.
+- **Confirm `deferred-suggestion` issues.** Each was filed during a critical review. Is the suggestion still worth doing? If not → close. If yes → leave open, optionally add a comment with current relevance.
+
+### 2. Review open Dependabot PRs
+
+For each open Dependabot PR:
+
+1. Check CI is green.
+2. Read the diff.
+3. Read the changelog of the bumped dep.
+4. Apply the merge policy:
+   - **Patch / minor of any dep** → merge directly after CI + changelog check. No DoR/DoD/retro.
+   - **Patch / minor of a critical-path dep** → merge directly, but read the changelog more closely (deprecations, removed exports, runtime behaviour notes). Escalate if anything looks non-trivial.
+   - **Major bump of any runtime dep** OR **major bump of a critical-path dep** OR **any breaking change flagged in changelog** → file an issue and run a full story through the main loop.
+
+The consuming project's "critical-path deps" list lives in its `CLAUDE.md` loop-overlay. If unspecified, default to: testing framework, primary database driver, primary validation library, CLI framework.
+
+### 3. `npm audit` (or language equivalent)
+
+Run the consuming project's audit command. Default: `npm audit`.
+
+- **`high` / `critical` advisories** → file an immediate issue. Fix before the next story starts.
+- **`moderate`** → noted in the maintenance pass; not a blocker.
+- **`low` / `info`** → ignored unless they cluster.
+
+## Output
+
+Produce a 5–10 line summary:
+
+```
+## Maintenance pass · <date>
+
+Issues triaged: <n> closed, <n> re-prioritised, <n> left open.
+Dependabot PRs: <n> merged, <n> escalated to story.
+npm audit: <severity counts>. Action: <none | issue #X filed>.
+
+Hand-off to /plan-story.
+```
+
+## Exit gate
+
+Maintenance is done when:
+
+- Open issues are walked.
+- Open Dependabot PRs are walked.
+- Audit is run.
+- Summary is posted (PR comment, or chat message if no PR exists yet).
+
+Hand off to `/product-dev-agent:plan-story` next.
+
+## Guardrails
+
+- **Do not skip a Dependabot PR because "it looks routine".** Read the changelog every time.
+- **Do not auto-merge majors.** Even Dependabot for a major bump needs a story.
+- **Do not let high/critical audits coexist with new feature work.** Fix-or-mitigate before planning the next story.

--- a/product-dev-agent/skills/plan-story/SKILL.md
+++ b/product-dev-agent/skills/plan-story/SKILL.md
@@ -1,0 +1,41 @@
+---
+description: Phase 1 of the product-dev-agent loop. Drive the planning of a single story from intent to a fully-specified plan ready for critical review. Use when the user says "let's plan story X", "/plan-story X", or kicks off a new feature.
+---
+
+# /product-dev-agent:plan-story
+
+You are running **Phase 1** of the product-dev-agent loop. Read `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` § "Phase 1 — Plan" before starting.
+
+`$ARGUMENTS` should contain the story id (e.g. `2.4`, `M.1`). If empty, ask the user for it.
+
+## Your job
+
+Take the user from raw intent to a **fully-specified plan** that the next phase (`/product-dev-agent:review-plan`) can critique. Phase 1 ends when:
+
+1. Intent is captured in 2–4 sentences.
+2. **At least 3 alternatives** were considered, with one-line reasons each was set aside.
+3. The selected approach is justified against the alternatives.
+4. **Gherkin scenarios** (or the project's equivalent acceptance format) are written and unambiguous.
+5. A **draft PR** exists on the consuming project's GitHub repo with sections 1–6 of `${CLAUDE_PLUGIN_ROOT}/templates/pull_request_template.md` filled in.
+6. The plan file lives at `docs/plans/story-<id>.md` in the consuming repo, mirroring the PR sections 1–6 plus a "Plan for Sonnet" detailed enough that the implementation phase needs no clarifying questions.
+
+## Workflow
+
+1. **Run the maintenance sub-loop first.** Before planning a new story, invoke `/product-dev-agent:maintenance` (triage open issues, review Dependabot PRs, `npm audit`). This is unconditional per workflow.md § 6.7.
+2. **Collect intent.** Ask the user 2–4 questions about the goal, the user pain, and any constraints.
+3. **Diverge.** Generate at least 3 distinct technical approaches. For each: 1-line description + 1-line tradeoff.
+4. **Converge.** Recommend one. State why it beats the others.
+5. **Write Gherkin.** One scenario per user-visible behaviour. Story sizing: more than ~3 scenarios → split (per workflow.md § 6.6).
+6. **Open draft PR.** Use the GitHub MCP tools. Title: `<scope>: <verb> <object> (Story <id>)`. Body uses `${CLAUDE_PLUGIN_ROOT}/templates/pull_request_template.md`; fill sections 1–6 only. Section 7 (Suggestion log) is filled by `/review-plan`. Mark as **draft**.
+7. **Write the plan file.** `docs/plans/story-<id>.md` in the consuming repo. Include: same content as PR sections 1–6 + a "Plan for Sonnet" subsection covering files to touch, tests to write first, slice-by-slice commit sequence, and Definition of Done for this story. Commit it: `chore(docs): plan for Story <id>`.
+
+## Exit gate
+
+Phase 1 is done when the draft PR is open, sections 1–6 are filled (no `TBD`), the plan file is committed, and the user agrees the scope is right. Hand off to `/product-dev-agent:review-plan` next.
+
+## Guardrails
+
+- **Do not write production code in this phase.** Plans only.
+- **Do not skip alternatives.** "I went straight to the obvious answer" is the most common planning failure — three alternatives forces real comparison.
+- **Sizing.** Adapter stories (file-format readers, bank CSVs, export targets) need coarser slices, not finer — see workflow.md § 6.6.
+- **Story id discipline.** Every commit subject in this story must end with `(Story <id>)`.

--- a/product-dev-agent/skills/retro/SKILL.md
+++ b/product-dev-agent/skills/retro/SKILL.md
@@ -1,0 +1,49 @@
+---
+description: Phase 5 of the product-dev-agent loop. Write the Keep/Change/Try retrospective for the just-finished story and fold any new rules into CLAUDE.md or docs/. Use after /review-impl is clean, or when the user says "write the retro", "retrospective", or "/retro".
+---
+
+# /product-dev-agent:retro
+
+You are running **Phase 5** of the product-dev-agent loop. Read `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` § "Phase 5 — Retrospective" + `${CLAUDE_PLUGIN_ROOT}/docs/retrospective-format.md` before starting.
+
+`$ARGUMENTS` should contain the story id. If empty, infer it from the branch or ask.
+
+## Your job
+
+Produce a **Keep / Change / Try** retrospective that:
+
+1. Documents what worked, what didn't, and what to try next.
+2. Surfaces concrete action items.
+3. Folds any **new rule** into the loop's documentation in the same PR (no rule lives only in a retro file).
+
+## Workflow
+
+1. **Read the PR end-to-end.** Sections 1–8, the diff, the suggestion log, the agent's deviations and follow-ups.
+2. **Read the previous retrospective** (if any) at `docs/retrospectives/`. Note any "Try" items from last story — did they prove out? They graduate to "Keep" + a CLAUDE.md/`docs/` rule, or sunset.
+3. **Write the retro file** at `docs/retrospectives/story-<id>.md` using `${CLAUDE_PLUGIN_ROOT}/templates/retrospective-template.md`. Field guidance is in `${CLAUDE_PLUGIN_ROOT}/docs/retrospective-format.md`.
+4. **For each new rule** (a "Try" graduating to "Keep", or a finding from this story that codifies into a rule): edit the relevant file in the same PR. Most common targets:
+   - The consuming project's `CLAUDE.md` (loop overlay or project-specific section).
+   - The consuming project's `docs/engineering-standards.md` overrides.
+   - A new follow-up issue against the plugin if the rule is generic and should ship in `${CLAUDE_PLUGIN_ROOT}/docs/`.
+5. **Update the retrospectives index.** `docs/retrospectives/README.md` Index list — add this story.
+6. **Commit.** `chore(retro): Story <id>` (and the rule edits in the same commit, per "no rule lives only in a retro" principle).
+7. **Update PR section 9.** Paste the 3-line Keep/Change/Try summary; link the full file.
+
+## Exit gate (Definition of Done)
+
+Phase 5 is done when:
+
+- `docs/retrospectives/story-<id>.md` is committed.
+- Any new rule has landed in CLAUDE.md / `docs/` / a templates file in the same PR.
+- Retrospectives index updated.
+- PR section 9 filled.
+- PR section 10 (Merge checklist) ready for the user to tick.
+
+After this, the user reviews the merge checklist and merges. Phase 5 does not merge.
+
+## Guardrails
+
+- **Be specific.** "The plan under-specified the migration rollback path" beats "better planning". A "Change" without a concrete next-time action is just venting.
+- **Try ≠ commit forever.** A "Try" is an experiment for the *next* story only. If it works, it graduates to "Keep" and a rule edit. If it doesn't, it sunsets.
+- **No rule in retro only.** The retrospective file is history; the rule must live where future-you will read it (CLAUDE.md, engineering-standards, etc.).
+- **Carryover loop.** If last story had a "Try", this retro must report whether it worked.

--- a/product-dev-agent/skills/review-impl/SKILL.md
+++ b/product-dev-agent/skills/review-impl/SKILL.md
@@ -1,0 +1,84 @@
+---
+description: Phase 4 of the product-dev-agent loop. Re-run P1/P2/P3 against the actual code diff, produce a refactor plan, and gate the merge checklist. Use after /implement returns, or when the user says "review the implementation", "post-impl review", or "/review-impl".
+---
+
+# /product-dev-agent:review-impl
+
+You are running **Phase 4** of the product-dev-agent loop. Read `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` § "Phase 4 — Code review on the implementation" before starting.
+
+## Your job
+
+Re-run **P1, P2, P3 against the actual diff** — not the plan. The plan is a hypothesis; the diff is reality. Findings split into:
+
+- **Blockers.** Fix before merge. Delegate execution back to the sonnet-implementer.
+- **Refactor candidates.** Same PR if cheap, otherwise file a deferred-suggestion issue.
+- **Follow-ups.** Out-of-scope improvements; file as issues.
+
+## P1 retro-check — Functional
+
+- The acceptance scenarios + unit tests actually deliver the intent (not just any path).
+- For each `this test fails if …` claim in PR sections, audit that the production path it guards is the real code, not a bystander.
+- New behaviour matches the PRD/story, not the plan's interpretation of it.
+
+## P2 retro-check — Product QA
+
+Walk `${CLAUDE_PLUGIN_ROOT}/docs/quality-assurance-skeleton.md` + the consuming project's `docs/quality-assurance.md` against the diff.
+
+**Mock diversity check.** When the diff includes structured output (JSON payloads, tables, machine-readable formats), spot-check that at least one test assertion runs against a non-default mock fixture. Example: a `--json` test must cover `duplicates: [item]`, not only `duplicates: []` — otherwise a hardcoded-default value silently passes a zero-mock test suite. This catches the "test passes but output is wrong" bug class.
+
+**`this test fails if …` audit.** For every test the PR claims guards a specific production path, trace the path. If the test would still pass against a stripped-down implementation, the test is decorative, not protective.
+
+## P3 retro-check — Engineering
+
+Walk `${CLAUDE_PLUGIN_ROOT}/docs/engineering-standards.md` + `${CLAUDE_PLUGIN_ROOT}/docs/security-checklist.md` + the consuming project's `docs/architecture.md` against the diff.
+
+Look for:
+- Layer-boundary violations (Core importing Infra).
+- New `any` / unchecked nulls / float-on-money / bare-`except` (per project's language rules).
+- Coupling spikes — a Core file suddenly importing from elsewhere.
+- Naming drift — the function name no longer describes what it does.
+- Dead code, orphan TODOs, commented-out blocks.
+- Over-abstraction — a single implementation behind an interface that "might grow".
+- Premature concurrency or caching (YAGNI).
+- Security-checklist boxes that the implementation invalidates (the plan-time review walked the plan; this walk validates the code).
+
+## Deviations report cross-check
+
+Read the agent's "Deviations from plan" section (PR section 8). For each:
+- Was the deviation justified? (If not → blocker.)
+- Was the alternative plausible? (If yes and the chosen path is worse → refactor candidate.)
+- Does the deviation hide a tool/library substitution that should have been flagged earlier? (If yes → write it up as a refactor candidate and add a note to the suggestion log so future reviews catch the pattern.)
+
+## Refactor plan
+
+Produce one. Format:
+
+```
+## Blockers (must fix before merge)
+- <finding> · <file:line> · <required change>
+
+## Refactor candidates (this PR)
+- <finding> · <required change>
+
+## Follow-ups (file as issues)
+- <finding> · <link to filed issue>
+```
+
+Delegate blocker + this-PR refactor execution back to the sonnet-implementer (re-invoke `/product-dev-agent:implement` with the refactor plan as the spec). Do not edit production code yourself.
+
+## Exit gate (toward Definition of Done)
+
+Phase 4 is done when:
+
+- All blockers are fixed and green-suite is green again.
+- All refactor-candidates resolved (done in PR or moved to follow-up).
+- Suggestion log updated with any new findings.
+- CI green.
+
+Hand off to `/product-dev-agent:retro` next.
+
+## Guardrails
+
+- **Do not soften the standards because tests pass.** The whole point of Phase 4 is catching what tests miss (Phase 4 has historically caught real correctness bugs that 100%-passing test suites missed).
+- **Do not edit production code.** Delegate.
+- **Walk in full.** Cherry-picked reviews are not reviews.

--- a/product-dev-agent/skills/review-plan/SKILL.md
+++ b/product-dev-agent/skills/review-plan/SKILL.md
@@ -1,0 +1,76 @@
+---
+description: Phase 2 of the product-dev-agent loop. Run the 3-pass critical review (P1 functional, P2 product QA, P3 engineering) on a draft plan before implementation. Use after /plan-story, or when the user says "review the plan", "P1/P2/P3", or "/review-plan".
+---
+
+# /product-dev-agent:review-plan
+
+You are running **Phase 2** of the product-dev-agent loop. Read `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` § "Phase 2 — Critical review on the plan" before starting.
+
+`$ARGUMENTS` may contain a PR number to review. If empty, default to the current branch's draft PR.
+
+## Your job
+
+Walk the plan through **three independent passes**. Each pass produces suggestions tagged `adopted` / `deferred` / `rejected`. Phase 2 ends only when every suggestion has a non-empty resolution and every `deferred` row links a GitHub issue.
+
+## The three passes
+
+Run them in order. Do **not** combine them into one prose review — keep the suggestions distinct so the suggestion log stays auditable.
+
+### P1 — Functional
+
+Source of truth: the consuming project's PRD, epic/story doc, and the story's stated FR/NFR coverage.
+
+Check:
+- Plan satisfies the target FR/NFRs.
+- Acceptance scenarios (Gherkin or equivalent) cover the user-visible behaviours.
+- No scope drift — the plan doesn't sneak in unrelated work.
+- Edge cases the PRD calls out are addressed (or explicitly deferred with reason).
+
+### P2 — Product Quality / QA
+
+Source of truth: `${CLAUDE_PLUGIN_ROOT}/docs/quality-assurance-skeleton.md` + the consuming project's `docs/quality-assurance.md` (domain invariants).
+
+Walk every invariant in the QA doc against the plan. For accounting/financial domains: correctness, currency rules, allocation conservation, determinism, validity windows, no silent data loss. For other domains: domain-equivalent invariants. Privacy & data sovereignty. Coherence with the product brief. Observability of failures.
+
+### P3 — Engineering
+
+Source of truth: `${CLAUDE_PLUGIN_ROOT}/docs/engineering-standards.md` + `${CLAUDE_PLUGIN_ROOT}/docs/security-checklist.md` + the consuming project's `docs/architecture.md` and any project-specific security additions.
+
+Walk:
+- Architecture principles (layer boundaries respected; no Core importing from Infra).
+- SOLID applied pragmatically (not ceremonially).
+- KISS / YAGNI (no speculative abstractions, no "just in case" config).
+- Testing tiers covered (acceptance + unit + property where invariants exist + integration where Infra is touched).
+- Coverage expectations met (typically 100% branch on Core).
+- TDD rhythm planned correctly (red → green → refactor commit sequence).
+- Security checklist walked **in full**.
+- Style cheat-sheet respected.
+
+## Suggestion log mechanics
+
+For each suggestion, append a row to PR section 7 (Suggestion log). Format:
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+
+Resolution rules:
+- `adopted` → rewrite the plan to incorporate the suggestion. Mark the row.
+- `deferred` → file a GitHub issue using `${CLAUDE_PLUGIN_ROOT}/templates/deferred-suggestion-issue.md`. Link the issue in the row. Use the GitHub MCP tools.
+- `rejected` → one-line reason in the row.
+
+## Exit gate (Definition of Ready)
+
+Phase 2 is done — and the story is **Ready** — when:
+
+- Every suggestion-log row has a non-empty Resolution.
+- Every `deferred` row links an open GitHub issue.
+- The plan body has been rewritten to incorporate every `adopted` suggestion.
+- No untagged items remain.
+
+Hand off to `/product-dev-agent:implement` next.
+
+## Guardrails
+
+- **Do not implement during review.** This phase is words only.
+- **Do not soften the rules.** A genuine engineering-standards violation is not a "deferred suggestion"; it's a plan revision. Defer is for legitimate scope-creep candidates only.
+- **Walk the security checklist in full**, not just the items that look relevant. The checkbox discipline catches what cherry-picking misses.

--- a/product-dev-agent/templates/claude-md-snippet.md
+++ b/product-dev-agent/templates/claude-md-snippet.md
@@ -1,0 +1,68 @@
+<!-- product-dev-agent:snippet -->
+## Product development loop
+
+This project uses the [`product-dev-agent`](https://github.com/xavierbriand/product-dev-agent) plugin for its development workflow.
+
+**Authoritative loop reference:** `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` — phases, DoR/DoD, model tiers, commit conventions.
+
+### Loop skills
+
+Drive the loop with these slash commands (the `product-dev-agent:` prefix is required — Claude Code namespaces all plugin skills):
+
+- `/product-dev-agent:maintenance` — triage issues, review Dependabot, audit. Run before every new story.
+- `/product-dev-agent:plan-story <id>` — Phase 1: intent → alternatives → Gherkin → draft PR + plan file.
+- `/product-dev-agent:review-plan` — Phase 2: P1/P2/P3 critical review of the plan. DoR gate.
+- `/product-dev-agent:implement` — Phase 3: hand off to the `sonnet-implementer` agent.
+- `/product-dev-agent:review-impl` — Phase 4: P1/P2/P3 retro-check against the diff. Refactor plan.
+- `/product-dev-agent:retro <id>` — Phase 5: Keep/Change/Try retrospective. New rules land in same PR.
+- `/product-dev-agent:bootstrap` — one-shot installer for templates + this snippet. Use `--check` to detect drift.
+
+### Loop overlay (project-specific)
+
+<!-- Fill in for this project. Examples below. -->
+
+- **Green-suite command:** `<your project's lint+build+test command>` (e.g. `npm run lint && npm run build && npm test`).
+- **Stack:** <language, runtime, primary frameworks>.
+- **Critical-path deps:** <list — used by maintenance sub-loop's escalation policy>.
+- **Audit command:** `<your project's vulnerability audit>` (e.g. `npm audit`).
+- **Acceptance runner:** <e.g. quickpickle, behave, godog>.
+- **Property runner:** <e.g. fast-check, hypothesis, proptest> — required wherever this project's domain has invariants (see `docs/quality-assurance.md`).
+
+### Recommended `.claude/settings.json` permissions
+
+To avoid permission prompts on every loop invocation, add to your project's `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test)",
+      "Bash(npm run test:*)",
+      "Bash(npm run build)",
+      "Bash(npm run lint)",
+      "Bash(npm audit)",
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff)",
+      "Bash(git diff:*)",
+      "Bash(git log)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch)",
+      "Bash(git branch:*)",
+      "Bash(git fetch)",
+      "Bash(git fetch:*)"
+    ]
+  }
+}
+```
+
+Replace `npm` with your project's package manager / build tool.
+
+### Project-specific rules
+
+<!--
+Below this line, document anything the loop's defaults don't cover for this project:
+domain invariants, money precision, security additions, story tracker, etc.
+-->
+<!-- end product-dev-agent:snippet -->

--- a/product-dev-agent/templates/deferred-suggestion-issue.md
+++ b/product-dev-agent/templates/deferred-suggestion-issue.md
@@ -1,0 +1,38 @@
+---
+name: Deferred suggestion
+about: A critical-review suggestion that was deferred out of a PR. Tracks it so it doesn't get lost.
+title: "[deferred] "
+labels: ["deferred-suggestion"]
+assignees: []
+---
+
+## Source
+
+- **PR:** <!-- link -->
+- **Phase:** <!-- P1 / P2 / P3 -->
+
+## Suggestion
+
+<!-- Restate the suggestion as it appeared in the suggestion log. -->
+
+## Why deferred
+
+<!--
+Why we didn't do it inside the source PR. Scope creep, dependency on another
+story, out-of-scope refactor, etc. Be specific — future-us needs to decide if
+it's still worth doing.
+-->
+
+## Proposed resolution
+
+<!--
+How we'd address it if we picked this up. Doesn't have to be a full plan —
+enough that a planning session can pick it up without re-discovering the context.
+-->
+
+## Estimated scope
+
+<!--
+One of: trivial (inline fix) / small (single-session story) / medium (multi-day
+story) / large (needs decomposition). Best-guess is fine.
+-->

--- a/product-dev-agent/templates/pull_request_template.md
+++ b/product-dev-agent/templates/pull_request_template.md
@@ -1,0 +1,101 @@
+<!--
+product-dev-agent PR template. Every section is required.
+No section may be blank or left as `TBD` at merge.
+
+- Sections 1–6 are filled during /product-dev-agent:plan-story.
+- Section 7 (Suggestion log) is filled during /product-dev-agent:review-plan.
+- Section 8 (Implementer's learnings) is pasted from the implementation agent's return.
+- Section 9 (Retrospective) is written during /product-dev-agent:retro.
+- Section 10 (Merge checklist) is the final gate — the user ticks it.
+
+Full workflow: see ${CLAUDE_PLUGIN_ROOT}/docs/workflow.md
+-->
+
+## 1. Story
+
+<!-- Link to the story entry in your project's epic doc. -->
+
+## 2. Intent
+
+<!-- 2–4 sentences. What problem, what outcome? -->
+
+## 3. Alternatives considered
+
+<!-- One line each. Why each was set aside. -->
+
+-
+
+## 4. Selected solution & rationale
+
+<!-- What we're building. Why it beats the alternatives listed above. -->
+
+## 5. Acceptance scenarios
+
+<!-- Gherkin or your project's equivalent acceptance format. -->
+
+```gherkin
+Feature:
+
+  Scenario:
+    Given
+    When
+    Then
+```
+
+## 6. Plan for the implementer
+
+<!--
+Files to touch · tests to write first · slice-by-slice commit sequence ·
+Definition of Done for this story. Self-contained: the implementation agent
+should not have to ask clarifying questions to proceed.
+-->
+
+## 7. Suggestion log
+
+<!--
+Filled during the 3-pass critical review (P1 functional, P2 product QA, P3 engineering).
+Resolution is one of `adopted` / `deferred` / `rejected`.
+- `deferred` rows MUST link an open GitHub issue in Link/Reason.
+- `rejected` rows MUST carry a one-line reason in Link/Reason.
+- `adopted` rows mean the plan was rewritten to incorporate the suggestion.
+DoR is not met until every row has a non-empty Resolution.
+-->
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+|       |            |            |               |
+
+## 8. Implementer's learnings
+
+<!--
+Pasted verbatim from the implementation agent's return report. Fixed structure:
+
+## What was built
+## Red → green sequence (per test)
+## Deviations from plan (with rationale)
+## Unknowns encountered
+## Proposed follow-ups
+## Files touched
+-->
+
+## 9. Retrospective
+
+<!--
+3-line summary (Keep / Change / Try). Full retro file committed at
+docs/retrospectives/story-<id>.md — link here.
+-->
+
+- **Keep:**
+- **Change:**
+- **Try:**
+
+Full retrospective: <!-- link to docs/retrospectives/story-<id>.md -->
+
+## 10. Merge checklist
+
+- [ ] Green-suite green on CI
+- [ ] PR out of draft
+- [ ] Retrospective file committed at `docs/retrospectives/story-<id>.md`
+- [ ] All suggestion-log items resolved (no blank `Resolution` cells)
+- [ ] All Phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
+- [ ] User approval

--- a/product-dev-agent/templates/retrospective-template.md
+++ b/product-dev-agent/templates/retrospective-template.md
@@ -1,0 +1,42 @@
+# Story <id> retrospective
+
+**PR:** <url>  **Closed:** YYYY-MM-DD
+
+<!--
+Field guidance lives in ${CLAUDE_PLUGIN_ROOT}/docs/retrospective-format.md.
+Short version:
+- Keep — what worked, repeat next time.
+- Change — what didn't work, with a concrete next-time action.
+- Try — an experiment for the NEXT story only. Graduates to Keep + a rule edit, or sunsets.
+- New rules MUST land in CLAUDE.md / docs/ / a template in the SAME PR.
+- Action items are concrete and assignable.
+-->
+
+## Keep
+
+-
+
+## Change
+
+-
+
+## Try
+
+-
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+|      |                |        |
+
+## Carryovers resolved
+
+<!--
+For each "Try" from the previous story's retrospective, report the outcome:
+- Worked → graduated to Keep + rule edit (link the edit).
+- Didn't work → note why; experiment sunset.
+- Inconclusive → carry forward, or sunset if carried twice already.
+-->
+
+-


### PR DESCRIPTION
## Meta PR — not a story

This is a meta change: extract accounting's product development loop into a reusable Claude Code plugin so other projects can adopt it without copy-pasting `CLAUDE.md` § 6–7 + agent specs + templates by hand. Not tracked under `docs/epics.md`. Not driven through the loop's PR template — the loop itself is the subject.

Decisions captured in plan mode (see `/root/.claude/plans/i-d-like-to-make-snoopy-fiddle.md` for the full record):
- **Standalone repo** scaffolded under `product-dev-agent/` in this branch; user will move to `github.com/xavierbriand/product-dev-agent`.
- **Slash commands per phase** — 7 skills, namespaced as `/product-dev-agent:<skill>`.
- **Side-by-side migration** — accounting `CLAUDE.md` §§ 6–7, the in-repo agent, and the `.github/` templates stay in force until **Story 3.1** validates the plugin end-to-end. After Story 3.1 ships through plugin skills, that story's retro strips the now-redundant in-repo content.
- **Truly generalize** — Node/TypeScript specifics pushed to consumer overlay; engineering-standards `docs` reads "pick an acceptance runner / unit runner / property runner / integration runner".
- **Drift detection** — `/bootstrap --check` diffs consumer-side templates against plugin canon; non-zero exit on drift.
- **Hook kept** — minimal `SessionStart` reminder if bootstrap artifacts are missing in a git repo.
- **Skills layout** — `skills/<name>/SKILL.md` (current Claude Code recommendation), not flat `commands/`.
- **Versioned at 0.1.0** in `plugin.json`.
- **Historical retros** get a one-paragraph "Legacy references" note in `docs/retrospectives/README.md`; frozen retro files unedited.

## What's in `product-dev-agent/`

| Layer | Count | Files |
| --- | --- | --- |
| Manifest | 1 | `.claude-plugin/plugin.json` |
| Agents | 1 | `sonnet-implementer.md` (generalised — no Story-N citations, no `dinero`/`better-sqlite3`/`commander` refs, `${CLAUDE_PLUGIN_ROOT}` paths) |
| Skills | 7 | `plan-story`, `review-plan`, `implement`, `review-impl`, `retro`, `maintenance`, `bootstrap` — one per loop phase |
| Docs | 5 | `workflow.md` (authoritative), `engineering-standards.md`, `security-checklist.md`, `quality-assurance-skeleton.md`, `retrospective-format.md` |
| Templates | 4 | PR (10 sections), deferred-suggestion issue, retrospective skeleton, CLAUDE.md snippet |
| Hooks | 1 | `SessionStart` soft-reminder if bootstrap artifacts missing |
| Scripts | 2 | `bootstrap.sh` (install + `--check`), `session-start-reminder.sh` |

## Accounting migration (additive only — no deletions)

- `CLAUDE.md` — added a loop-reference note above § 1 pointing at the plugin and explaining the side-by-side period. Nothing removed.
- `docs/retrospectives/README.md` — added a one-paragraph "Legacy references" redirect mapping pre-migration `CLAUDE.md § 6.x` citations to plugin `workflow.md` sections. Frozen retro files (Stories 1.3 through 2.4) unedited.

## Validation

```
=== plugin.json validity ===                          OK
=== hooks.json validity ===                           OK
=== Frontmatter on agent + 7 skills ===               all 8 OK
=== bash scripts syntax ===                           bootstrap.sh + reminder OK

=== bootstrap on scratch repo ===
  --check on empty: 4 missing, exit 1                 ✓
  first install: 4 written                            ✓
  --check after install: 4 up-to-date, exit 0         ✓
  second install: 0 written, 4 unchanged              ✓ idempotent
  CLAUDE.md snippet count after 2 installs: 1         ✓ marker-gated

=== SessionStart reminder ===
  silent in non-git dir                               ✓
  nudges in unbootstrapped git repo                   ✓
  silent after bootstrap                              ✓
```

## Acceptance test (deferred to Story 3.1)

The definitive proof the plugin works is running the next accounting story end-to-end through plugin skills + the thin `CLAUDE.md`. That's Story 3.1's job. If it ships cleanly, Story 3.1's retro action strips:
- `CLAUDE.md` §§ 2, 4, 5, 6, 7 (Architecture, Style, Testing, Workflow, DoD — all generic, all in plugin now)
- `.claude/agents/sonnet-implementer.md`
- The body of `docs/engineering-standards.md` (replaced with a pointer)

Until then, the in-repo content remains authoritative for accounting; the plugin is opt-in.

## Next steps for the user

1. Review the plugin scaffold + the additive migration changes.
2. Either: (a) merge as-is and start Story 3.1 with the plugin loaded locally, or (b) extract `product-dev-agent/` to `github.com/xavierbriand/product-dev-agent` first (`git subtree split` or plain copy + new repo init), then merge this branch.
3. After Story 3.1 ships through the plugin: open the strip PR per the side-by-side plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5njNAozaEpnuX9vjFo9Ev)_