### PR TITLE
chore(gitignore): add *.db-shm and .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ data/*.db
 *.db
 *.db-journal
 *.db-wal
+*.db-shm
 *.bak
 
 # Environment
@@ -21,6 +22,7 @@ data/*.db
 # Editors
 .vscode/
 .idea/
+.claude/settings.local.json
 
 # Testing
 coverage/


### PR DESCRIPTION
## Summary
- `*.db-shm` was missing alongside the existing `*.db-wal` / `*.db-journal` SQLite sidecar patterns.
- `.claude/settings.local.json` is machine-local Claude Code state and should never be committed.

Closes #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)