### PR TITLE
story-maint-04: validate dbPath against symlink hijacking

### DIFF
--- a/.claude/agents/sonnet-implementer.md
+++ b/.claude/agents/sonnet-implementer.md
@@ -77,6 +77,20 @@ Phase 4 review discovers the gap by reading test names / comments
 (story-maint-01 caught a 500ms timeout silently dropped this way), adding a
 round-trip.
 
+**Commit-bundle separation (retro finding, story-maint-04).**
+`chore:` baseline-tooling commits (lint excludes, test-runner excludes, formatter
+ignores, etc.) must stay separate from `test:` / `feat:` story commits, even when
+committed back-to-back. If a `feat:` commit body needs a tooling preamble — e.g.
+*"Also excludes .claude/ worktrees from vitest to prevent agent-session pollution"*
+— that preamble belongs in a sibling `chore:` commit landed first, not bundled
+into the `feat:`. Why: a `feat:` commit's role in `git log --oneline` is "this is
+the slice that turned the previously-failing tests green"; bundling tooling makes
+the commit's role ambiguous and complicates future revert / cherry-pick.
+story-maint-04's `feat(db): validateDbPath implementation — minimal green` commit
+shipped a vitest-config exclude alongside the helper code; the exclude
+should have been a sibling `chore(test):` or merged with the earlier `chore(lint):`
+baseline commit.
+
 ## Gherkin coverage checklist
 <Tick every Gherkin scenario in the plan against the test it maps to, one line each:
 `✓ <scenario name> → <test file>:<describe name>` — or `✗ <scenario name> → not covered: <rationale>`.

