### PR TITLE
story-maint-02: os.homedir() fallback in FileConfigService

### DIFF
--- a/docs/plans/story-maint-02.md
+++ b/docs/plans/story-maint-02.md
@@ -1,0 +1,109 @@
+# Story maint-02 — `os.homedir()` fallback in FileConfigService
+
+## Context
+
+Second story on the pre-Epic-3 maintenance track. [Issue #22](https://github.com/xavierbriand/accounting/issues/22) — Story 1.4 P3 finding (minor defensive-correctness nit, deferred at the time).
+
+[src/infra/config/config-service.ts:29](src/infra/config/config-service.ts:29) computes the XDG config fallback as:
+
+```ts
+path.join(this.opts.homeDir ?? process.env['HOME'] ?? '/tmp', '.config')
+```
+
+`/tmp` is a cross-platform hazard: world-writable on POSIX, nonexistent on Windows. Node's built-in `os.homedir()` already handles the cross-platform resolution (honours `HOME` on POSIX, `USERPROFILE` on Windows, falls back to `/etc/passwd` if both absent) and **never returns `undefined`**. The current chain is over-specified and the tail is unsafe.
+
+**Maintenance sub-loop (§ 6.7)** run 2026-04-24 before planning: main synced, 0 open Dependabot PRs, `npm audit` unchanged (0 high/critical, 4 moderate/4 low — all dev-chain), 12 open issues post story-maint-01 merge. **Proceed-to-planning.**
+
+## Story (verbatim from [issue #22](https://github.com/xavierbriand/accounting/issues/22))
+
+> Or, cleaner: `path.join(this.opts.homeDir ?? os.homedir(), '.config')` — dropping the `HOME` env check, since `os.homedir()` already inspects it on POSIX. Add a test that `os.homedir()` is used when no explicit `homeDir` is passed.
+
+Closes #22. No FR coverage (tooling/hardening). Walks the [security-checklist](docs/security-checklist.md) line "avoid predictable world-writable paths".
+
+## Selected solution
+
+Two options, one chosen.
+
+**Option A — minimal (add `os.homedir()` as the last fallback):**
+```ts
+path.join(this.opts.homeDir ?? process.env['HOME'] ?? os.homedir(), '.config')
+```
+Preserves the `HOME` env short-circuit. Con: redundant — `os.homedir()` already reads `HOME` on POSIX.
+
+**Option B — clean (drop `HOME`, let `os.homedir()` own POSIX/Windows resolution):** ← **chosen**
+```ts
+path.join(this.opts.homeDir ?? os.homedir(), '.config')
+```
+Single source of truth; one fewer branch to test; matches the behaviour the repo already expects on Windows (where `HOME` isn't set and `/tmp` doesn't exist).
+
+### Chosen implementation
+
+- **Edit [src/infra/config/config-service.ts:29](src/infra/config/config-service.ts:29)**:
+  - Add `import os from 'os';` at the top (alongside `import fs` / `import path`).
+  - Replace the fallback expression with `path.join(this.opts.homeDir ?? os.homedir(), '.config')`.
+- **Add one integration test** to [tests/integration/infra/config/config-service.test.ts](tests/integration/infra/config/config-service.test.ts):
+  - Unset `HOME` via `vi.stubEnv('HOME', '')`; construct `FileConfigService` without `homeDir` or `xdgConfigHome`; assert the both-missing error cites `${os.homedir()}/.config/accounting/config.yaml` and **not** `/tmp/.config`.
+  - `vi.unstubAllEnvs()` in `afterEach`.
+
+## Gherkin acceptance scenarios
+
+```gherkin
+Feature: XDG fallback uses os.homedir() instead of /tmp
+
+  Scenario: HOME unset, no explicit homeDir → fallback resolves via os.homedir()
+    Given HOME is unset
+    And neither opts.homeDir nor opts.xdgConfigHome is passed
+    When FileConfigService.load() is called against an empty projectDir
+    Then the both-missing error cites a path under os.homedir()/.config/accounting/config.yaml
+    And the error does not mention /tmp
+
+  Scenario: Explicit opts.homeDir wins
+    Given opts.homeDir = /custom/home
+    When FileConfigService.load() is called against an empty projectDir
+    Then the both-missing error cites /custom/home/.config/accounting/config.yaml
+    (This scenario is covered implicitly — new test asserts the opts override still wins after the refactor.)
+```
+
+## Slice plan for Sonnet
+
+Target **3 commits** (§ 6.6 minimum; story is genuinely one-behaviour). No optional refactor slot — the fix is the refactor.
+
+1. **`test(config): falls back to os.homedir() when HOME unset — failing (story-maint-02)`**
+   - Add the new integration test. Must fail against current code (HOME-unset path lands in `/tmp/.config/...`, which the assertion forbids).
+   - Use `vi.stubEnv('HOME', '')` + `vi.unstubAllEnvs()` around the test (scoped to the single test, not the whole file).
+   - `npm test` shows 1 failure in `config-service.test.ts`.
+
+2. **`feat(config): use os.homedir() fallback in FileConfigService — minimal green (story-maint-02)`**
+   - Add `import os from 'os';`.
+   - Replace the `process.env['HOME'] ?? '/tmp'` fallback with `os.homedir()`.
+   - `npm test` 213/213 green; `npm run lint && npm run build` green.
+
+3. **`refactor(config): empty slot — no behaviour-preserving cleanup identified (story-maint-02)`**
+   - Empty `refactor:` commit per § 6.4. Body: "No-op: the change is already minimal (2 lines net), no naming/duplication/LOC trigger hit."
+
+## Risks
+
+- **`vi.stubEnv` leakage.** If `afterEach` doesn't run (e.g., test aborts mid-run), a stubbed env could persist into the next test. `vi.unstubAllEnvs()` in `afterEach` is vitest's canonical unwind. No risk in practice — vitest guarantees `afterEach` runs even on test failure.
+- **`os.homedir()` throws on hostile systems.** Per Node docs it never throws in normal operation; returns `/etc/passwd` entry or equivalent. No catch needed.
+- **Windows behaviour.** On Windows `os.homedir()` returns `USERPROFILE` (e.g. `C:\Users\alice`). Safer than the old `/tmp` fallback (which was a POSIX path). Net improvement.
+- **PII in error messages.** Error now shows `${os.homedir()}/.config/...` which embeds the username. Current error already does this when `HOME` is set (the vast majority of cases). Not a regression.
+
+## Suggestion log
+
+Phase 2 (P1 / P2 / P3) run by Opus on 2026-04-24.
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+| P1 | Gherkin scenario 2 ("explicit opts.homeDir wins") is described parenthetically, not written as a formal scenario. If you want the test to explicitly cover it, promote to a first-class scenario. | rejected | Not worth an explicit scenario — current tests already exercise the opts.homeDir path via `xdgConfigHome` injection. Adding a homeDir-only path coverage is out of scope (would expand the fix beyond the issue's AC). |
+| P2 | `os.homedir()` embeds username in error-message paths — PII implication? | rejected | No change from today's behaviour when `HOME` is set. Only the `HOME`-unset fallback differs. Current flow already leaks home path. Not introduced by this change. |
+| P3 | Should `import os from 'os'` use the `node:os` protocol? | rejected | The repo already uses bare `'fs'` / `'path'` imports (see [src/infra/config/config-service.ts:1–2](src/infra/config/config-service.ts:1)). Consistent with repo convention; switching one file to `node:os` would be cosmetic drift. If repo-wide `node:` adoption is ever desired, it's a separate story. |
+
+No deferred or adopted items. All 3 rejected with reasons. DoR gate met.
+
+## DoR checklist
+
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review): 3 rejections with reasons.
+- [ ] Draft PR open with template sections 1–6 filled. **Next action.**
+
+**DoR gate met. Ready for Phase 3 (Sonnet implementation) after PR opens.**

--- a/docs/retrospectives/story-maint-02.md
+++ b/docs/retrospectives/story-maint-02.md
@@ -1,0 +1,53 @@
+# Story maint-02 retrospective
+
+**PR:** [#44](https://github.com/xavierbriand/accounting/pull/44)  **Closed:** pending merge  **Closes issue:** [#22](https://github.com/xavierbriand/accounting/issues/22)
+
+Second story on the pre-Epic-3 maintenance track. Ninth end-to-end run of the loop overall. Genuinely tiny scope: replace a 1-expression fallback chain in `FileConfigService`. Net diff: 2 LOC in production, 14 LOC in tests (1 new test + `vi` import + `afterEach` unwind). Plan doc landed at ~110 lines (vs maint-01's 276) — first data point for the "plan-doc scales with story size" pattern maint-01's retro proposed.
+
+## Keep
+
+- **Sonnet's TDD-rigor caught a flaw in my plan before it could ship a false-green test.** My plan specified `vi.stubEnv('HOME', '')` for the red→green test. Sonnet tried it, discovered that on POSIX `os.homedir()` returns `''` when `HOME` is empty-string (it reads the env literally, doesn't fallback), so `path.join('', '.config')` equals `path.join(os.homedir(), '.config')` in that specific case — the test would pass on both old and new code. Silent false-green. Sonnet switched to `vi.stubEnv('HOME', undefined)` (HOME fully deleted), which causes `os.homedir()` to fall through to `/etc/passwd` on POSIX, producing a genuinely different path from the old `/tmp` fallback. **TDD's "write a test that would fail against the wrong implementation" discipline caught the plan-text flaw. Without the red→green proof, I'd have shipped a test that didn't actually test the fix.** Value from keeping the strict TDD rhythm even on tiny stories.
+- **Plan-doc size scaled correctly with story size.** Story-maint-01's retro proposed "for stories under ~20 LOC of diff, the plan doc could be a section in the PR body rather than a dedicated `docs/plans/` file — informal, if maint-02 through maint-04 all fit this shape, propose it formally". Tested it here: kept the plan doc but trimmed from 276 to ~110 lines by density rather than section-removal (same structure, denser prose, skipped the "implementation details" fan-out since there was nothing to fan out). **Structure stayed; verbosity dropped. Matches the retro's intent without the structural change.** One more data point (maint-03 or similar) will settle whether "scale by density" is the right answer vs "promote to PR body".
+- **P1/P2/P3 on a tiny story legitimately resolves to all-rejections.** Plan-phase review found 3 suggestions, all rejected with reasons (over-scoping, PII non-issue, node: import cosmetic drift). An empty-after-review suggestion log used to feel like a skipped step; on a small story it's the correct outcome. **Don't confuse "no adopted suggestions" with "reviewer didn't engage" — the reviewer engaged, the plan was right.**
+- **Rules landed in maint-01 held on first application.** (i) `subagent_type: "sonnet-implementer"` direct invocation: worked first try, zero fallback needed. (ii) Inline-refactor < 5 LOC exception: didn't trigger (no refactor needed), but passively validated — the rule didn't interfere. (iii) Safeguard-removal rule in sonnet-implementer.md § 4: borderline trigger (Sonnet dropped `process.env['HOME']` from a fallback chain) — see Change B below. **Three new rules from maint-01 co-existed with this story cleanly; zero conflict with existing workflow.**
+
+## Change
+
+- **A. Plan-phase env-var test fixtures need deliberate `undefined` vs `''` picks.** When a plan specifies a test that unsets an env var, I need to (a) distinguish between "empty string" and "fully deleted", (b) pick the one that produces a true red against the pre-fix code, (c) call it out in the plan's test-shape description so Sonnet doesn't have to re-derive it. Saved here by Sonnet's TDD rigor; next time could silently ship a useless test. Not worth a rule change — pattern-match on "env-var test" and verify red-proof in the plan write-up. Action: add to personal plan-writing checklist (not a docs update — too niche for CLAUDE.md).
+- **B. Safeguard-removal rule has a blurry boundary on "fallback-chain member removal."** Sonnet dropped `process.env['HOME']` from the fallback chain `homeDir ?? HOME ?? '/tmp'` and did NOT flag it as a safeguard-removal in Deviations. Arguable either way: strict reading ("any defensive-chain member" triggers) would flag it; pragmatic reading ("replacement clearly preserves purpose via a documented internal reference") would skip. Sonnet took the pragmatic reading; the plan-text also spelled it out; I reviewed the diff and agreed. **The rule as-written (from maint-01 retro) doesn't distinguish "removed → no replacement" from "removed → absorbed by a more general construct".** Don't tighten the rule yet — one borderline case isn't enough evidence. But if maint-03 or a later story removes a fallback-chain member without the plan pre-explaining the absorption, Sonnet should flag it. **Try:** extend the rule in a future retro (not this one) to say "mechanical chain-member removal where the replacement absorbs the prior branch's purpose can skip the Deviations entry *iff the plan text documents the absorption*; otherwise flag." Too narrow to codify now; park for observation.
+
+## Try
+
+- **"Plan-to-PR-body" threshold experiment.** Informal observation: story-maint-02's plan doc is 109 lines for a 2-LOC production diff. If the next 1–2 similarly-sized stories land, propose in that retro: for sub-10-LOC production diffs with a single acceptance scenario and all-reject suggestion logs, move the plan content directly into the PR body and skip `docs/plans/story-X.md`. Saves one commit + one file lookup per story. Don't propose yet — one data point.
+- **Plan-phase env-var sanity-check.** Before committing a plan that names specific env-var values in a test fixture (empty string vs `undefined` vs a placeholder), actually reason through what the pre-change code does with each value. Mental dry-run. Not a rule, just a reviewer habit.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| A. Personal plan-writing checklist note: "env-var test fixtures need `undefined` vs `''` explicit picks with red-proof". | Not docs — reviewer habit. | informal, tracked by reference to this retro |
+| B. Observe the safeguard-removal rule's behaviour on the next 1–2 stories that remove a fallback-chain member; codify a refinement only if a borderline case causes a real miss. | Observed across maint-03 and beyond. | open, passive |
+
+## Loop metrics (ninth run; second maintenance-track story)
+
+- **Plan phase:** 1 maintenance sub-loop (0 new Dependabot PRs, audit unchanged from prior loop) + Opus P1/P2/P3 plan review (3 findings, all rejected with reasons).
+- **Implementation:** 1 Sonnet task (3 commits of 3 planned). 1 deviation (`stubEnv` value change — caught and documented).
+- **Phase-4 retro-check:** 3 passes (P1 / P2 / P3). Zero findings — diff is minimal and aligns exactly with plan.
+- **Retro fixes:** 0 (no blockers surfaced).
+- **Issues closed by this story:** [#22](https://github.com/xavierbriand/accounting/issues/22).
+- **Issues opened:** 0.
+- **Total commits on branch:** 5 (1 plan + 3 implementation + this retro).
+- **Test count:** 212 → 213 (+1 new integration test).
+- **Diff stats:** 2 LOC prod + 14 LOC test + 109 LOC plan + ~75 LOC retro.
+- **Bugs squashed:** 0 (this was hardening, not bug-fix).
+- **New runtime deps:** 0. **New dev deps:** 0.
+- **Time-to-DoD:** sub-10-minute implementation; ~20 min total including plan + review + retro.
+
+## Carryovers resolved
+
+- Story 1.4 retro P3 finding (`/tmp` HOME fallback) → **CLOSED by this story**.
+- Story-maint-01 retro action A (safeguard-removal rule in sonnet-implementer.md § 4) → engaged; borderline case observed, rule held pragmatically. See Change B.
+- Story-maint-01 retro action B (Opus inline-refactor < 5 LOC exception) → didn't trigger (no refactor needed).
+- Story-maint-01 retro action E (CLAUDE.md § 6.3 invocation note refresh) → engaged; `subagent_type: "sonnet-implementer"` direct invocation worked first try on this story, as the updated note promised.
+- Issue [#42](https://github.com/xavierbriand/accounting/issues/42) (vitest config consolidation): still open, not touched this story. Next potentially at maint-03 if another story needs the vitest config.
+- Issue [#43](https://github.com/xavierbriand/accounting/issues/43) (helper extraction): still open, not touched.

--- a/src/infra/config/config-service.ts
+++ b/src/infra/config/config-service.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { parse as yamlParse } from 'yaml';
 import type { ConfigService } from '@core/ports/config-service.js';
@@ -26,7 +27,7 @@ export class FileConfigService implements ConfigService {
     const xdgHome =
       this.opts.xdgConfigHome ??
       process.env['XDG_CONFIG_HOME'] ??
-      path.join(this.opts.homeDir ?? process.env['HOME'] ?? '/tmp', '.config');
+      path.join(this.opts.homeDir ?? os.homedir(), '.config');
 
     const xdgPath = path.join(xdgHome, 'accounting', 'config.yaml');
 

--- a/tests/integration/infra/config/config-service.test.ts
+++ b/tests/integration/infra/config/config-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -52,6 +52,7 @@ describe('FileConfigService', () => {
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true });
     fs.rmSync(xdgDir, { recursive: true });
+    vi.unstubAllEnvs();
   });
 
   it('loads accounting.yaml from projectDir when present', () => {
@@ -131,5 +132,19 @@ describe('FileConfigService', () => {
     const result = service.load();
 
     expect(result.isSuccess).toBe(true);
+  });
+
+  it('falls back to os.homedir() when HOME is unset and no explicit homeDir is provided', () => {
+    const systemHome = os.homedir();
+    vi.stubEnv('HOME', undefined);
+    const service = new FileConfigService({ projectDir: tmpDir });
+
+    // fails if FileConfigService uses /tmp instead of os.homedir() when HOME is unset
+    const result = service.load();
+
+    expect(result.isFailure).toBe(true);
+    const expectedXdgPath = path.join(systemHome, '.config', 'accounting', 'config.yaml');
+    expect(result.error).toContain(expectedXdgPath);
+    expect(result.error).not.toContain('/tmp/.config');
   });
 });


### PR DESCRIPTION
## 1. Story

[Issue #22](https://github.com/xavierbriand/accounting/issues/22) — Story 1.4 P3 deferred suggestion. Second pre-Epic-3 maintenance story (sequence: #18 ✓ → **#22** → #35 → #21 → #38 → #12 → #11 → Epic 3).

## 2. Intent

`FileConfigService` computes the XDG fallback path as `path.join(this.opts.homeDir ?? process.env['HOME'] ?? '/tmp', '.config')`. `/tmp` is a POSIX-only, world-writable fallback that's nonexistent on Windows. Node's `os.homedir()` already handles cross-platform resolution and never returns `undefined` — replace the brittle tail with a single `os.homedir()` call.

## 3. Alternatives considered

- **Option A** — add `os.homedir()` as the *last* fallback after `process.env['HOME']`. Rejected: redundant — `os.homedir()` already inspects `HOME` on POSIX.
- **Option B** (chosen) — drop `process.env['HOME']` entirely: `path.join(this.opts.homeDir ?? os.homedir(), '.config')`. Single source of truth, one fewer branch.

## 4. Selected solution & rationale

Option B. Full rationale in [docs/plans/story-maint-02.md](docs/plans/story-maint-02.md).

## 5. Gherkin scenarios

```gherkin
Feature: XDG fallback uses os.homedir() instead of /tmp

  Scenario: HOME unset, no explicit homeDir → fallback resolves via os.homedir()
    Given HOME is unset
    And neither opts.homeDir nor opts.xdgConfigHome is passed
    When FileConfigService.load() is called against an empty projectDir
    Then the both-missing error cites a path under os.homedir()/.config/accounting/config.yaml
    And the error does not mention /tmp
```

## 6. Plan for Sonnet

Target **3 commits**. Full plan: [docs/plans/story-maint-02.md](docs/plans/story-maint-02.md).

## 7. Suggestion log

Phase 2 (P1 / P2 / P3) run by Opus on 2026-04-24.

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P1 | Promote the "explicit `opts.homeDir` wins" case to a formal Gherkin scenario. | rejected | Existing tests already exercise this via `xdgConfigHome` injection. Expanding scope beyond the issue's AC. |
| P2 | `os.homedir()` embeds username in error paths — PII implication. | rejected | No change from today: error already shows `$HOME`-derived path when `HOME` is set. Only the fallback differs. |
| P3 | Should `import os from 'os'` use the `node:os` protocol? | rejected | Repo uses bare `'fs'` / `'path'` imports. Consistent with convention. Separate story if repo-wide adoption is desired. |

**Phase-4 retro-check findings (post-implementation):** zero. Diff is minimal, aligns exactly with plan. Sonnet's one deviation (`vi.stubEnv('HOME', undefined)` instead of the plan's `''`) was a TDD-rigor catch — the plan's `''` value would have produced a silent false-green; `undefined` is the correct red-proof.

## 8. Sonnet's learnings

## What was built

The single Gherkin scenario "HOME unset, no explicit homeDir → fallback resolves via `os.homedir()`" is covered by a new integration test that stubs `HOME` to `undefined`, constructs `FileConfigService` without `homeDir` or `xdgConfigHome`, and asserts the both-missing error cites a path under `os.homedir()/.config/accounting/config.yaml` and does NOT contain `/tmp/.config`. Production fix is 2 LOC net in `src/infra/config/config-service.ts`. 213/213 tests pass.

## Red → green sequence

- `test(config): falls back to os.homedir() when HOME unset — failing` · `ba2f311` · Proved: current code produces `/tmp/.config/...` when HOME is deleted; test asserts the path must cite `os.homedir()/.config` — red as expected.
- `feat(config): use os.homedir() fallback in FileConfigService — minimal green` · `276ccfd` · Proved: `os.homedir()` fallback resolves the real system home when HOME is absent; 213/213 green.
- `refactor(config): empty slot — no cleanup identified` · `8cc7f9d` · Empty `refactor:` commit per § 6.4.

## Deviations from plan

- **`vi.stubEnv('HOME', undefined)` instead of `vi.stubEnv('HOME', '')`.** With `HOME=''`, old code's `process.env['HOME'] ?? '/tmp'` short-circuits at `''` (not nullish) and `os.homedir()` returns `''` on POSIX, so both produce equivalent `path.join('', '.config/...')` — the test would pass against the old code, defeating the red→green proof. Using `undefined` truly deletes HOME so old code falls through to `/tmp` and new code falls through to `os.homedir()`'s `/etc/passwd` lookup. The vitest API permits `string | undefined`.

## Gherkin coverage checklist

- ✓ "HOME unset, no explicit homeDir → fallback resolves via `os.homedir()`" → `tests/integration/infra/config/config-service.test.ts`: `FileConfigService > falls back to os.homedir() when HOME is unset and no explicit homeDir is provided`

## Unknowns encountered

None.

## Proposed follow-ups

None.

## Files touched

- `src/infra/config/config-service.ts` · added `import os from 'os';`; replaced `process.env['HOME'] ?? '/tmp'` tail with `os.homedir()`.
- `tests/integration/infra/config/config-service.test.ts` · added `vi` to vitest imports; added `vi.unstubAllEnvs()` in `afterEach`; added the HOME-unset integration test.

## 9. Retrospective

- **Keep:** Sonnet's TDD rigor caught a plan-text flaw (my planned `stubEnv('HOME', '')` would have produced a silent false-green on POSIX) before it could ship. Plan-doc size scaled correctly with story size (110 lines vs maint-01's 276). Three rules from maint-01 retro co-existed cleanly.
- **Change:** (A) plan-phase env-var test fixtures need deliberate `undefined`-vs-`''` picks with red-proof (reviewer habit, not docs); (B) safeguard-removal rule boundary is blurry on fallback-chain member removal — observe next 1–2 stories before tightening.
- **Try:** "Plan-to-PR-body" threshold — if the next 1–2 tiny stories fit the same shape, propose moving sub-10-LOC stories' plans into the PR body and skipping `docs/plans/story-X.md`. One data point isn't enough yet.

Full retrospective: [docs/retrospectives/story-maint-02.md](docs/retrospectives/story-maint-02.md).

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-maint-02.md`
- [x] All suggestion-log items resolved
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)