### PR TITLE
story-maint-03: friendly 'run migrate' hint for uninitialised DB

### DIFF
--- a/docs/plans/story-maint-03.md
+++ b/docs/plans/story-maint-03.md
@@ -1,0 +1,173 @@
+# Story maint-03 — Friendly "run migrate" error for uninitialised DB
+
+## Context
+
+Third story on the pre-Epic-3 maintenance track. [Issue #35](https://github.com/xavierbriand/accounting/issues/35) — surfaced during Story 2.5's first-contact-with-real-data manual smoke test. Labeled `bug` + `ux`.
+
+Today, running `npm run ingest -- -f <csv> --db-path /tmp/fresh.db` against a **non-existent or unmigrated** DB path produces a raw Node stack trace:
+
+```
+node_modules/better-sqlite3/lib/methods/wrappers.js:5
+SqliteError: no such table: transactions
+    at new SqliteTransactionRepository (src/infra/db/repositories/sqlite-transaction-repo.ts:28:28)
+    at Command.<anonymous> (src/cli/program.ts:49:35)
+```
+
+**Root cause.** [SqliteTransactionRepository](src/infra/db/repositories/sqlite-transaction-repo.ts) eagerly prepares 4 statements in its constructor ([line 28](src/infra/db/repositories/sqlite-transaction-repo.ts:28)). On an empty DB the first prepare throws synchronously; [program.ts:41–70](src/cli/program.ts:41)'s `.action` handler doesn't wrap construction in any error surface — the exception propagates to Node's unhandled-rejection printer.
+
+Siblings: `SqliteHashRepository` has an empty constructor (prepares lazily) and `NodeSqliteSnapshotService` has an empty constructor (never prepares). Only `SqliteTransactionRepository` eagerly prepares, and only on *this* failure path. No need to touch them.
+
+**Outcome.** A CLI-level **pre-flight migration check** in `program.ts`'s `ingest` action, backed by a tiny `assertMigrated(db, dbPath): Result<void>` helper in infra. On `user_version === 0` → write a friendly stderr line (`error: database not initialised at <path>` + `hint: run 'accounting migrate --db-path <path>' first`) and `process.exit(2)`. The raw `SqliteError` stack never reaches the user.
+
+**Maintenance sub-loop (§ 6.7)** run 2026-04-24 post-story-maint-02: main synced, 0 new Dependabot PRs, `npm audit` unchanged (0 high/critical, 4 moderate/4 low — all dev-chain). 12 open issues. **Proceed-to-planning.**
+
+## Story (verbatim from [issue #35](https://github.com/xavierbriand/accounting/issues/35))
+
+> Expected:
+> ```
+> error: database not initialised at /tmp/fresh.db
+> hint: run 'accounting migrate --db-path /tmp/fresh.db' first
+> ```
+> No stack trace, no raw SQLite error class name.
+
+Closes #35. No FR coverage (UX hardening). Walks [docs/engineering-standards.md](docs/engineering-standards.md)'s "error surfaces are user-facing contracts, not debugging aids" and [docs/quality-assurance.md](docs/quality-assurance.md)'s spirit ("no stack trace from a first-party code path").
+
+## Selected solution
+
+Three options, one chosen (the one the issue author already preferred).
+
+**Option 1 — pre-flight check in CLI** (chosen). `program.ts`'s `ingest` action reads `PRAGMA user_version` via a tiny helper; if `0`, prints friendly error + exits 2. Helper lives in `src/infra/db/migration-check.ts` for reuse when future CLI commands land.
+- Pro: smallest diff; fully backward-compatible; works for `ingest` now and every future command that needs a migrated DB (reconcile, transfer, etc.) by calling the same helper.
+- Pro: separates concerns cleanly — the composition root (`program.ts`) owns the "is the DB ready?" question, not the repository constructors.
+- Con: requires one extra `PRAGMA` round-trip per command invocation. Negligible (<1 ms).
+
+**Option 2 — lazy prepares in `SqliteTransactionRepository`.** Move the 4 `db.prepare()` calls from the constructor into each method. Rejected: doesn't actually fix the UX — the first `saveBatch` call would still crash with the same raw `SqliteError`, just later in the flow. Also loses the constructor-time fail-fast signal, which is a repo-pattern consistency regression.
+
+**Option 3 — try/catch at CLI error boundary.** Wrap `.action` in try/catch that pattern-matches `SqliteError` + "no such table". Rejected (issue author also flagged this as "brittle"): string-matching DB error messages is fragile across SQLite/better-sqlite3 versions.
+
+### Chosen implementation
+
+1. **New file** [src/infra/db/migration-check.ts](src/infra/db/migration-check.ts):
+   ```ts
+   import type Database from 'better-sqlite3';
+   import { Result } from '@core/shared/result.js';
+
+   export function assertMigrated(db: Database.Database, dbPath: string): Result<void> {
+     const userVersion = db.pragma('user_version', { simple: true }) as number;
+     if (userVersion === 0) {
+       return Result.fail(
+         `database not initialised at ${dbPath}\n` +
+         `hint: run 'accounting migrate --db-path ${dbPath}' first`,
+       );
+     }
+     return Result.ok(undefined);
+   }
+   ```
+   Pattern mirrors [migrator.ts:18](src/infra/db/migrator.ts:18)'s existing `db.pragma('user_version', { simple: true }) as number` idiom. Returns `Result.fail` (not throw) so CLI callers stay on the existing error-surfacing path.
+
+2. **Wire into [src/cli/program.ts:41](src/cli/program.ts:41)** inside the `ingest` action, **before** constructing any repositories:
+   ```ts
+   .action(async (options) => {
+     const resolvedDb = path.resolve(options.dbPath);
+     const db = getDb(resolvedDb);
+
+     const migrationCheck = assertMigrated(db, resolvedDb);
+     if (migrationCheck.isFailure) {
+       process.stderr.write(`error: ${migrationCheck.error}\n`);
+       process.exit(2);
+     }
+
+     // ... existing construction + runIngestCommand call unchanged
+   });
+   ```
+   Exit code 2 matches existing convention ([runIngestCommand](src/cli/commands/ingest-command.ts) exits 2 on `--non-interactive` low-confidence).
+
+3. **Unit test** for `assertMigrated` — 3 cases: unmigrated → `Result.fail` with the friendly message, migrated → `Result.ok`, migrated-then-check-again stable.
+
+4. **Subprocess integration test** in `tests/integration/cli/uninit-db-hint.test.ts` — spawns the built CLI (`node dist/cli/program.js ingest ...`), points at a non-existent DB path, asserts exit=2, stderr contains the expected strings, stderr does NOT contain `SqliteError` or `at new` (stack-trace token). This is the first subprocess test in the repo; the new `tests/integration/cli/` pattern is worth it because nothing else proves the user-visible fix end-to-end.
+
+5. **`migrate` command stays untouched.** It's the recovery path; must not gate itself on `user_version`. Current `migrate.ts` already wraps `runMigrations` in try/catch — acceptable error surface.
+
+## Gherkin acceptance scenarios
+
+```gherkin
+Feature: Friendly error when ingesting against an uninitialised database
+
+  Scenario: Fresh / unmigrated DB exits 2 with a friendly hint
+    Given a database path that does not yet exist, or exists but has not been migrated
+    When I run `accounting ingest --file <csv> --db-path <path>`
+    Then the process exits with code 2
+    And stderr contains "database not initialised at <path>"
+    And stderr contains "hint: run 'accounting migrate --db-path <path>' first"
+    And stderr does not contain "SqliteError"
+    And stderr does not contain a stack-trace token (e.g. "at new " or "at Command")
+
+  Scenario: Migrated DB ingest works as before
+    Given a database path that has been migrated
+    When I run `accounting ingest --file <csv> --db-path <path>`
+    Then the migration check passes silently
+    And the rest of the ingest pipeline runs as before
+
+  Scenario: `migrate` command against a fresh path still works
+    Given a database path that does not yet exist
+    When I run `accounting migrate --db-path <path>`
+    Then migrations run and the DB is initialised
+    (This is the recovery path — the pre-flight check must NOT gate `migrate` itself.)
+```
+
+## Slice plan for Sonnet
+
+Target **5 commits** + optional refactor slot.
+
+1. **`test(db): assertMigrated helper — failing (story-maint-03)`**
+   - Add `tests/integration/infra/db/migration-check.test.ts` (integration because it uses a real `better-sqlite3` in-memory DB).
+   - 3 test cases:
+     - `(a)` empty DB (user_version = 0) → `Result.fail`; `result.error` contains "database not initialised" + "hint: run 'accounting migrate" + the exact dbPath string.
+     - `(b)` migrated DB (after `runMigrations(db)`) → `Result.ok`.
+     - `(c)` stability: calling twice on a migrated DB returns `ok` both times (no state pollution).
+   - All 3 fail because `src/infra/db/migration-check.ts` doesn't exist yet.
+
+2. **`feat(db): assertMigrated helper — minimal green (story-maint-03)`**
+   - Create [src/infra/db/migration-check.ts](src/infra/db/migration-check.ts) with the body from "Chosen implementation" above.
+   - 3 unit tests green.
+
+3. **`test(cli): subprocess ingest vs uninitialised DB — failing (story-maint-03)`**
+   - Add `tests/integration/cli/uninit-db-hint.test.ts` (new test file; first subprocess test in the repo).
+   - Use `execFileSync('node', ['dist/cli/program.js', 'ingest', ...], { ... })` pattern. CI builds `dist/` before tests; locally `npm run build` is required first (document in the test's header comment).
+   - Setup: create a tmpdir, write a minimal CSV fixture (any valid BPCE shape), assert exit === 2, stderr contains "database not initialised", stderr does NOT contain "SqliteError" or "at new ".
+   - Fails under current code (exits with stack trace).
+
+4. **`feat(cli): pre-flight migration check on ingest — minimal green (story-maint-03)`**
+   - Edit [src/cli/program.ts](src/cli/program.ts): add `import { assertMigrated } from '../infra/db/migration-check.js';`.
+   - Inside the `ingest` `.action`, after `getDb(resolvedDb)` and BEFORE constructing any repositories, call `assertMigrated(db, resolvedDb)`. On failure: `process.stderr.write(...)` + `process.exit(2)`.
+   - Subprocess test green. All 216 tests green (213 existing + 3 unit + subprocess integration).
+
+5. **`refactor(...): empty slot (story-maint-03)`** — or a real behaviour-preserving cleanup if one surfaces. Candidates: none currently anticipated — the change is minimal and the helper is in its natural location. Expect empty commit per § 6.4.
+
+## Risks & deferred items
+
+- **Subprocess test fragility.** Spawning `node dist/cli/program.js` couples the test to the build output. CI always builds before tests (see `.github/workflows/ci.yml`); locally, a fresh checkout needs `npm run build` once. If this becomes friction, a later story can either (a) vitest's `runCLI` helper if we adopt one, or (b) refactor `program.ts` to export a testable handler. Not this story.
+- **`migrate` command remains untested for the "user_version > 0 starting state" case.** Its idempotency is already covered by existing migrator tests. No regression surface here.
+- **No changes to `SqliteTransactionRepository`.** The constructor still eagerly prepares; if someone bypasses `program.ts` and instantiates it directly against an empty DB, the crash reappears. Acceptable — the composition root is the sanctioned entry point.
+- **Integration test directory `tests/integration/cli/` already exists** (see `ingest-commit.test.ts`). No new directory; new file pattern only.
+
+## Suggestion log
+
+Phase 2 (P1 / P2 / P3) run by Opus on 2026-04-24.
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+| P1 | The 3rd Gherkin scenario ("migrate still works on fresh path") lacks a corresponding test. Should we add one? | rejected | Already covered by existing `tests/integration/infra/db/migration-004.test.ts` and migrator tests. Not a regression surface for this story; adding a test would be coverage-duplication. |
+| P2 | The friendly error embeds the full dbPath; if that path contains sensitive info (e.g., `/home/alice/secret/db.db`), is that a PII surface? | rejected | The user is the one who typed the path. Echoing it back is expected UX (search any POSIX CLI error for prior art). Redacting would be surprising and remove the actionability (user can't copy the hint). |
+| P3 | Should the helper go in `src/core/` (with a Core-level port) or `src/infra/` (as direct helper)? | adopted | Helper stays in `src/infra/db/migration-check.ts` — it's inherently coupled to `better-sqlite3`'s Database type, no port abstraction buys anything. Confirmed by reading § 2 architecture note: Core depends on nothing, Infra talks to the outside world. PRAGMA is a SQLite wire-protocol concern; belongs in Infra. |
+| P3 | Subprocess test introduces a new pattern. Worth it? | adopted | Yes — the issue's acceptance criterion is user-visible behaviour (no stack trace in stderr). Unit-testing the helper alone doesn't prove the wire-up. Subprocess test is the minimum pattern that provides E2E proof. Document the one-time `npm run build` requirement in the test file's header comment. |
+
+No deferred items. 2 adopted / 2 rejected. DoR gate met.
+
+## DoR checklist
+
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review): 4 findings (2 adopted, 2 rejected). No deferred items.
+- [ ] Draft PR with template sections 1–6 filled. **Next action.**
+
+**DoR gate met. Ready for Phase 3 after PR opens.**

--- a/docs/retrospectives/story-maint-03.md
+++ b/docs/retrospectives/story-maint-03.md
@@ -1,0 +1,62 @@
+# Story maint-03 retrospective
+
+**PR:** [#45](https://github.com/xavierbriand/accounting/pull/45)  **Closed:** pending merge  **Closes issue:** [#35](https://github.com/xavierbriand/accounting/issues/35)
+
+Third story on the pre-Epic-3 maintenance track. Tenth end-to-end run of the loop overall. A proper bug fix this time (not hardening): ingest against an uninitialised or non-existent DB used to print a raw Node stack trace; now exits 2 with a friendly hint. ~30 LOC of production code + two new test files (9 LOC helper + 4 LOC wire-up + 78 LOC helper test + 74 LOC subprocess test). Test count 213 → 217 (+4). **First subprocess integration test in the repo** — the new pattern is worth documenting separately.
+
+## Keep
+
+- **Sonnet's deviation handling was textbook.** The plan specified `node dist/cli/program.js` for the subprocess test; Sonnet tried it, hit `ERR_MODULE_NOT_FOUND` on the `@core/*` path alias, investigated the root cause (`tsc` doesn't rewrite path aliases in emitted output), chose the working alternative (`tsx src/cli/program.ts` — which is already how `npm run ingest`/`npm run migrate` invoke the CLI), documented the deviation with full root-cause analysis, and proposed a follow-up ([#46](https://github.com/xavierbriand/accounting/issues/46)). **This is exactly the "safeguard-removal rule" pattern from maint-01 retro generalized to tooling substitutions: when the plan's named tool doesn't work, the Deviation names (a) what happened, (b) why, (c) what the alternative would have been, (d) follow-up scope.** Zero round-trips needed; I approved the deviation at review time.
+- **Pre-flight check at the composition root is the right architecture.** The P3 plan-review finding (helper stays in `src/infra/`, not a Core port) held: `PRAGMA user_version` is inherently coupled to `better-sqlite3.Database`; abstracting it via a port would have been ceremony for no benefit. Composition root (`program.ts`) runs the check; repository constructors stay unchanged. Future commands (reconcile, transfer, etc.) just call `assertMigrated` the same way.
+- **Subprocess test earned its complexity.** 450 ms per run (vs ~90 ms in-process) because `tsx` transpiles each invocation. Acceptable cost — it's the only way to prove the user-visible stderr/exit contract end-to-end. The helper-level integration tests prove the logic; the subprocess test proves the wire-up. Both layers pull their weight.
+- **Four rules from maint-01/02 retros continued to function without conflict:**
+  1. `subagent_type: "sonnet-implementer"` direct invocation (maint-01 E) — worked first try.
+  2. Inline-refactor < 5 LOC exception (maint-01 B) — didn't trigger (no refactor needed).
+  3. Safeguard-removal rule (maint-01 A) — generalized here to tooling substitution; Sonnet's deviation write-up implicitly followed the pattern even though the rule's trigger text focuses on defensive constructs.
+  4. Env-var fixture red-proof (maint-02 A) — N/A this story (no env stubbing).
+- **Plan-to-retro scope drift was zero.** Plan said 5 slices + optional refactor; Sonnet delivered exactly that. Plan estimated 216 tests post-change (213 + 3 helper); actual is 217 (213 + 3 helper + 1 subprocess = 217). One off-by-one in my plan's count — trivial.
+
+## Change
+
+- **A. Plan-phase tooling-invocation verification.** My plan specified `node dist/cli/program.js` for the subprocess test without checking whether `dist/` is actually runnable. A 10-second `grep npm package.json` for `ingest`/`migrate` scripts would have surfaced that the repo invokes via `tsx src/cli/program.ts`, not via `node dist/`. Sonnet caught it; next time I should pre-check. **This mirrors maint-02 Change A (env-var fixture red-proof).** Both findings are "plan made an assumption about runtime/tooling behaviour without verifying" — pattern worth naming. **Not a docs rule yet** — reviewer habit. If this pattern recurs in maint-04 or a later story, codify in the planning cheat sheet (§ 6.1 phase 1?) as "Plans that name a specific runtime invocation, env-var value, or build artifact must verify it against repo reality before committing the plan."
+- **B. `dist/` is not a runnable artifact.** Pre-existing condition the story surfaced but didn't introduce. Not a bug in this PR; filed [#46](https://github.com/xavierbriand/accounting/issues/46). Worth noting as retro context because it changes a mental-model assumption about the repo: **`npm run build` type-checks and emits; it does not produce a runnable CLI**. Anyone picking up a subprocess-test story in future should expect `tsx`-based spawning until #46 resolves.
+- **C. Commit `ace92ee` bundled 3 test cases into one TDD red commit.** The plan listed three separate test cases (a/b/c) for `assertMigrated`. Sonnet's return report listed them as three separate lines under the same commit SHA. Looking at the git log: it's genuinely one commit with all three tests added simultaneously. This is acceptable per § 6.4 ("Target 6–10 commits per story; only split further when a slice's failing test genuinely cannot turn green without an intermediate `feat:` step") — all three tests fail for the same reason (helper doesn't exist) and turn green together (once the helper lands). But the return report's presentation was confusing (same SHA ×3). **Not a rule change; just a noticed presentation quirk.** Sonnet could have grouped the three bullets under a single sequence line for clarity: "`chore(tooling): add 3 integration tests for assertMigrated` · ace92ee · proved helper must exist + returns right shape + is stable". No action required — mental note for future report-reading.
+
+## Try
+
+- **Plan-phase "runtime invocation / env / build-artifact" verification step.** When a plan specifies ANY of: a subprocess command, a specific env-var value in a test, a build-artifact path, a tooling binary (`tsx`, `tsc`, `eslint`, etc.) — do a 10-second grep of `package.json` / existing tests to confirm the invocation matches repo reality. If maint-04 or similar surfaces another "plan-assumed-the-wrong-thing" finding, promote to a formal Plan-agent stress-test item or a § 6.1 phase 1 checklist line. Two data points (maint-02 B + maint-03 A) are enough to see a pattern but not enough to codify; want a third.
+- **Subprocess tests as a recognized category.** Now that the pattern exists ([uninit-db-hint.test.ts](../blob/main/tests/integration/cli/uninit-db-hint.test.ts)), future stories that need user-visible stderr/exit-code proof can copy it. Worth noting in [docs/engineering-standards.md](../blob/main/docs/engineering-standards.md) or the testing cheat sheet at some point — but only if a second subprocess test lands and the pattern is clearly durable.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| A. Personal plan-writing checklist — verify runtime-invocation/env-var/build-artifact assumptions against `package.json` + existing tests before committing a plan. | Reviewer habit; not docs. | informal, tracked by reference to this retro + maint-02 retro |
+| B. Follow-up [#46](https://github.com/xavierbriand/accounting/issues/46) — make `dist/` runnable (tsc-alias / `#imports` / bundler). | Filed. | open |
+| C. Observe whether subprocess tests recur; if a second lands cleanly, codify the pattern in engineering-standards. | Passive observation. | open |
+
+## Loop metrics (tenth run; third maintenance-track story)
+
+- **Plan phase:** 1 maintenance sub-loop (0 new Dependabot PRs, audit unchanged) + Opus P1/P2/P3 plan review (4 findings: 2 adopted / 2 rejected).
+- **Implementation:** 1 Sonnet task (5 commits of 5 planned; empty refactor per § 6.4 sanction). **1 deviation** — subprocess runner swapped from `node dist/` to `tsx src/` — documented with root cause and follow-up.
+- **Phase-4 retro-check:** 3 passes (P1 / P2 / P3). Zero blockers. Gherkin coverage verified: 3 scenarios, 2 directly covered, 1 (migrate-still-works) covered by existing migrator tests per rejected P1 suggestion.
+- **Retro fixes:** 0 (no refactor needed, no blockers).
+- **Issues closed by this story:** [#35](https://github.com/xavierbriand/accounting/issues/35).
+- **Issues opened:** 1 ([#46](https://github.com/xavierbriand/accounting/issues/46)) — dist-not-runnable follow-up.
+- **Total commits on branch:** 7 (1 plan + 5 implementation + this retro).
+- **Test count:** 213 → 217 (+4: 3 helper unit/integration + 1 subprocess integration).
+- **Diff stats:** 13 LOC helper + 8 LOC program.ts + 78 LOC helper test + 74 LOC subprocess test + 173 LOC plan + ~95 LOC retro.
+- **Bugs squashed:** 1 (#35 — the raw-SqliteError stack trace is gone; users get a clean hint).
+- **New runtime deps:** 0. **New dev deps:** 0.
+- **New test pattern introduced:** subprocess integration test via `tsx src/cli/program.ts`.
+- **Time-to-DoD:** one session, ~45 min total.
+
+## Carryovers resolved
+
+- Story 2.5 retro pre-merge smoke-test finding → **CLOSED by this story**. #35 was the first-contact-with-real-data bug reported at that time.
+- story-maint-01 retro action A (safeguard-removal rule) → engaged; pattern generalized implicitly to "tooling substitution" in Sonnet's deviation. Consider renaming/broadening the rule in a future retro (not this one) if a third case shows the same shape.
+- story-maint-01 retro action B (Opus inline-refactor < 5 LOC) → didn't trigger.
+- story-maint-01 retro action E (harness invocation refresh) → engaged; third story in a row using `subagent_type: "sonnet-implementer"` direct invocation without issue.
+- story-maint-02 retro Change A (env-var fixture red-proof) → extended here to "runtime-invocation fixture verification" (Change A of this retro). Same underlying pattern.
+- Issue [#42](https://github.com/xavierbriand/accounting/issues/42) (vitest config consolidation): still open.
+- Issue [#43](https://github.com/xavierbriand/accounting/issues/43) (helper extraction): still open.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -15,6 +15,7 @@ import { readBpceCsv } from '../infra/fs/read-bpce-csv.js';
 import { inquirerPrompter } from './utils/interactive.js';
 import { runIngestCommand } from './commands/ingest-command.js';
 import { runMigrate } from './migrate.js';
+import { assertMigrated } from '../infra/db/migration-check.js';
 
 const program = new Command();
 
@@ -41,6 +42,13 @@ program
   .action(async (options: { file: string; nonInteractive: boolean; json: boolean; dbPath: string }) => {
     const resolvedDb = path.resolve(options.dbPath);
     const db = getDb(resolvedDb);
+
+    const migrationCheck = assertMigrated(db, resolvedDb);
+    if (migrationCheck.isFailure) {
+      process.stderr.write(`error: ${migrationCheck.error}\n`);
+      process.exit(2);
+    }
+
     const configService = new FileConfigService({ projectDir: process.cwd() });
     const csvParser = new NodeCsvParser();
     const hashRepo = new SqliteHashRepository(db);

--- a/src/infra/db/migration-check.ts
+++ b/src/infra/db/migration-check.ts
@@ -1,0 +1,13 @@
+import type Database from 'better-sqlite3';
+import { Result } from '@core/shared/result.js';
+
+export function assertMigrated(db: Database.Database, dbPath: string): Result<void> {
+  const userVersion = db.pragma('user_version', { simple: true }) as number;
+  if (userVersion === 0) {
+    return Result.fail(
+      `database not initialised at ${dbPath}\n` +
+      `hint: run 'accounting migrate --db-path ${dbPath}' first`,
+    );
+  }
+  return Result.ok(undefined);
+}

--- a/tests/integration/cli/uninit-db-hint.test.ts
+++ b/tests/integration/cli/uninit-db-hint.test.ts
@@ -1,0 +1,71 @@
+// NOTE: This test spawns the built CLI; CI runs npm run build before tests. Locally, run 'npm run build' once before this test.
+/**
+ * Integration test: CLI ingest against an uninitialised DB emits a friendly error.
+ *
+ * Gherkin coverage:
+ *   - "Fresh / unmigrated DB exits 2 with a friendly hint"
+ *
+ * fails if: pre-flight migration check is missing from program.ts (ingest action would
+ *   attempt to construct SqliteTransactionRepository, which eagerly prepares statements
+ *   and throws a raw SqliteError with a stack trace — visible as "SqliteError" or "at new "
+ *   in stderr), or the exit code is wrong (not 2), or the friendly message strings are absent.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const CLI_PATH = path.join(__dirname, '../../../dist/cli/program.js');
+
+const FIXTURE_CSV = path.join(__dirname, '../../fixtures/csv/bpce-valid.csv');
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-uninit-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+describe('ingest against uninitialised DB', () => {
+  it('exits 2, stderr contains friendly hint, no SqliteError or stack trace', () => {
+    // fails if: pre-flight migration check is not wired into program.ts ingest action —
+    //   without the check, SqliteTransactionRepository constructor throws a raw SqliteError
+    //   with a stack trace that would reach the user. This test proves the user-visible fix.
+    const tmpDir = makeTmpDir();
+    const dbPath = path.join(tmpDir, 'uninit.db');
+    const csvPath = path.join(tmpDir, 'bpce-valid.csv');
+    fs.copyFileSync(FIXTURE_CSV, csvPath);
+
+    let error: { status: number | null; stderr: Buffer | string; stdout: Buffer | string } | null = null;
+
+    try {
+      execFileSync('node', [CLI_PATH, 'ingest', '--file', csvPath, '--db-path', dbPath], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (e) {
+      error = e as { status: number | null; stderr: Buffer | string; stdout: Buffer | string };
+    }
+
+    expect(error).not.toBeNull();
+
+    const stderr = error!.stderr.toString();
+    expect(error!.status).toBe(2);
+    expect(stderr).toContain('database not initialised');
+    expect(stderr).toContain("hint: run 'accounting migrate");
+    expect(stderr).not.toContain('SqliteError');
+    expect(stderr).not.toContain('at new ');
+  });
+});

--- a/tests/integration/cli/uninit-db-hint.test.ts
+++ b/tests/integration/cli/uninit-db-hint.test.ts
@@ -1,4 +1,6 @@
-// NOTE: This test spawns the built CLI; CI runs npm run build before tests. Locally, run 'npm run build' once before this test.
+// NOTE: This test spawns the CLI via tsx (handles @core path alias). No separate build step needed.
+// The plan specified 'node dist/cli/program.js' but dist/ does not rewrite @core imports;
+// tsx resolves them via tsconfig.json paths at runtime. Deviation documented in return report.
 /**
  * Integration test: CLI ingest against an uninitialised DB emits a friendly error.
  *
@@ -20,7 +22,8 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const CLI_PATH = path.join(__dirname, '../../../dist/cli/program.js');
+const TSX_BIN = path.join(__dirname, '../../../node_modules/.bin/tsx');
+const CLI_SRC = path.join(__dirname, '../../../src/cli/program.ts');
 
 const FIXTURE_CSV = path.join(__dirname, '../../fixtures/csv/bpce-valid.csv');
 
@@ -51,7 +54,7 @@ describe('ingest against uninitialised DB', () => {
     let error: { status: number | null; stderr: Buffer | string; stdout: Buffer | string } | null = null;
 
     try {
-      execFileSync('node', [CLI_PATH, 'ingest', '--file', csvPath, '--db-path', dbPath], {
+      execFileSync(TSX_BIN, [CLI_SRC, 'ingest', '--file', csvPath, '--db-path', dbPath], {
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe'],
       });

--- a/tests/integration/infra/db/migration-check.test.ts
+++ b/tests/integration/infra/db/migration-check.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Integration tests for assertMigrated — pre-flight migration check helper.
+ *
+ * Gherkin coverage:
+ *   - "Fresh / unmigrated DB exits 2 with a friendly hint"
+ *     (partial — unit-level probe of the helper; CLI subprocess test covers the full scenario)
+ *
+ * fails if: helper returns ok on an empty DB (migration guard would be bypassed),
+ *   friendly message is missing key strings (user can't act on the hint),
+ *   or stable call on a migrated DB suddenly returns failure (regression on repeated check).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { assertMigrated } from '../../../../src/infra/db/migration-check.js';
+import { runMigrations } from '../../../../src/infra/db/migrator.js';
+
+const dbs: Database.Database[] = [];
+
+function makeEmptyDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  dbs.push(db);
+  return db;
+}
+
+function makeMigratedDb(): Database.Database {
+  const db = makeEmptyDb();
+  runMigrations(db);
+  return db;
+}
+
+afterEach(() => {
+  for (const db of dbs.splice(0)) {
+    if (db.open) db.close();
+  }
+});
+
+describe('assertMigrated', () => {
+  it('(a) empty DB (user_version=0) returns Result.fail with friendly message containing dbPath', () => {
+    // fails if: assertMigrated returns ok on an uninitialised DB
+    //   (the migration guard would be bypassed, SqliteTransactionRepository constructor
+    //    would throw a raw SqliteError that reaches the user as a stack trace)
+    const db = makeEmptyDb();
+    const dbPath = '/tmp/test-uninit.db';
+
+    const result = assertMigrated(db, dbPath);
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('database not initialised');
+    expect(result.error).toContain("hint: run 'accounting migrate");
+    expect(result.error).toContain(dbPath);
+  });
+
+  it('(b) migrated DB (after runMigrations) returns Result.ok', () => {
+    // fails if: assertMigrated incorrectly reads user_version or the pragma idiom
+    //   differs from the migrator's own check — a migrated DB would be wrongly rejected
+    const db = makeMigratedDb();
+    const dbPath = '/tmp/test-migrated.db';
+
+    const result = assertMigrated(db, dbPath);
+
+    expect(result.isSuccess).toBe(true);
+  });
+
+  it('(c) calling assertMigrated twice on a migrated DB is stable — both return ok', () => {
+    // fails if: assertMigrated modifies state or has side effects that cause
+    //   the second call to behave differently from the first
+    const db = makeMigratedDb();
+    const dbPath = '/tmp/test-stable.db';
+
+    const first = assertMigrated(db, dbPath);
+    const second = assertMigrated(db, dbPath);
+
+    expect(first.isSuccess).toBe(true);
+    expect(second.isSuccess).toBe(true);
+  });
+});


### PR DESCRIPTION
## 1. Story

[Issue #35](https://github.com/xavierbriand/accounting/issues/35) (`bug` + `ux`) — surfaced during Story 2.5's first-contact-with-real-data manual smoke test. Third pre-Epic-3 maintenance story (sequence: #18 ✓ → #22 ✓ → **#35** → #21 → #38 → #12 → #11 → Epic 3).

## 2. Intent

Running `accounting ingest --db-path <non-existent-or-unmigrated-db>` currently prints a raw Node stack trace with `SqliteError: no such table: transactions`. Unfriendly, debugging-aid output. Replace with a composition-root pre-flight `user_version` check that emits a clean `error: database not initialised at <path>\nhint: run 'accounting migrate --db-path <path>' first` and `process.exit(2)`.

## 3. Alternatives considered

- **Option 1** (chosen) — pre-flight check in `program.ts` via `assertMigrated(db, dbPath)` helper in infra. Composition-root-owned, reusable for future commands.
- **Option 2** — lazy `db.prepare()` in `SqliteTransactionRepository`. Rejected: defers the crash, no UX improvement.
- **Option 3** — try/catch error boundary with `SqliteError` message-matching. Rejected: brittle string matching across better-sqlite3 versions.

## 4. Selected solution & rationale

Option 1. Full detail in [docs/plans/story-maint-03.md](docs/plans/story-maint-03.md).

1. New [src/infra/db/migration-check.ts](src/infra/db/migration-check.ts) exporting `assertMigrated(db, dbPath): Result<void>`.
2. [src/cli/program.ts](src/cli/program.ts) `ingest` action calls `assertMigrated(db, resolvedDb)` right after `getDb()`. On failure: stderr line + `process.exit(2)`.
3. 3 helper unit tests + 1 subprocess integration test (first of its kind in the repo).
4. `migrate` command stays untouched (it's the recovery path).

## 5. Gherkin scenarios

```gherkin
Feature: Friendly error when ingesting against an uninitialised database

  Scenario: Fresh / unmigrated DB exits 2 with a friendly hint
    Given a database path that does not yet exist, or exists but has not been migrated
    When I run `accounting ingest --file <csv> --db-path <path>`
    Then the process exits with code 2
    And stderr contains "database not initialised at <path>"
    And stderr contains "hint: run 'accounting migrate --db-path <path>' first"
    And stderr does not contain "SqliteError"
    And stderr does not contain a stack-trace token

  Scenario: Migrated DB ingest works as before
    Given a database path that has been migrated
    When I run `accounting ingest --file <csv> --db-path <path>`
    Then the migration check passes silently
    And the rest of the ingest pipeline runs as before

  Scenario: `migrate` command against a fresh path still works
    Given a database path that does not yet exist
    When I run `accounting migrate --db-path <path>`
    Then migrations run and the DB is initialised
```

## 6. Plan for Sonnet

Target **5 commits** + optional refactor slot. Full plan: [docs/plans/story-maint-03.md](docs/plans/story-maint-03.md).

## 7. Suggestion log

Phase 2 (P1 / P2 / P3) run by Opus on 2026-04-24.

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P1 | Add a test for the "migrate still works on fresh path" Gherkin scenario. | rejected | Already covered by existing migrator tests. |
| P2 | Friendly error echoes the user-supplied dbPath — PII? | rejected | User typed the path; echoing is expected UX. |
| P3 | Should the helper go in `src/core/` (Core port) or `src/infra/` (direct helper)? | adopted | Stays in `src/infra/` — coupled to `better-sqlite3.Database` type; no port buys anything. |
| P3 | Subprocess test introduces a new repo pattern. Worth it? | adopted | Yes — user-visible stderr/exit contract needs E2E proof. |

**Phase-4 retro-check findings (post-implementation):** zero blockers. Sonnet's one deviation (`tsx src/cli/program.ts` instead of `node dist/cli/program.js`) was a legitimate root-cause catch: `tsc` doesn't rewrite `@core/*` path aliases, so `dist/` isn't runnable with bare Node. Pre-existing repo condition; filed [#46](https://github.com/xavierbriand/accounting/issues/46) as follow-up.

## 8. Sonnet's learnings

## What was built

Three Gherkin scenarios addressed: (1) fresh/unmigrated DB exits with code 2 and a friendly hint instead of a raw `SqliteError` stack; (2) migrated DB continues to work; (3) `migrate` command untouched. Two new files: `src/infra/db/migration-check.ts` (9-LOC `assertMigrated(db, dbPath): Result<void>` helper reading `PRAGMA user_version`) and two test files (helper integration + CLI subprocess). Wire-up in `program.ts` is 4 LOC added immediately after `getDb()`. 217/217 green.

## Red → green sequence

- `(a) empty DB → Result.fail` · `ace92ee` — plus cases `(b)` migrated → `Result.ok` and `(c)` stability, all in one commit (turn green together).
- `feat(db): assertMigrated helper` · `844e1fd` — helper implementation; 3 tests green.
- `test(cli): subprocess ingest vs uninitialised DB — failing` · `f8f6f92` — proves the wire-up is needed.
- `feat(cli): pre-flight migration check in program.ts` · `da57107` — all 217 green.
- `refactor(db): empty slot` · `0f5dc7e` — per § 6.4.

## Deviations from plan

- **Subprocess runner: `tsx src/cli/program.ts` instead of `node dist/cli/program.js`.** Root cause: `tsc` does not rewrite `@core/*` path aliases in emitted `.js` files — `dist/` is not runnable with bare Node (`ERR_MODULE_NOT_FOUND`). The project's `npm run migrate`/`npm run ingest` scripts already use `tsx src/cli/program.ts`. The subprocess test now matches that invocation pattern. Trade-off: ~450 ms per run (vs ~90 ms in-process) because `tsx` transpiles each invocation. Alternative (`node dist/`) would require `tsc-alias` or `#imports` subpath mapping. Filed [#46](https://github.com/xavierbriand/accounting/issues/46).

## Gherkin coverage checklist

- ✓ Fresh / unmigrated DB exits 2 with a friendly hint → `tests/integration/cli/uninit-db-hint.test.ts`
- ✓ Migrated DB ingest works as before → `tests/integration/infra/db/migration-check.test.ts` cases (b)+(c) at helper level; `tests/integration/cli/ingest-commit.test.ts` regresses at CLI level
- ✗ `migrate` command against a fresh path still works — not covered by new test. Per rejected P1 suggestion: existing migrator tests cover it.

## Unknowns encountered

The `@core` path alias resolution gap between `tsc` output and Node.js runtime was not anticipated in the plan. Surfaced during subprocess-test debugging; filed as follow-up #46.

## Proposed follow-ups

- [#46](https://github.com/xavierbriand/accounting/issues/46) — make `dist/` runnable (tsc-alias / `#imports` / bundler). Would also let future subprocess tests use `node dist/` (~5× faster).

## Files touched

- `src/infra/db/migration-check.ts` · new · `assertMigrated(db, dbPath): Result<void>` helper.
- `src/cli/program.ts` · +1 import, +6 LOC pre-flight check in the `ingest` action.
- `tests/integration/infra/db/migration-check.test.ts` · new · 3 integration tests for the helper.
- `tests/integration/cli/uninit-db-hint.test.ts` · new · subprocess integration test (first of its kind).

## 9. Retrospective

- **Keep:** Sonnet's deviation handling was textbook — plan's `node dist/` failed on `@core/*` path alias; Sonnet investigated root cause, pivoted to `tsx src/` (matching existing npm scripts), documented deviation, proposed follow-up #46. Pre-flight composition-root check architecture held; four rules from maint-01/02 retros co-existed cleanly.
- **Change:** (A) plan-phase tooling-invocation verification — my plan specified `node dist/` without checking if dist/ is runnable; mirrors maint-02 Change A (env-var fixture red-proof); want a third data point before codifying. (B) `dist/` not runnable — filed [#46](https://github.com/xavierbriand/accounting/issues/46).
- **Try:** "Plan-phase runtime-invocation verification" — 10-second grep of `package.json`/existing tests to confirm subprocess commands, env-var values, and build-artifact paths match repo reality before committing the plan.

Full retrospective: [docs/retrospectives/story-maint-03.md](docs/retrospectives/story-maint-03.md).

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-maint-03.md`
- [x] All suggestion-log items resolved
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)