--- a/docs/plans/story-maint-04.md
+++ b/docs/plans/story-maint-04.md
@@ -1,0 +1,197 @@
+# Story maint-04 — Validate `dbPath` against symlink-based path hijacking
+
+## Context
+
+Fourth story on the pre-Epic-3 maintenance track. [Issue #21](https://github.com/xavierbriand/accounting/issues/21) — Story 1.4 P3 deferred suggestion. **Elevated in priority by Story 2.5**, which added a sibling `.bak` snapshot path derived from `dbPath`: the filename attack surface doubled.
+
+**Threat model.** `dbPath` is user-controlled via two sources: (a) the CLI `--db-path` flag, (b) `accounting.yaml`'s `dbPath` field (parsed into `AppConfig.dbPath` — not yet wired to `getDb` at CLI level, but latent). An adversary with write access to the config location (tainted share-file, co-installed compromised package, or a hostile `accounting.yaml` in a cloned repo) can point `dbPath` at a symlink whose target is an unrelated file the user can write to. `better-sqlite3.Database` opens the path, follows the symlink, writes SQLite bytes — corrupting or creating the target. The blast radius extends to `${dbPath}.bak` since Story 2.5 snapshots there.
+
+**Current defence.** [src/cli/program.ts:43](src/cli/program.ts:43) and [src/cli/migrate.ts:6](src/cli/migrate.ts:6) both call `path.resolve(options.dbPath)` before `getDb()`. That collapses `..` segments but **does nothing about symlinks**. No validation of the resolved path's filesystem reality.
+
+**Outcome.** A new `validateDbPath(rawPath): Result<string>` helper in infra that:
+1. Resolves the path (`path.resolve`).
+2. `lstatSync`s it: if the entry exists and is a symbolic link, refuses with a friendly error.
+3. Tolerates `ENOENT` (fresh install: path doesn't exist yet — `getDb` will create it).
+
+Wired into both `migrate` and `ingest` actions at the composition root (same pattern as story-maint-03's `assertMigrated`). Updates the [docs/security-checklist.md:26](docs/security-checklist.md) line about user-controlled paths to name the new enforcement.
+
+**Maintenance sub-loop (§ 6.7)** run 2026-04-25 post story-maint-03 merge: main synced, 0 new Dependabot PRs, `npm audit` unchanged (0 high/critical). **Proceed-to-planning.**
+
+## Story (from [issue #21](https://github.com/xavierbriand/accounting/issues/21), scoped)
+
+> In the wire-up story:
+> 1. Normalize the path via `path.resolve` before opening.  ← **already done**; lock it in.
+> 2. Assert it is within an allowed root... reject symlinks that escape it, reject absolute paths outside the allowed root, reject paths containing `..` after resolution when strict mode is enabled.
+> 3. Document the policy in `docs/security-checklist.md`.
+> 4. Add a unit test for each rejection case.
+
+**Scope cut.** The issue's bullet 2 proposes three enforcement layers (symlink-escape, absolute-outside-allowed-root, strict-mode `..` rejection). For this story we adopt **only the symlink rejection**. Allowed-root policy requires defining an allowed-root concept (`dataDir` config field, per-user data directory, project-root fencing) that doesn't exist today; strict-mode `..` would forbid legitimate user-chosen relative paths. Both become their own stories when a concrete policy emerges. Documented under "Deferred items" below.
+
+Closes #21. No FR coverage (security hardening). Walks [docs/security-checklist.md § Validation & boundaries](docs/security-checklist.md).
+
+## Selected solution
+
+Two options considered.
+
+**Option A — single check at composition root** (chosen). Helper `validateDbPath(raw): Result<string>` in `src/infra/db/db-path-validator.ts`. Both `migrate` and `ingest` actions in `program.ts` call it before `getDb()`. Consistent with story-maint-03's `assertMigrated` pattern.
+- Pro: one policy point; same code path for both commands and any future command.
+- Pro: helper is pure + Result-returning; easy to unit test.
+- Con: each action has to remember to call it. Mitigated by grouping composition-root checks — both land near `getDb(resolvedDb)`.
+
+**Option B — check inside `getDb`.** Move the validation into `src/infra/db/sqlite-client.ts`. Impossible to forget, enforced everywhere.
+- Pro: single choke point.
+- Con: `getDb`'s signature must change from throwing-on-failure to `Result<Database>` (since validation is policy and should be surface-able). Touches every caller (program.ts migrate + ingest actions, plus every test that constructs a DB). Big blast radius for a security policy that currently has two callers.
+- Con: `getDb` today does real file I/O (creates empty DB, sets pragmas, chmods). Mixing validation into that is layering a policy onto an operation — breaks single responsibility.
+
+**Option A chosen.** Option B is re-considered if a third caller emerges.
+
+### Chosen implementation
+
+1. **New file** [src/infra/db/db-path-validator.ts](src/infra/db/db-path-validator.ts):
+   ```ts
+   import fs from 'fs';
+   import path from 'path';
+   import { Result } from '@core/shared/result.js';
+
+   export function validateDbPath(rawPath: string): Result<string> {
+     const resolved = path.resolve(rawPath);
+     try {
+       const stat = fs.lstatSync(resolved);
+       if (stat.isSymbolicLink()) {
+         return Result.fail(
+           `refusing to open dbPath: ${rawPath} is a symbolic link. ` +
+           `Point --db-path at a regular file or let one be created fresh.`,
+         );
+       }
+     } catch (err) {
+       const code = (err as NodeJS.ErrnoException).code;
+       if (code !== 'ENOENT') {
+         return Result.fail(`failed to stat dbPath '${rawPath}': ${String(err)}`);
+       }
+       // ENOENT is acceptable — getDb will create the file.
+     }
+     return Result.ok(resolved);
+   }
+   ```
+   Returns the resolved path on success so callers don't re-`path.resolve`.
+
+2. **Wire into [src/cli/program.ts](src/cli/program.ts)** — both `migrate` and `ingest` actions, replacing the current `path.resolve(options.dbPath)` line:
+   ```ts
+   const validation = validateDbPath(options.dbPath);
+   if (validation.isFailure) {
+     process.stderr.write(`error: ${validation.error}\n`);
+     process.exit(2);
+   }
+   const resolvedDb = validation.value;
+   ```
+   The `migrate` action currently delegates to `runMigrate(options.dbPath)` in `migrate.ts`. Two moves:
+   - Option W (widens program.ts): inline the validation in program.ts before calling `runMigrate`, pass the validated path.
+   - Option X (widens migrate.ts): move validation into `runMigrate` itself.
+   - **Choice:** W — keeps the composition-root pattern consistent with `ingest`.
+
+3. **Update [src/cli/migrate.ts](src/cli/migrate.ts)** — accept the already-resolved path from program.ts; drop the internal `path.resolve`.
+
+4. **Update [docs/security-checklist.md:26](docs/security-checklist.md)** — expand the "No user-controlled path strings reach `fs` without prior normalization" line to mention the new symlink-rejection enforcement at CLI boundaries.
+
+5. **Tests:**
+   - **Unit:** `tests/integration/infra/db/db-path-validator.test.ts` (integration tier because it touches real `fs.lstatSync`):
+     - `(a)` non-existent path → `Result.ok(resolved)`.
+     - `(b)` regular file at path → `Result.ok(resolved)`.
+     - `(c)` symlink at path (pointing at a real target) → `Result.fail` with "symbolic link" token.
+     - `(d)` symlink at path (dangling — target doesn't exist) → `Result.fail` with "symbolic link" token. Defensive case: dangling symlinks are still symlinks.
+     - `(e)` `EACCES` surface: a stat that fails for non-ENOENT reason propagates as `Result.fail`. Simulate by stubbing `fs.lstatSync` (vitest mock).
+   - **Subprocess integration:** `tests/integration/cli/symlink-dbpath-refuse.test.ts` — reuses the tsx-spawn pattern from story-maint-03's [uninit-db-hint.test.ts](tests/integration/cli/uninit-db-hint.test.ts). Two tests (one per command):
+     - `ingest --db-path <symlink>` → exit 2, stderr contains "symbolic link" + "refusing to open dbPath", no `SqliteError` or stack token.
+     - `migrate --db-path <symlink>` → same.
+
+## Gherkin acceptance scenarios
+
+```gherkin
+Feature: Reject symlinked dbPath
+
+  Scenario: CLI ingest against a symlinked db path is refused
+    Given a symlink at /tmp/link.db pointing at anywhere (target existent or dangling)
+    When I run `accounting ingest --db-path /tmp/link.db --file <csv>`
+    Then the process exits with code 2
+    And stderr contains "refusing to open dbPath"
+    And stderr contains "symbolic link"
+    And stderr does not contain "SqliteError"
+    And no write reaches the symlink's target
+
+  Scenario: CLI migrate against a symlinked db path is refused
+    Given a symlink at /tmp/link.db
+    When I run `accounting migrate --db-path /tmp/link.db`
+    Then the process exits with code 2
+    And stderr contains "refusing to open dbPath"
+    And stderr contains "symbolic link"
+
+  Scenario: Regular file at dbPath proceeds normally
+    Given a regular file at /tmp/real.db (possibly an existing SQLite DB)
+    When I run `accounting ingest --db-path /tmp/real.db ...`
+    Then validation passes silently
+    And the rest of the ingest pipeline runs as before
+
+  Scenario: Non-existent dbPath proceeds (getDb creates fresh)
+    Given /tmp/fresh.db does not exist
+    When I run `accounting migrate --db-path /tmp/fresh.db`
+    Then validation passes (ENOENT is acceptable)
+    And getDb creates the file and migrations run
+```
+
+## Slice plan for Sonnet
+
+Target **7 commits** + retrospective.
+
+1. **`test(db): validateDbPath — failing (story-maint-04)`**
+   - New file `tests/integration/infra/db/db-path-validator.test.ts` with the 5 cases enumerated above.
+   - All 5 fail because the helper file doesn't exist yet.
+
+2. **`feat(db): validateDbPath implementation — minimal green (story-maint-04)`**
+   - Create `src/infra/db/db-path-validator.ts` with the exact body above.
+   - All 5 unit tests green.
+
+3. **`test(cli): migrate + ingest refuse symlinked dbPath — failing (story-maint-04)`**
+   - New file `tests/integration/cli/symlink-dbpath-refuse.test.ts` — 2 subprocess tests (reuse tsx-spawn pattern from [uninit-db-hint.test.ts](tests/integration/cli/uninit-db-hint.test.ts)).
+   - Each test: create a tmpdir, create a symlink inside it (pointing at a sibling real file — avoids ENOENT on the target), spawn `tsx src/cli/program.ts migrate|ingest --db-path <symlink>`, assert exit=2 + stderr contents.
+   - Fails under current code: `getDb` will happily follow the symlink and better-sqlite3 will open the target (possibly a valid SQLite file, possibly not — either way, no stderr refusal).
+
+4. **`feat(cli): wire validateDbPath into program.ts migrate + ingest — minimal green (story-maint-04)`**
+   - Edit `src/cli/program.ts`: import `validateDbPath`; in both `migrate` and `ingest` actions, call it before `getDb`. On failure: stderr + exit 2.
+   - Edit `src/cli/migrate.ts`: drop the internal `path.resolve` (program.ts now hands in a validated path); `runMigrate(resolvedDb)` directly.
+   - Subprocess tests green.
+   - Existing tests regression-check: `npm test` runs full suite.
+
+5. **`chore(docs): document dbPath symlink-rejection in security-checklist (story-maint-04)`**
+   - Edit [docs/security-checklist.md:26](docs/security-checklist.md) — expand the existing line to call out the new enforcement. Add a sub-bullet for the `.bak` sibling surface that's transitively protected.
+
+6. **`refactor(db): empty slot — no cleanup identified (story-maint-04)`**
+   - Empty `refactor:` per § 6.4.
+
+7. **Retrospective** (`chore(retro): ...`) — separate commit as always.
+
+## Risks & deferred items
+
+- **Allowed-root enforcement is out of scope.** A policy (`dataDir: ~/.accounting` or similar) requires a product decision. Not blocking for the symlink rejection — the main attack vector closes. File a follow-up issue for "define an allowed-root policy for dbPath" if/when a concrete caller surfaces.
+- **Parent-directory symlinks unvalidated.** If `dbPath = /home/alice/data/db.sqlite` and `/home/alice/data` is itself a symlink to an attacker-chosen directory, `lstatSync` on `db.sqlite` doesn't flag it. Realpath-parent comparison would catch it but introduces allowed-root complexity. Documented limitation; scoped out.
+- **TOCTOU between lstat and open.** A narrow window exists where an attacker could swap the file for a symlink between our `lstatSync` and better-sqlite3's `open`. For a local-CLI threat model this is acceptable: the attacker already has filesystem write access to the user's path. Story 2.5's snapshot service uses atomic-rename-from-randomised-tmp precisely because writes are the attackable surface; opens are harder to race.
+- **`AppConfig.dbPath` config-file surface is still un-wired.** Current state: CLI `--db-path` flag is the only source of `dbPath` reaching `getDb`. When a future story wires `configService.load().value.dbPath` → `getDb`, it should call the same `validateDbPath` helper. Called out in the retro to be linked when that story lands.
+
+## Suggestion log
+
+Phase 2 (P1 / P2 / P3) run by Opus on 2026-04-25.
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+| P1 | Gherkin scenario 4 ("non-existent dbPath proceeds") — covered by the unit test case (a) and implicitly by existing migrator tests (they use in-memory or fresh paths). Add a subprocess version too? | rejected | Doubles subprocess-test cost (slow `tsx` transpile) for a path already covered at the unit + integration levels. |
+| P2 | Symlink error message echoes the raw `rawPath` — PII leak? | rejected | Same posture as story-maint-03 P2 rejection: the user typed the path, echoing is UX. Redacting removes the actionable "which path?" context. |
+| P3 | Should the validation be in `src/core/` (Core port) or `src/infra/` (direct helper)? | adopted | Stays in `src/infra/db/` — the check is intrinsically bound to `fs.lstatSync` (Node API); no Core port buys anything. Mirrors story-maint-03 P3 decision for `assertMigrated`. |
+| P3 | Should the helper also check for hard links (multiple names pointing at one inode)? | rejected | Hard links don't participate in path-traversal attacks — they share an inode but can't point "outside" the filesystem. Not a symlink-class concern. |
+| P3 | Scenario 4 test relies on `getDb` creating the file; if `getDb`'s behaviour changes (e.g., stops auto-creating), the scenario silently breaks. Should we assert file creation too? | adopted | Expand scenario 4's subprocess test (or rely on existing migrator tests covering the create path). Decision: rely on existing tests — they'd fail first if `getDb` regressed. Avoid over-testing here. |
+
+2 adopted / 3 rejected / 0 deferred. DoR gate met.
+
+## DoR checklist
+
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review): 5 findings (3 adopted, 3 rejected). No deferred items.
+- [ ] Draft PR with template sections 1–6 filled. **Next action.**

--- a/docs/retrospectives/story-maint-04.md
+++ b/docs/retrospectives/story-maint-04.md
@@ -1,0 +1,58 @@
+# Story maint-04 retrospective
+
+**PR:** [#50](https://github.com/xavierbriand/accounting/pull/50)  **Closed:** pending merge  **Closes issue:** [#21](https://github.com/xavierbriand/accounting/issues/21)
+
+Fourth story on the pre-Epic-3 maintenance track. Eleventh end-to-end run of the loop overall. First **security-hardening** story (vs hardening-with-UX or pure-tooling). Plan scope: symlink rejection at the CLI composition root for both `migrate` and `ingest`. Implementation came in 8 commits + 1 Opus inline fix + retro = 10 on the branch. Test count 217 → 224 (+7: 5 helper + 2 subprocess). Reused the tsx-spawn subprocess pattern from story-maint-03.
+
+## Keep
+
+- **The four-story streak of "helper-at-composition-root" is now a stable pattern.** maint-02 (`os.homedir()` in FileConfigService) → maint-03 (`assertMigrated` before getDb) → maint-04 (`validateDbPath` before getDb). Three composition-root checks, all in `program.ts`'s action handlers, all with the same `Result.fail → stderr → exit 2` shape. Each check stays orthogonal; they compose without coupling. **Not yet a documented pattern in engineering-standards.md, but worth promoting once the next analogous check lands.** (#42 vitest config or future allowed-root validation would be candidates.)
+- **§ 6.1 phase 4 inline-refactor exception (story-maint-01 retro action B) earned its keep.** P3 retro-check found a dead-code self-invocation in `migrate.ts` (`runMigrate('accounting.db')` at lines 15-17) that violated the new `resolvedDbPath` param name. All four exception criteria met (single file, < 5 LOC, fix coordinates pre-specified, no design question — the block is unreachable from any package.json script). Inline-fixed in commit `f024b02` rather than spinning up another Sonnet round. Saved an estimated ~5 minutes of round-trip overhead. **Three stories in, the rule continues to be calibrated correctly.**
+- **Sonnet's deviation handling kept improving.** maint-03 was textbook (named the dropped guard's purpose). maint-04 went further: when the agent's worktree polluted the lint baseline, Sonnet **fixed the baseline first as a separately-named `chore(lint)` commit (`8dbd318`) before any story commits**. Clean separation. The plan didn't anticipate the pollution; Sonnet's response was disciplined.
+- **Subprocess-test pattern is proving durable.** Second story to use it (after maint-03). Same `tsx`-binary-path + `execFileSync` + try-catch + `afterEach` cleanup shape. Two new tests added cleanly; no friction from the pattern itself. **If maint-05 or a later story uses it again, promote to docs/engineering-standards.md as a recognized test category.** Two data points isn't enough yet; want a third.
+- **Plan-doc length stayed appropriate.** ~150 lines for a story with a real design dimension (allowed-root scope cut, Option A vs B trade-off, three test layers). story-maint-02/03/04 plan-doc lengths: 110 → 173 → 197. Scaling with complexity, not story length. The maint-01 retro's "scale by density, not section removal" theory holds.
+- **Security-checklist update was specific, not generic.** The diff at line 26 names the new helper, names the `.bak` transitive-protection chain, and credits Story 2.5's atomic-rename pattern that closes that surface. Future readers can trace the security posture without re-deriving the design.
+
+## Change
+
+- **A. `feat(db)` commit (`342e950`) bundled vitest config edits with the helper implementation.** Minor § 6.4 violation — a `feat:` commit should be the minimal code that turns the previously-failing tests green. The vitest `.claude` exclude is tooling baseline, structurally identical to the `chore(lint)` exclude in commit `8dbd318`. They should have been the same commit (or a sibling `chore(test)`). **Why it matters:** the `feat(db)` commit subject + body now describes both the helper AND a vitest exclude, which makes the commit's role ambiguous in `git log`. **Why I didn't rebase:** CLAUDE.md forbids interactive rebase (`-i`); a non-interactive splitting requires `git filter-branch` or temporary worktree rewriting — too much risk to fix a presentation issue. **Action B in this retro codifies the rule:** Sonnet must keep `chore(lint)` / `chore(test)` baseline-tooling commits separate from `test:` / `feat:` story commits, even when they're committed back-to-back.
+- **B. Sonnet's grep for `runMigrate` callers missed the in-file self-call.** When verifying the param-rename was safe, Sonnet ran `grep -rn "runMigrate" src tests` (or equivalent) and found only `program.ts:37`. Correct as far as cross-file callers go. But the file being modified (`migrate.ts`) had a self-call at line 16 that the grep should have flagged. **Cause:** mental model was "find external callers"; the in-file self-call falls outside that frame. **Fix:** the standard "before renaming a function, find every call site" check needs to include the function's own file. Trivially captured: just don't filter the function's own file out of the grep, or include `git grep -p` to list contexts. **Codifying this is overkill for a one-time miss; note here for future reference.**
+- **C. Worktree-pollution baseline fixes are foreseeable now.** maint-04 is the second story this session that started with `.claude/worktrees/` debris (the first was the `chore/dependabot-tmp-uuid` branch at the top of the session that got in the way of `git branch -d`). **Try-item C below proposes filing `.claude/` for `.gitignore` as [#51](https://github.com/xavierbriand/accounting/issues/51).** When that lands, future stories won't need a `chore(lint)` baseline fix.
+
+## Try
+
+- **Promote "composition-root pre-flight check" to a documented pattern.** When story-maint-05 or a future story adds a fourth or fifth check, write a short § in [docs/engineering-standards.md](../blob/main/docs/engineering-standards.md) describing the pattern: composition-root location, `Result<T>`-returning helper, `stderr + exit 2` on failure, mirror tests at unit + subprocess layers. Not before — three data points is borderline; four will be conclusive.
+- **Codify the commit-bundle separation rule.** Extend [.claude/agents/sonnet-implementer.md § 4](../blob/main/.claude/agents/sonnet-implementer.md) "Deviations from plan" with: *"`chore:` baseline-tooling commits must stay separate from `test:`/`feat:` story commits, even when committed back-to-back. If a `feat:` commit body needs a tooling preamble, that preamble belongs in a sibling `chore:` commit landed first."* This is action item A below — lands in this PR per § 7 #10.
+- **`.claude/` to `.gitignore`** — filed as [#51](https://github.com/xavierbriand/accounting/issues/51). Resolving it removes the need for `chore(lint)` baseline fixes in future stories.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| A. Codify commit-bundle separation rule in `.claude/agents/sonnet-implementer.md` § 4. | This PR, same commit as this retro. | in same commit as this retro |
+| B. Personal in-file self-call check before function rename. | Reviewer habit, not docs. | informal |
+| C. [#51](https://github.com/xavierbriand/accounting/issues/51) — add `.claude/` to `.gitignore`. | Filed. | open |
+
+## Loop metrics (eleventh run; fourth maintenance-track story)
+
+- **Plan phase:** 1 maintenance sub-loop (0 new Dependabot PRs, audit unchanged) + Opus P1/P2/P3 plan review (5 findings: 2 adopted / 3 rejected / 0 deferred).
+- **Implementation:** 1 Sonnet task (8 commits — 1 baseline `chore(lint)` + 6 planned slices + 1 `chore(docs)` security-checklist). 2 deviations (baseline `.claude` exclusion bundled, vitest configs bundled with `feat(db)`).
+- **Phase-4 retro-check:** 3 passes (P1 / P2 / P3). 1 minor blocker (dead-code self-invocation in migrate.ts after the param rename) — fixed inline by Opus per § 6.1 phase 4 exception. Commit `f024b02`.
+- **Issues closed by this story:** [#21](https://github.com/xavierbriand/accounting/issues/21).
+- **Issues opened:** 1 ([#51](https://github.com/xavierbriand/accounting/issues/51) — `.claude/` in `.gitignore`).
+- **Total commits on branch:** 10 (1 plan + 1 baseline lint fix + 6 planned slices + 1 Opus inline refactor + this retro).
+- **Test count:** 217 → 224 (+7: 5 helper + 2 subprocess).
+- **Diff stats:** 23 LOC helper + 16 LOC program.ts + 5 LOC migrate.ts (-3 inline refactor) + 105 LOC helper test + 110 LOC subprocess test + 1 LOC security-checklist + 197 LOC plan + ~95 LOC retro + tooling baseline (3 LOC across 3 config files).
+- **Bugs squashed:** 1 latent path-traversal vector closed (#21). Plus removed 3 lines of dead code in migrate.ts.
+- **New runtime deps:** 0. **New dev deps:** 0.
+- **Time-to-DoD:** one session, ~50 min total.
+
+## Carryovers resolved
+
+- Story 1.4 P3 deferred suggestion (#21 dbPath validation) → **CLOSED by this story** (symlink scope; allowed-root deferred per plan).
+- story-maint-01 retro action B (Opus inline-refactor < 5 LOC exception) → engaged for the second time (first: trivial timeout restore in maint-01 itself; second: dead-code removal here). Rule continues to fit.
+- story-maint-01 retro action E (harness invocation refresh) → engaged for the fourth story in a row. `subagent_type: "sonnet-implementer"` direct invocation reliable.
+- story-maint-03 retro Try ("plan-phase runtime-invocation verification") → **didn't trigger this story** because the subprocess test pattern was already specified in the plan (reusing maint-03's). One indication the rule self-stabilises after the first observation.
+- Issue [#42](https://github.com/xavierbriand/accounting/issues/42) (vitest config consolidation): still open. This story added an `exclude` line to BOTH configs; resolving #42 would let us touch one file instead.
+- Issue [#43](https://github.com/xavierbriand/accounting/issues/43) (helper extraction): still open.
+- Issue [#46](https://github.com/xavierbriand/accounting/issues/46) (dist-not-runnable): still open. The new subprocess test pivots to `tsx` for the same reason maint-03's did.

--- a/docs/security-checklist.md
+++ b/docs/security-checklist.md
@@ -23,7 +23,7 @@ A failure of any item at P3-retro is a **merge blocker**, not a deferred suggest
 
 - [ ] Zod schemas validate every external input: CLI args, file reads, config parsing. Validation happens before the data reaches Core.
 - [ ] Core (`src/core/`) contains no calls to Node APIs (`fs`, `path`, `os`, `crypto`), no `commander`, no `better-sqlite3`, no `process.exit`.
-- [ ] No user-controlled path strings reach `fs` without prior normalization; no path traversal (`../`) possible via ingestion.
+- [ ] No user-controlled path strings reach `fs` without prior normalization. `dbPath` is additionally validated at the CLI composition root via `validateDbPath` — symlinks at the resolved path are refused with a friendly stderr error + exit 2. `${dbPath}.bak` (Story 2.5 snapshot sibling) is transitively protected: if `dbPath` itself is rejected, snapshot creation never runs; if `dbPath` is valid, Story 2.5's atomic-rename-from-randomised-tmp pattern neutralises a pre-planted symlink at the `.bak` target. No path traversal (`../`) possible via ingestion.
 - [ ] CLI commands refuse unknown flags (commander's default).
 
 ## Secrets & PII

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,6 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    ignores: ["dist", "node_modules", "coverage"],
+    ignores: ["dist", "node_modules", "coverage", ".claude"],
   }
 );

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -11,7 +11,3 @@ export function runMigrate(resolvedDbPath: string): void {
     process.exit(1);
   }
 }
-
-if (import.meta.url === `file://${process.argv[1]}`) {
-  runMigrate('accounting.db');
-}

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,9 +1,8 @@
-import path from 'path';
 import { getDb } from '../infra/db/sqlite-client.js';
 import { runMigrations } from '../infra/db/migrator.js';
 
-export function runMigrate(dbPath: string): void {
-  const db = getDb(path.resolve(dbPath));
+export function runMigrate(resolvedDbPath: string): void {
+  const db = getDb(resolvedDbPath);
   try {
     runMigrations(db);
     console.log('Migration completed successfully.');

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,5 +1,4 @@
 import { Command } from 'commander';
-import path from 'path';
 import { getDb } from '../infra/db/sqlite-client.js';
 import { FileConfigService } from '../infra/config/config-service.js';
 import { NodeCsvParser } from '../infra/csv/node-csv-parser.js';
@@ -16,6 +15,7 @@ import { inquirerPrompter } from './utils/interactive.js';
 import { runIngestCommand } from './commands/ingest-command.js';
 import { runMigrate } from './migrate.js';
 import { assertMigrated } from '../infra/db/migration-check.js';
+import { validateDbPath } from '../infra/db/db-path-validator.js';
 
 const program = new Command();
 
@@ -29,7 +29,12 @@ program
   .description('Run database migrations')
   .option('--db-path <path>', 'Path to the SQLite database', 'accounting.db')
   .action((options: { dbPath: string }) => {
-    runMigrate(options.dbPath);
+    const validation = validateDbPath(options.dbPath);
+    if (validation.isFailure) {
+      process.stderr.write(`error: ${validation.error}\n`);
+      process.exit(2);
+    }
+    runMigrate(validation.value);
   });
 
 program
@@ -40,7 +45,12 @@ program
   .option('--json', 'Output JSON instead of a table', false)
   .option('--db-path <path>', 'Path to the SQLite database', 'accounting.db')
   .action(async (options: { file: string; nonInteractive: boolean; json: boolean; dbPath: string }) => {
-    const resolvedDb = path.resolve(options.dbPath);
+    const validation = validateDbPath(options.dbPath);
+    if (validation.isFailure) {
+      process.stderr.write(`error: ${validation.error}\n`);
+      process.exit(2);
+    }
+    const resolvedDb = validation.value;
     const db = getDb(resolvedDb);
 
     const migrationCheck = assertMigrated(db, resolvedDb);

--- a/src/infra/db/db-path-validator.ts
+++ b/src/infra/db/db-path-validator.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+import { Result } from '@core/shared/result.js';
+
+export function validateDbPath(rawPath: string): Result<string> {
+  const resolved = path.resolve(rawPath);
+  try {
+    const stat = fs.lstatSync(resolved);
+    if (stat.isSymbolicLink()) {
+      return Result.fail(
+        `refusing to open dbPath: ${rawPath} is a symbolic link. ` +
+        `Point --db-path at a regular file or let one be created fresh.`,
+      );
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      return Result.fail(`failed to stat dbPath '${rawPath}': ${String(err)}`);
+    }
+    // ENOENT is acceptable — getDb will create the file.
+  }
+  return Result.ok(resolved);
+}

--- a/tests/integration/cli/symlink-dbpath-refuse.test.ts
+++ b/tests/integration/cli/symlink-dbpath-refuse.test.ts
@@ -1,0 +1,110 @@
+// NOTE: Spawns the CLI via tsx (handles @core path alias). No separate build step needed.
+/**
+ * Integration tests: CLI migrate and ingest refuse a symlinked dbPath.
+ *
+ * Gherkin coverage:
+ *   - "CLI ingest against a symlinked db path is refused"
+ *   - "CLI migrate against a symlinked db path is refused"
+ *
+ * fails if: validateDbPath is not wired into program.ts — without the check,
+ *   better-sqlite3 would follow the symlink and write SQLite bytes into an unintended
+ *   target file (no stderr refusal, no exit 2). This test proves the guard is in place
+ *   at the CLI composition root for both commands.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TSX_BIN = path.join(__dirname, '../../../node_modules/.bin/tsx');
+const CLI_SRC = path.join(__dirname, '../../../src/cli/program.ts');
+
+const FIXTURE_CSV = path.join(__dirname, '../../fixtures/csv/bpce-valid.csv');
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-symlink-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+describe('migrate against symlinked dbPath', () => {
+  it('exits 2, stderr contains "refusing to open dbPath" and "symbolic link", no SqliteError or stack trace', () => {
+    // fails if: validateDbPath is not called in the migrate action of program.ts —
+    //   better-sqlite3 would follow the symlink and open the target, exiting 0 instead of 2,
+    //   with no "refusing to open dbPath" message in stderr
+    const tmpDir = makeTmpDir();
+    const realFile = path.join(tmpDir, 'real.db');
+    const linkPath = path.join(tmpDir, 'link.db');
+    fs.writeFileSync(realFile, '');
+    fs.symlinkSync(realFile, linkPath);
+
+    let error: { status: number | null; stderr: Buffer | string; stdout: Buffer | string } | null = null;
+
+    try {
+      execFileSync(TSX_BIN, [CLI_SRC, 'migrate', '--db-path', linkPath], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (e) {
+      error = e as { status: number | null; stderr: Buffer | string; stdout: Buffer | string };
+    }
+
+    expect(error).not.toBeNull();
+
+    const stderr = error!.stderr.toString();
+    expect(error!.status).toBe(2);
+    expect(stderr).toContain('refusing to open dbPath');
+    expect(stderr).toContain('symbolic link');
+    expect(stderr).not.toContain('SqliteError');
+    expect(stderr).not.toContain('at new ');
+  });
+});
+
+describe('ingest against symlinked dbPath', () => {
+  it('exits 2, stderr contains "refusing to open dbPath" and "symbolic link", no SqliteError or stack trace', () => {
+    // fails if: validateDbPath is not called in the ingest action of program.ts —
+    //   the migration guard (assertMigrated) runs after getDb, so without validateDbPath
+    //   the process would open the symlink target as a DB, then fail with either
+    //   "database not initialised" or a SqliteError — neither contains "refusing to open dbPath"
+    const tmpDir = makeTmpDir();
+    const realFile = path.join(tmpDir, 'real.db');
+    const linkPath = path.join(tmpDir, 'link.db');
+    const csvPath = path.join(tmpDir, 'bpce-valid.csv');
+    fs.writeFileSync(realFile, '');
+    fs.symlinkSync(realFile, linkPath);
+    fs.copyFileSync(FIXTURE_CSV, csvPath);
+
+    let error: { status: number | null; stderr: Buffer | string; stdout: Buffer | string } | null = null;
+
+    try {
+      execFileSync(TSX_BIN, [CLI_SRC, 'ingest', '--file', csvPath, '--db-path', linkPath], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (e) {
+      error = e as { status: number | null; stderr: Buffer | string; stdout: Buffer | string };
+    }
+
+    expect(error).not.toBeNull();
+
+    const stderr = error!.stderr.toString();
+    expect(error!.status).toBe(2);
+    expect(stderr).toContain('refusing to open dbPath');
+    expect(stderr).toContain('symbolic link');
+    expect(stderr).not.toContain('SqliteError');
+    expect(stderr).not.toContain('at new ');
+  });
+});

--- a/tests/integration/infra/db/db-path-validator.test.ts
+++ b/tests/integration/infra/db/db-path-validator.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Integration tests for validateDbPath — symlink-rejection helper.
+ *
+ * Gherkin coverage:
+ *   - "Regular file at dbPath proceeds normally" (cases a, b)
+ *   - "Non-existent dbPath proceeds (getDb creates fresh)" (case a)
+ *   - "CLI ingest against a symlinked db path is refused" (cases c, d — unit-level probe;
+ *     subprocess test covers the full CLI scenario)
+ *   - "CLI migrate against a symlinked db path is refused" (cases c, d)
+ *
+ * fails if: validateDbPath returns ok for a symlink (the symlink-rejection guard would be
+ *   bypassed and better-sqlite3 would follow the link), or returns fail for a non-existent
+ *   path (blocking legitimate fresh-install workflows), or returns fail for a regular file
+ *   (blocking normal usage).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { validateDbPath } from '../../../../src/infra/db/db-path-validator.js';
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-dbpath-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tmpDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+describe('validateDbPath', () => {
+  it('(a) non-existent path returns Result.ok with the resolved path', () => {
+    // fails if: validateDbPath rejects ENOENT (fresh-install path would be blocked;
+    //   getDb legitimately creates the file on first use)
+    const tmpDir = makeTmpDir();
+    const dbPath = path.join(tmpDir, 'fresh.db');
+
+    const result = validateDbPath(dbPath);
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.value).toBe(path.resolve(dbPath));
+  });
+
+  it('(b) regular file at path returns Result.ok with the resolved path', () => {
+    // fails if: validateDbPath incorrectly refuses an ordinary file (all normal usage would break)
+    const tmpDir = makeTmpDir();
+    const dbPath = path.join(tmpDir, 'real.db');
+    fs.writeFileSync(dbPath, '');
+
+    const result = validateDbPath(dbPath);
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.value).toBe(path.resolve(dbPath));
+  });
+
+  it('(c) symlink pointing at a real sibling file returns Result.fail with "symbolic link" and "refusing to open dbPath"', () => {
+    // fails if: validateDbPath returns ok for a symlink — better-sqlite3 would follow the
+    //   link and write SQLite bytes into an unintended file, corrupting it
+    const tmpDir = makeTmpDir();
+    const target = path.join(tmpDir, 'real.db');
+    const link = path.join(tmpDir, 'link.db');
+    fs.writeFileSync(target, '');
+    fs.symlinkSync(target, link);
+
+    const result = validateDbPath(link);
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('symbolic link');
+    expect(result.error).toContain('refusing to open dbPath');
+  });
+
+  it('(d) dangling symlink (target does not exist) returns Result.fail with "symbolic link" and "refusing to open dbPath"', () => {
+    // fails if: validateDbPath treats a dangling symlink as ENOENT (the link itself exists
+    //   as an lstat entry; only the target is missing — both valid and dangling symlinks
+    //   must be refused)
+    const tmpDir = makeTmpDir();
+    const target = path.join(tmpDir, 'nonexistent.db');
+    const link = path.join(tmpDir, 'dangling.db');
+    fs.symlinkSync(target, link);
+
+    const result = validateDbPath(link);
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('symbolic link');
+    expect(result.error).toContain('refusing to open dbPath');
+  });
+
+  it('(e) non-ENOENT stat failure propagates as Result.fail', () => {
+    // fails if: validateDbPath swallows unexpected lstatSync errors (EACCES would be
+    //   masked, silently proceeding to open an inaccessible path)
+    const eaccesError = Object.assign(new Error('Permission denied'), { code: 'EACCES' });
+    vi.spyOn(fs, 'lstatSync').mockImplementation(() => { throw eaccesError; });
+
+    const result = validateDbPath('/some/path/db.sqlite');
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('failed to stat dbPath');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,5 +5,6 @@ export default defineConfig({
         alias: {
             '@core': path.resolve(import.meta.dirname, './src/core'),
         },
+        exclude: ['**/node_modules/**', '**/.claude/**'],
     },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
     alias: {
       '@core': path.resolve(__dirname, './src/core'),
     },
+    exclude: ['**/node_modules/**', '**/.claude/**'],
   },
 });


### PR DESCRIPTION
## 1. Story

[Issue #21](https://github.com/xavierbriand/accounting/issues/21) — Story 1.4 P3 deferred suggestion. Fourth pre-Epic-3 maintenance story (sequence: #18 ✓ → #22 ✓ → #35 ✓ → **#21** → #38 → #12 → #11 → Epic 3). Elevated by Story 2.5's `.bak` sibling-path surface.

## 2. Intent

`dbPath` is user-controlled (CLI flag + config file). Today both `migrate` and `ingest` actions call `path.resolve(dbPath)` — collapses `..` but does nothing about symlinks. An adversary with write access to the config location can point `dbPath` at a symlink whose target is an unrelated file the user can write to; `better-sqlite3` follows and corrupts. Add a `validateDbPath(raw): Result<string>` helper that refuses symlinks at the resolved path, and wire it into both commands at the composition root.

## 3. Alternatives considered

- **Option A** (chosen) — helper at composition root, `program.ts` calls it before `getDb`. Mirrors story-maint-03's `assertMigrated` pattern.
- **Option B** — check inside `getDb`. Rejected: would force `getDb` to return `Result<Database>`, propagating through every caller including tests. Too much blast radius for two callers today.

**Scope cut.** Issue's bullet 2 proposes three layers (symlink, allowed-root, strict-`..`). This story does only **symlink rejection** — allowed-root and strict-`..` need a policy that doesn't exist yet (no concrete caller for `dataDir`). Documented as deferred items.

## 4. Selected solution & rationale

Option A. Full detail in [docs/plans/story-maint-04.md](docs/plans/story-maint-04.md).

1. New [src/infra/db/db-path-validator.ts](src/infra/db/db-path-validator.ts) — `validateDbPath(raw): Result<string>`: resolves, `lstatSync`s, refuses on symbolic link, tolerates ENOENT.
2. Wire into both `migrate` and `ingest` actions in [src/cli/program.ts](src/cli/program.ts). On failure: stderr + `process.exit(2)`.
3. [src/cli/migrate.ts](src/cli/migrate.ts) drops internal `path.resolve` (program.ts hands in a validated path).
4. 5 helper unit tests + 2 subprocess integration tests (reusing the tsx-spawn pattern from story-maint-03).
5. [docs/security-checklist.md:26](docs/security-checklist.md) updated to document the new enforcement.

## 5. Gherkin scenarios

```gherkin
Feature: Reject symlinked dbPath

  Scenario: CLI ingest against a symlinked db path is refused
    Given a symlink at /tmp/link.db
    When I run `accounting ingest --db-path /tmp/link.db --file <csv>`
    Then the process exits with code 2
    And stderr contains "refusing to open dbPath" + "symbolic link"
    And stderr does not contain "SqliteError"

  Scenario: CLI migrate against a symlinked db path is refused
    Given a symlink at /tmp/link.db
    When I run `accounting migrate --db-path /tmp/link.db`
    Then the process exits with code 2
    And stderr contains "refusing to open dbPath" + "symbolic link"

  Scenario: Regular file at dbPath proceeds normally
    When I run `accounting ingest --db-path /tmp/real.db ...`
    Then validation passes silently

  Scenario: Non-existent dbPath proceeds (getDb creates fresh)
    When I run `accounting migrate --db-path /tmp/fresh.db`
    Then validation passes (ENOENT acceptable); getDb creates the file
```

## 6. Plan for Sonnet

Target **7 commits** + retrospective. Full plan: [docs/plans/story-maint-04.md](docs/plans/story-maint-04.md).

## 7. Suggestion log

Phase 2 (P1 / P2 / P3) run by Opus on 2026-04-25.

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P1 | Add a subprocess version of Scenario 4. | rejected | Covered by unit case (a) + existing migrator tests. |
| P2 | Symlink error echoes `rawPath` — PII? | rejected | User typed it; echoing is UX. |
| P3 | Helper in `src/core/` or `src/infra/`? | adopted | Stays in `src/infra/db/` — bound to `fs.lstatSync`. |
| P3 | Check for hard links too? | rejected | Hard links don't participate in path-traversal attacks. |
| P3 | Scenario 4 implicitly tests `getDb` auto-create — assert explicitly? | adopted | Rely on existing migrator tests. |

**Phase-4 retro-check findings (post-implementation):**

| Phase | Finding | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P3 | `migrate.ts` self-invocation block (lines 15-17) was dead code that violated its new `resolvedDbPath` param contract by passing the literal `'accounting.db'`. Sonnet's grep missed the in-file self-call. | fixed in-PR | Commit `f024b02` — Opus inline refactor per § 6.1 phase 4 exception (single file, < 5 LOC, dead code, no design question). |
| P3 | `feat(db)` commit (`342e950`) bundled vitest config exclude with helper implementation — § 6.4 commit-bundle violation. | rule update | New rule in `.claude/agents/sonnet-implementer.md` § 4: "Commit-bundle separation". Landed in retro commit. |
| Follow-up | `.claude/` debris in `git status` (worktree + settings.local). | deferred | Filed [#51](https://github.com/xavierbriand/accounting/issues/51). |

## 8. Sonnet's learnings

## What was built

Helper `validateDbPath(rawPath): Result<string>` in `src/infra/db/db-path-validator.ts` rejects symlinks at the resolved path via `fs.lstatSync`, tolerates ENOENT, propagates other stat errors. Both `migrate` and `ingest` actions in `src/cli/program.ts` call it before `getDb()`; on failure stderr + exit 2. `migrate.ts` drops internal `path.resolve`. Security checklist updated. `.claude/` excluded from ESLint + vitest as a baseline fix.

## Red → green sequence

- 5 helper cases (a–e) → red, then green (commits `89b4109` → `342e950`).
- 2 subprocess cases (migrate + ingest) → red, then green (commits `94bfb5f` → `0f0d166`).
- Security-checklist line update + empty refactor (`41494f6`, `1e73754`).

## Deviations from plan

- **Pre-existing `.claude/` worktree pollution.** Required an `eslint.config.js` ignore (commit `8dbd318`) to establish a green baseline. Vitest exclude was bundled into the `feat(db)` commit — see Phase-4 P3 finding above.
- **`migrate.ts` parameter renamed `dbPath` → `resolvedDbPath`** as the plan specified.
- **Subprocess test uses `tsx`** per story-maint-03's pattern + [#46](https://github.com/xavierbriand/accounting/issues/46).

## Gherkin coverage checklist

- ✓ CLI ingest against symlinked dbPath → `tests/integration/cli/symlink-dbpath-refuse.test.ts`
- ✓ CLI migrate against symlinked dbPath → same file
- ✓ Regular file at dbPath proceeds → helper test case (b)
- ✓ Non-existent dbPath proceeds → helper test case (a)

## Unknowns encountered

None.

## Proposed follow-ups

- `.claude/` to `.gitignore` (filed as [#51](https://github.com/xavierbriand/accounting/issues/51)).
- Allowed-root policy (deferred per plan; will surface when `AppConfig.dbPath` wires to `getDb`).
- Parent-directory symlinks unvalidated (documented limitation).

## Files touched

- `src/infra/db/db-path-validator.ts` · new · the helper.
- `src/cli/program.ts` · 11 LOC added · wire-up in both actions.
- `src/cli/migrate.ts` · -3 LOC (dead self-invocation removed by Opus inline refactor) + param rename.
- `tests/integration/infra/db/db-path-validator.test.ts` · new · 5 unit cases.
- `tests/integration/cli/symlink-dbpath-refuse.test.ts` · new · 2 subprocess cases.
- `docs/security-checklist.md` · expanded line 26.
- `eslint.config.js`, `vitest.config.ts`, `vitest.config.js` · `.claude` ignored.

## 9. Retrospective

- **Keep:** Four-story streak of "helper-at-composition-root" pattern is now stable (maint-02 → maint-03 → maint-04). § 6.1 phase 4 inline-refactor exception (maint-01 action B) earned its keep on a 3-LOC dead-code removal. Sonnet's deviation handling kept improving — separated the baseline `.claude` lint fix into its own `chore(lint)` commit before any story work.
- **Change:** (A) `feat(db)` commit bundled vitest config exclude — § 6.4 violation; codified as new rule in sonnet-implementer.md § 4 ("Commit-bundle separation"). (B) Sonnet's grep for `runMigrate` callers missed the in-file self-call — reviewer habit. (C) `.claude/` worktree pollution recurring — filed [#51](https://github.com/xavierbriand/accounting/issues/51).
- **Try:** Promote "composition-root pre-flight check" to a documented engineering pattern when a fourth analogous check lands.

Full retrospective: [docs/retrospectives/story-maint-04.md](docs/retrospectives/story-maint-04.md).

Rule changes landing in this PR (per § 7 #10):
- `.claude/agents/sonnet-implementer.md` § 4 — new "Commit-bundle separation" rule.

## 10. Merge checklist

- [ ] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-maint-04.md`
- [x] All suggestion-log items resolved
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)