### PR TITLE
chore(ci): restrict GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds top-level `permissions: { contents: read }` to `.github/workflows/ci.yml`.
- Closes CodeQL alert [#1](https://github.com/xavierbriand/accounting/security/code-scanning/1) (`actions/missing-workflow-permissions`, CWE-275, severity: warning / medium).
- Least-privilege scope — the workflow only checks out code and runs `npm ci` / lint / build / test.

## Test plan
- [ ] CI green on this branch.
- [ ] CodeQL scan on `main` (post-merge) clears alert #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)