### PR TITLE
chore(deps): pin tmp >=0.2.4 and uuid >=14 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3536,15 +3536,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4235,15 +4226,12 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4385,9 +4373,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -4395,7 +4383,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -48,5 +48,9 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.0",
     "vitest": "^4.1.5"
+  },
+  "overrides": {
+    "tmp": "^0.2.4",
+    "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Closes Dependabot [#1](https://github.com/xavierbriand/accounting/security/dependabot/1) (`tmp` GHSA-52f5-9888-hmc6, low — symlink-bypass file write) and [#2](https://github.com/xavierbriand/accounting/security/dependabot/2) (`uuid` GHSA-w5hq-g745-h8pq, moderate — missing buffer bounds check in v3/v5/v6).
- Both are transitive: `tmp` via `@inquirer/prompts` → `@inquirer/editor` → `external-editor` (runtime, but the editor prompt is dormant — only `select`/`confirm` are imported), and `uuid` via `quickpickle` → `@cucumber/messages` (dev only).
- Uses `npm overrides` to pin patched versions without bumping the parents (no critical-path major per CLAUDE.md § 6.7).
- Lint, build, 213 tests all green. `npm audit` reports 0 vulnerabilities.

## Test plan
- [x] CI green (lint + build + tests).
- [ ] Dependabot re-scan post-merge clears alerts #1 and #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)