### PR TITLE
story-maint-11: Result combinators + busy_timeout + YAML-authoritative dbPath (#65, #56)

### DIFF
--- a/docs/plans/story-maint-11.md
+++ b/docs/plans/story-maint-11.md
@@ -1,0 +1,291 @@
+# Story maint-11 — Code refactor bundle: Result combinators + busy_timeout + YAML-authoritative dbPath + #56
+
+## Context
+
+Second story of the **Refactor epic** (Epic M-A) per the senior-engineer refactor backlog plan. Bundles four code-health improvements that share a common shape (small Core/Infra/CLI changes, no new product features) and pay back during Epic 3:
+
+1. **`Result` combinators** (`map`, `flatMap`, `getOrElse`, `Result.all`) on [src/core/shared/result.ts](src/core/shared/result.ts). Epic 3 (Predictive Transfer Engine) will chain `Money` operations, ledger lookups, and validity-window resolutions; the current `if (r.isFailure) return Result.fail(r.error); const x = r.value;` boilerplate appears 16 times in Core today and would multiply.
+2. **SQLite `busy_timeout` pragma** in [src/infra/db/sqlite-client.ts](src/infra/db/sqlite-client.ts). Currently `journal_mode = WAL` and `foreign_keys = ON` are set but `busy_timeout` is not. Snapshot creation + ingest commit (Story 2.5) can plausibly contend; default behaviour is an immediate `SQLITE_BUSY` error rather than the customary 5-second wait. One-line fix.
+3. **YAML-authoritative `dbPath` + `--db-path-override` flag** — closes [#65](https://github.com/xavierbriand/accounting/issues/65). Currently `program.ts` ignores `accounting.yaml`'s `dbPath` field entirely and uses the `--db-path` flag's default `'accounting.db'`. Per user direction (refactor backlog plan), config becomes authoritative; the CLI flag is renamed to `--db-path-override` and warns on use (preserving the operator escape hatch for recovery scenarios).
+4. **Issue [#56](https://github.com/xavierbriand/accounting/issues/56)** — extract `findDuplicateIndices` helper from four near-identical patterns in [src/infra/config/config-schema.ts](src/infra/config/config-schema.ts).
+
+Bundled because each item is small (≤30 LOC of production code), they share one PR's overhead, and they're scope-independent so a partial revert is per-commit.
+
+**Maintenance sub-loop (§ 6.7) run 2026-04-26 pre-planning:**
+- `git status` clean post-PR-#66 merge; main rebased to `d9e5d54`.
+- Open issues: 8 — one bug ([#65](https://github.com/xavierbriand/accounting/issues/65), to be closed by this story), 7 deferred-suggestions; priorities unchanged.
+- Dependabot: no open PRs.
+- `npm audit`: zero vulnerabilities.
+- **Proceed-to-planning.**
+
+## Story
+
+> As a developer working on Epic 3, I want fewer `if (r.isFailure) return Result.fail(...)` boilerplates, predictable SQLite contention behaviour, a single source of truth for `dbPath`, and the duplicate-detection helper that's already triaged — so that Predictive Transfer Engine code reads cleanly, doesn't surface spurious `SQLITE_BUSY` errors during snapshot+commit, doesn't bait users into editing `accounting.yaml` then wondering why nothing changed, and reuses the helper instead of growing a fifth copy.
+
+Closes [#65](https://github.com/xavierbriand/accounting/issues/65), [#56](https://github.com/xavierbriand/accounting/issues/56). Walks [docs/architecture.md](docs/architecture.md) (Core dep-rule, Result discipline), [docs/engineering-standards.md](docs/engineering-standards.md) (no-`any`, function-size, naming), [docs/quality-assurance.md](docs/quality-assurance.md) (no silent data loss). No FR coverage (cleanup + bug fix).
+
+## Selected solution
+
+### 1. `Result` combinators
+
+Current API: `isSuccess`/`isFailure` getters, `value`/`error` getters, `Result.ok()`, `Result.fail()`, `Result.combine()`. Add four combinators + property tests:
+
+- `map<U>(fn: (t: T) => U): Result<U, E>` — transform success value, pass-through failure.
+- `flatMap<U>(fn: (t: T) => Result<U, E>): Result<U, E>` — chain Result-returning calls; short-circuit on first failure.
+- `getOrElse<U>(fallback: U): T | U` — extract value with default; useful at boundaries.
+- `Result.all<T>(rs: readonly Result<T>[]): Result<readonly T[]>` — short-circuit on first failure, accumulate successes. Existing `Result.combine` returns `Result<unknown>` and is functionally a `Result.all` with a discarded value array; deprecate `combine` in favour of `all`. (Internal API only — no external consumers.)
+
+Property tests using `fast-check`:
+- `map` identity: `r.map(x => x).equals(r)` for any Result.
+- `map` composition: `r.map(g(f(x))) === r.map(f).map(g)`.
+- `flatMap` left identity: `Result.ok(x).flatMap(f) === f(x)`.
+- `flatMap` right identity: `r.flatMap(Result.ok) === r`.
+- `flatMap` short-circuit: `Result.fail(e).flatMap(f) === Result.fail(e)` (f never called).
+- `getOrElse`: `Result.ok(x).getOrElse(y) === x`; `Result.fail(e).getOrElse(y) === y`.
+- `Result.all` empty: `Result.all([]) === Result.ok([])`.
+- `Result.all` first-failure: short-circuits on the first failing element.
+
+**Migrate exemplar call sites.** Pick two heavy ones and rewrite to combinator-style. Leave the rest opportunistic (Epic 3 stories will migrate as they touch the code):
+- [src/core/ingest/transaction-builder.ts:74](src/core/ingest/transaction-builder.ts) — currently `if (txResult.isFailure) return Result.fail(txResult.error); return Result.ok({ ... });` becomes `txResult.map((tx) => ({ transaction: tx, category, classification, confidence, idempotencyHash }))`.
+- [src/core/ingest/idempotency-service.ts:21,28](src/core/ingest/idempotency-service.ts) — convert one of the two `isFailure` early-returns to `flatMap` to demonstrate the chained shape.
+
+**Internal-API caveat.** `Result.combine`'s return type changes when removed (fewer call sites today; re-check via grep before deletion). Deprecation comment for one slice; removal as a follow-up if the grep finds external usage.
+
+### 2. SQLite `busy_timeout` pragma
+
+[src/infra/db/sqlite-client.ts:11-13](src/infra/db/sqlite-client.ts) currently sets:
+
+```ts
+dbInstance.pragma('journal_mode = WAL');
+dbInstance.pragma('foreign_keys = ON');
+```
+
+Add:
+
+```ts
+dbInstance.pragma('busy_timeout = 5000');
+```
+
+5000ms is the standard busy-timeout for SQLite-backed CLIs. Addresses snapshot+commit contention (Story 2.5 introduced both). Probe test: `db.prepare('PRAGMA busy_timeout').pluck().get()` returns `5000` immediately after `getDb()` returns.
+
+### 3. YAML-authoritative `dbPath` + `--db-path-override`
+
+**Issue #65's "Fix" section** (with user's `--db-path-override` modification):
+
+1. Load `FileConfigService` in `program.ts` **before** opening the DB; use `config.dbPath`.
+2. Rename `--db-path` to `--db-path-override` on both `migrate` and `ingest`. Warn to stderr on use.
+3. Replace `configService: ConfigService` dep in `IngestCommandDeps` with `config: AppConfig` (config already loaded upstream by `program.ts`).
+4. Remove the silent `= 'accounting.db'` default from `getDb()` to prevent future drift. `getDb` now requires an explicit `dbPath`.
+
+**Concrete code changes:**
+
+- [src/cli/program.ts](src/cli/program.ts):
+  - Both `migrate` and `ingest` actions: rename option to `--db-path-override <path>`. No default value.
+  - Both actions: load config via `FileConfigService` first; resolve effective `dbPath = options.dbPathOverride ?? config.dbPath`. If `options.dbPathOverride` is set, write `[warning] --db-path-override is set; YAML dbPath ignored. Use only for recovery.` to stderr (once).
+  - Pass `config` (not `configService`) into `runIngestCommand`'s deps.
+  - `migrate` action: same flag handling.
+- [src/cli/commands/ingest-command.ts](src/cli/commands/ingest-command.ts):
+  - `IngestCommandDeps`: replace `configService: Pick<ConfigService, 'load'>` with `config: AppConfig`.
+  - `loadAndParse` becomes `loadAccountAndParseCsv` (no longer loads config; receives it via deps).
+- [src/cli/migrate.ts](src/cli/migrate.ts): unchanged signature (already takes `resolvedDbPath: string`); just called with the new resolution.
+- [src/infra/db/sqlite-client.ts](src/infra/db/sqlite-client.ts): `getDb(dbPath: string)` — drop the default. Add path-mismatch guard: if called twice with different paths, throw `Error('getDb: already opened with a different path; call closeDb() first')`.
+- [src/infra/db/migration-check.ts](src/infra/db/migration-check.ts): the friendly hint currently reads `hint: run 'accounting migrate --db-path ${dbPath}' first` — update to `hint: run 'accounting migrate' first (or set dbPath in accounting.yaml)`. (No flag in the hint; recovery via override is a power-user path.)
+
+**Tests to update:**
+- [tests/unit/cli/commands/ingest-command.test.ts](tests/unit/cli/commands/ingest-command.test.ts) — replace `configService: { load: () => Result.ok(config) }` with `config` directly.
+- [tests/unit/cli/commands/ingest-command-flags.test.ts](tests/unit/cli/commands/ingest-command-flags.test.ts) — same shape change.
+- [tests/integration/cli/ingest-commit.test.ts](tests/integration/cli/ingest-commit.test.ts) — update `makeRealDeps` factory.
+- [tests/perf/ingest-throughput.test.ts](tests/perf/ingest-throughput.test.ts) — same.
+- **Subprocess tests** ([uninit-db-hint.test.ts](tests/integration/cli/uninit-db-hint.test.ts), [ingest-end-to-end-wiring.test.ts](tests/integration/cli/ingest-end-to-end-wiring.test.ts), [symlink-dbpath-refuse.test.ts](tests/integration/cli/symlink-dbpath-refuse.test.ts), [tests/features/steps/ingest.steps.ts](tests/features/steps/ingest.steps.ts), [tests/features/steps/commit.steps.ts](tests/features/steps/commit.steps.ts)) — pivot to inline-YAML `dbPath` (avoid the warning on every CI run). Use the `writeStubYaml` helper's `dbPath` override (already supported per [tests/_helpers/inline-config.ts:7](tests/_helpers/inline-config.ts)). The `--db-path` flag in test calls drops; the YAML in `<tmp>/accounting.yaml` carries `dbPath: <tmp>/test.db`.
+- **New regression test for #65** — `tests/integration/cli/dbpath-yaml-authoritative.test.ts` (or fold into the BDD suite as `Given accounting.yaml carries dbPath: ./mydb.db, When I run migrate without --db-path-override, Then the migration writes to ./mydb.db`). Subprocess tier; uses inline YAML.
+- **New regression test for `--db-path-override` warning** — assert that `accounting migrate --db-path-override <path>` produces the warning string in stderr.
+- **New unit test** — `getDb` throws on second call with mismatched path.
+
+### 4. Issue [#56](https://github.com/xavierbriand/accounting/issues/56) — extract `findDuplicateIndices`
+
+Four near-identical patterns in [src/infra/config/config-schema.ts](src/infra/config/config-schema.ts) (lines 30–38, 96–99, 101–104, 148–156). Extract:
+
+```ts
+function findDuplicateIndices<T>(items: readonly T[], keyFn: (t: T) => string): number[] {
+  const seen = new Map<string, number>();
+  const dupes: number[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const key = keyFn(items[i]);
+    if (seen.has(key)) {
+      dupes.push(i);
+    } else {
+      seen.set(key, i);
+    }
+  }
+  return dupes;
+}
+```
+
+(Map-based to avoid `indexOf`'s O(n²); preserves the "first occurrence is canonical, later occurrences are duplicates" semantic that all four call sites express.)
+
+Replace each call site:
+
+```ts
+// Before:
+names.forEach((n, i) => {
+  if (names.indexOf(n) !== i) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: [...], message: 'duplicate ...' });
+  }
+});
+
+// After:
+for (const i of findDuplicateIndices(items, (it) => it.partner)) {
+  ctx.addIssue({ code: z.ZodIssueCode.custom, path: [...], message: 'duplicate ...' });
+}
+```
+
+Tests in [tests/unit/infra/config/config-schema.test.ts](tests/unit/infra/config/config-schema.test.ts) already cover the four duplicate-detection paths; verify they stay green. Add one helper unit test for `findDuplicateIndices` itself (covers the empty array, all-unique, all-duplicate, mixed cases — under 20 LOC).
+
+## Production-code surface
+
+Per the [story-maint-10 retro](docs/retrospectives/story-maint-10.md) rule (CLAUDE.md § 6.1 phase 1), explicit list of production-code changes this story makes:
+
+- **`Result` class** ([src/core/shared/result.ts](src/core/shared/result.ts)) — adds 4 instance methods (`map`, `flatMap`, `getOrElse`) and 1 static method (`Result.all`). `Result.combine` deprecated (kept as alias for one slice; removed in slice 3 if grep confirms no consumers).
+- **`IngestCommandDeps`** ([src/cli/commands/ingest-command.ts](src/cli/commands/ingest-command.ts)) — `configService: Pick<ConfigService, 'load'>` replaced with `config: AppConfig`. Breaking change for the deps interface; affects 5 test files and `program.ts`.
+- **`getDb` signature** ([src/infra/db/sqlite-client.ts](src/infra/db/sqlite-client.ts)) — drops default value (`dbPath: string` instead of `dbPath: string = 'accounting.db'`). Now throws on re-open with mismatched path.
+- **CLI flag rename** ([src/cli/program.ts](src/cli/program.ts)) — `--db-path` → `--db-path-override` on both `migrate` and `ingest`. User-visible breaking change; documented in PR section "Operational note."
+- **Migration hint string** ([src/infra/db/migration-check.ts](src/infra/db/migration-check.ts)) — updated to not reference the renamed flag.
+
+## Gherkin acceptance scenarios
+
+Two new scenarios in [tests/features/ingest.feature](tests/features/ingest.feature) (extends the existing 4):
+
+```gherkin
+Scenario: dbPath in accounting.yaml is honoured (closes #65)
+  Given a fresh tmp dir
+  And an accounting.yaml at tmp dir with dbPath: "./ledger.db"
+  When I run `accounting migrate` with cwd=<tmp> and no --db-path-override
+  Then the migration creates the file at <tmp>/ledger.db
+  And no file exists at <tmp>/accounting.db
+  # fails if: program.ts uses the hardcoded 'accounting.db' default instead of
+  # config.dbPath, leaving ledger.db non-existent and accounting.db populated.
+
+Scenario: --db-path-override warns and overrides YAML dbPath
+  Given a fresh tmp dir
+  And an accounting.yaml at tmp dir with dbPath: "./ledger.db"
+  When I run `accounting migrate --db-path-override <tmp>/recovery.db` with cwd=<tmp>
+  Then the migration creates the file at <tmp>/recovery.db
+  And no file exists at <tmp>/ledger.db
+  And stderr contains "[warning]"
+  And stderr contains "--db-path-override is set"
+  # fails if: --db-path-override is silently honoured (no warn), or the rename
+  # didn't propagate (CLI parses old --db-path), or YAML dbPath wins over the override.
+```
+
+Both scenarios run subprocess via `spawnCli` against the dist binary — composition-root subprocess test rule (CLAUDE.md § 6.1 phase 1).
+
+## Slice plan for Sonnet
+
+Target **9 commits + retrospective**. At the upper end of the 6–10 band; story scope justifies the breadth.
+
+1. **`test(core): Result combinators property tests — failing (story-maint-11)`**
+   - Add `tests/unit/core/shared/result.test.ts` (or extend if exists) with `fast-check` properties for `map`, `flatMap`, `getOrElse`, `Result.all`. All fail (combinators don't exist yet).
+
+2. **`feat(core): Result.map / flatMap / getOrElse / all combinators — minimal green (story-maint-11)`**
+   - Implement the four combinators on the `Result` class.
+   - `Result.combine` kept untouched in this slice (deprecation comment only).
+   - All property tests turn green.
+
+3. **`refactor(core): migrate exemplar call sites + remove Result.combine (story-maint-11)`**
+   - Migrate `transaction-builder.ts:74` to `txResult.map(...)`.
+   - Migrate one branch in `idempotency-service.ts` to `flatMap` (illustrative; second branch stays as-is to keep the diff small).
+   - Grep-verify no consumers of `Result.combine` outside the test file (where it's tested explicitly); if confirmed, remove `Result.combine` and its test. Otherwise leave a deprecation comment for a follow-up issue.
+
+4. **`test(infra): SQLite busy_timeout pragma probe — failing (story-maint-11)`**
+   - Add a unit test in `tests/unit/infra/db/sqlite-client.test.ts` (create file if needed): `expect(db.prepare('PRAGMA busy_timeout').pluck().get()).toBe(5000)` after `getDb`. Fails today (default is 0).
+
+5. **`feat(infra): set busy_timeout=5000 — minimal green (story-maint-11)`**
+   - Add `dbInstance.pragma('busy_timeout = 5000')` to `getDb`.
+   - Probe test from slice 4 turns green.
+
+6. **`test(cli): YAML-authoritative dbPath + --db-path-override warn — failing (story-maint-11)`**
+   - Add the two Gherkin scenarios to `tests/features/ingest.feature`.
+   - Add the `Given an accounting.yaml at tmp dir with dbPath: <X>` step + `Then the migration creates the file at <Y>` step in `tests/features/steps/ingest.steps.ts`.
+   - Add unit test for `getDb` path-mismatch guard.
+   - Add unit test for the migration-check hint string update.
+   - All fail (production code unchanged).
+
+7. **`feat(cli): #65 fix + --db-path-override rename + warn-on-use — minimal green (story-maint-11)`**
+   - Update `program.ts` to load config first, resolve `dbPath = options.dbPathOverride ?? config.dbPath`, warn on override use.
+   - Rename `--db-path` to `--db-path-override` on both `migrate` and `ingest`.
+   - Refactor `IngestCommandDeps`: `configService` → `config`. Update `runIngestCommand` to read `config` directly instead of calling `loadAndParse(configService)`.
+   - Drop the `'accounting.db'` default from `getDb`.
+   - Update `migration-check.ts` hint string.
+   - Migrate **all** test files that mock `configService` (5 unit + 1 perf + integration) to pass `config` directly.
+   - Migrate subprocess tests to inline-YAML `dbPath` (avoid the warning on every CI run); drop `--db-path` from the spawn args. Updates `uninit-db-hint.test.ts`, `ingest-end-to-end-wiring.test.ts`, `symlink-dbpath-refuse.test.ts`, `ingest.steps.ts`, `commit.steps.ts`.
+   - Closes #65.
+   - All previously-green tests stay green; the new scenarios + unit tests turn green.
+
+8. **`refactor(infra): extract findDuplicateIndices helper (#56) (story-maint-11)`**
+   - Add helper to `src/infra/config/config-schema.ts` (or `src/infra/config/duplicate-indices.ts` if cleaner — Sonnet decision).
+   - Replace 4 call sites.
+   - Add helper unit test (5 cases).
+   - Existing config-schema tests stay green.
+   - Closes #56.
+
+9. **`chore(retro): story-maint-11 retrospective`** — Keep / Change / Try.
+
+**Why 9 commits, not 6.** The 4 deliverables are scope-independent (a partial revert leaves the rest functional). Each `test:` → `feat:` pair is a real TDD slice. Slices 4+5 (busy_timeout) are the smallest production change but split per CLAUDE.md § 6.4's "never combine red and green in one commit" rule. Bundling 8 (#56) into 7 would muddy the diff for reviewers — keep it as a separate refactor commit.
+
+## Risks & deferred items
+
+- **`Result.combine` removal in slice 3.** If grep finds an external consumer (test or app code), keep it deprecated with a comment + follow-up issue rather than removing. The deprecation alone is a behaviour-preserving cleanup; the removal can wait.
+
+- **`getDb` default removal could break a forgotten call site.** Run `git grep 'getDb('` before slice 7 to confirm only `program.ts` and `tests/integration/cli/ingest-commit.test.ts`-style files call it. Both pass an explicit path already.
+
+- **Subprocess test pivot to inline-YAML.** The `writeStubYaml` helper's `dbPath` override exists but currently defaults to `./test.db` (relative to YAML location). Tests need to either (a) use absolute paths in the YAML override, or (b) understand that `cwd=<tmp>` makes `./test.db` resolve to `<tmp>/test.db`. Verify the FileConfigService's path resolution before slice 7 to avoid mid-implementation surprise.
+
+- **`--db-path-override` operator UX.** The flag is intentionally clunky. If it's still used in tests heavily, the warning logs accumulate on every CI run. Hence the pivot to inline-YAML. Document this trade-off in the retro.
+
+- **`Result.all` vs `Result.combine` API surface.** Both functionally similar but `Result.combine` has a wider type (`Result<unknown>`). If a future consumer wants `Result.combine`'s shape (e.g., they want a single Result without unpacking the array), the deprecation note in slice 2 says: "Use `Result.all(...).map(() => undefined)` for the discard case."
+
+- **The `getDb` path-mismatch guard's error message** mentions `closeDb()`. Verify `closeDb` is exported and accessible from the call sites that would hit this — it is ([src/infra/db/sqlite-client.ts:21](src/infra/db/sqlite-client.ts)) but worth confirming during slice 7.
+
+- **Out of scope** for this story:
+  - `Result.allCollect` (accumulate all errors, not just first) — defer to first Epic 3 story that needs it.
+  - Remaining `isFailure` early-returns in Core (~10 sites). Migrate opportunistically as Epic 3 stories touch them.
+  - [#34](https://github.com/xavierbriand/accounting/issues/34) (999-row hash chunking) — only if Epic 3 grows batch sizes.
+  - [#42](https://github.com/xavierbriand/accounting/issues/42), [#43](https://github.com/xavierbriand/accounting/issues/43), [#46](https://github.com/xavierbriand/accounting/issues/46), [#51](https://github.com/xavierbriand/accounting/issues/51), [#57](https://github.com/xavierbriand/accounting/issues/57), [#58](https://github.com/xavierbriand/accounting/issues/58), [#59](https://github.com/xavierbriand/accounting/issues/59) — already closed or out of scope.
+  - Plugin migration → Epic M-B (story-maint-12a/b).
+
+## Verification plan
+
+End-to-end manual verification by the user before marking ready:
+
+1. `npm run lint && npm run build && npm test` — green; should be ~270 tests after additions.
+2. Manual smoke: with a fresh `accounting.yaml` containing `dbPath: ./mydb.db`, run `npm run migrate`. Confirm `./mydb.db` is created, not `./accounting.db`.
+3. Manual smoke: `npm run migrate -- --db-path-override /tmp/recovery.db`. Confirm warning prints to stderr, file appears at `/tmp/recovery.db`.
+4. SQLite probe: open the DB and run `PRAGMA busy_timeout;`. Should return `5000`.
+5. Spot-check `transaction-builder.ts` and `idempotency-service.ts` for cleaner Result combinator usage.
+
+CI gates: `npm run lint && npm run build && npm test` green. Subprocess tier still under ~5s aggregate.
+
+## Suggestion log
+
+Phase 2 (P1 / P2 / P3) by Opus on 2026-04-26.
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+| P1 | Slice 7 bundles a lot (CLI flag rename, deps-shape change, getDb signature change, hint update, 6+ test file updates). Risk: green-on-landing collapse for legitimately-sized work. Defensible per CLAUDE.md § 6.6 (adapter-rule analogue: the minimum-viable fix intrinsically bundles production change + mock-surface updates). | adopted (defended in plan) | Documented in slice 7 + § "Why 9 commits". The rename + deps-shape change cannot land separately — TS compile fails until both move together. The same logic applied to story-maint-09's factory-injection slice. |
+| P1 | The `getDb` default removal is a silent breaking change for any caller relying on it. Before removing, the slice should explicitly grep all call sites and confirm none rely on the default. | adopted | Added "Risks" entry + Sonnet instruction in slice 7 to grep first, list call sites in commit body. |
+| P1 | The `--db-path-override` warning is "warn-once" — does that mean per-process or per-call? If a single command parses args twice, double-warn possible. | adopted (clarified) | Per-process (one warning per CLI invocation). Implementation: `program.ts` action prints the warning before `getDb`. Single code path. |
+| P2 | `Result.all` deprecates `Result.combine`. Should we keep both for backwards-compat or do a hard rename? | adopted (mid-ground) | Slice 3 grep-checks for `Result.combine` consumers; if zero, remove. If non-zero, keep with deprecation comment + follow-up issue. Internal API; aggressive cleanup acceptable. |
+| P2 | Privacy: the new `dbpath-yaml-authoritative` scenario writes a YAML with a real-looking dbPath. No PII leak; dbPath is just a file path. | rejected | Not a PII concern. |
+| P2 | `findDuplicateIndices` extraction changes algorithmic complexity from O(n²) to O(n). Is this a regression risk? | rejected | Strictly improves perf. The extracted helper preserves the "first occurrence canonical" semantic of the inline `indexOf` form (verified by test). |
+| P3 | The `findDuplicateIndices` helper could live in a shared utility module if other parts of the codebase need duplicate detection. Cross-module placement decision? | adopted (in plan) | Slice 8 places in `src/infra/config/duplicate-indices.ts` (or co-located in `config-schema.ts` if the helper stays config-local). Sonnet decides between co-located or extracted module based on the diff size. |
+| P3 | Subprocess test pivot to inline-YAML — should this also drop the `--db-path` / `--db-path-override` flag entirely from the spawn args, or pass `--db-path-override` to ensure no warning regression? | adopted (clarified) | Drop the flag entirely from non-warning-test subprocess calls (avoids warning on every CI run). The new "warning" scenario explicitly passes `--db-path-override` to assert the warning fires. |
+| P3 | [#34](https://github.com/xavierbriand/accounting/issues/34) (999-row chunking) — adjacent to busy_timeout (both SQLite-related). Fold in? | rejected | Out of scope (not yet a real concern; only matters if Epic 3 grows batch sizes). Stays open. |
+| P3 | The `writeStubYaml` helper currently uses fictional partner names "Alice"/"Bob" — should the dbPath default be made absolute too (currently `./test.db`)? | deferred | Subprocess tests use `cwd=<tmp>`, so `./test.db` resolves to `<tmp>/test.db` — works correctly today. Absolute path would clutter logs. Revisit only if a future test fails on path resolution. |
+
+**Tally:** 7 adopted / 2 rejected / 1 deferred. DoR gate met.
+
+## DoR checklist
+
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review): 10 findings (7 adopted, 2 rejected, 1 deferred).
+- [ ] Draft PR with template sections 1–6 filled. **Next action.**

--- a/docs/retrospectives/story-maint-11.md
+++ b/docs/retrospectives/story-maint-11.md
@@ -1,0 +1,22 @@
+# Retrospective — story-maint-11
+
+Code refactor bundle: Result combinators + busy_timeout + YAML-authoritative dbPath + #56.
+
+## Keep
+
+- **Bundling scope-independent small items in one PR works well** — four deliverables landed as clean per-commit slices. Each commit is still revertable independently.
+- **The "grep contract before deletion" pattern** (slice 3 for `Result.combine`, slice 7 for `getDb`) was surfaced explicitly in the commit bodies. Reviewer can confirm removals were safe without re-running the search.
+- **Slice 7 as a single large commit** (the plan's "adapter-story coarser slices" analogy) was the right call. TypeScript compile forced production + all mock-surface changes to land together; splitting would have produced a red intermediate state for no benefit.
+- **The `busy_timeout` observation** (default already 5000 in the installed driver version) was correctly noted in the slice 4 commit body rather than silently passing. The pragma was still added explicitly — self-documenting intent, doesn't rely on the driver default.
+
+## Change
+
+- **`findDuplicateIndices` is still private to `config-schema.ts`**. The plan left the extraction/co-location decision to Sonnet based on diff size. The helper is 13 LOC and has no cross-module consumers yet. If a second consumer appears, extract to `src/infra/config/duplicate-indices.ts` at that point.
+- **`symlink-dbpath-refuse.test.ts` now depends on `writeStubYaml`** — the config load must succeed before `validateDbPath` is reached. This makes the symlink test slightly heavier (it writes a YAML stub). The tradeoff is correct: the test now exercises the real composition root path including config load.
+- **The `uninit-db-hint` test was updated to use YAML-authoritative dbPath**. The original test passed `--db-path` directly; the updated test uses `writeStubYaml` + no flag. The fixture CSV filename was also updated to match the YAML's `filenamePrefix: "bpce-valid_"` (the original used `bpce-valid.csv`, the updated uses `bpce-valid_real.csv`). If this test breaks in future, the likely cause is a mismatch between the YAML filenamePrefix and the fixture CSV filename.
+
+## Try
+
+- **Closing GitHub issues in the commit body** (via `Closes #65` / `Closes #56`) worked cleanly. Consider also adding `gh issue close` in the post-merge checklist so the issue board stays tidy without manual action.
+- **The migration hint update** removed the dbPath from the hint string. This is intentional (the path is in the error context already, and the new hint guides to `accounting.yaml`). However the integration test for `assertMigrated` was updated to assert both `dbPath` present in the error AND the new hint format. Worth confirming in Phase 4 that this is the right balance of context vs. verbosity.
+- **`Result.combine` was removed in slice 3**. The grep found zero external consumers. If a future consumer wants the "discard the array, get a single Result<void>" shape, use `Result.all(...).map(() => undefined)` as documented in the risk section. Consider adding this note to the `Result` class's JSDoc if Epic 3 consumers arrive.

--- a/src/cli/commands/ingest-command.ts
+++ b/src/cli/commands/ingest-command.ts
@@ -1,5 +1,4 @@
 import type { Writable } from 'stream';
-import type { ConfigService } from '@core/ports/config-service.js';
 import type { CsvParser } from '@core/ports/csv-parser.js';
 import type { IdempotencyService } from '@core/ingest/idempotency-service.js';
 import type { TransactionBuilder } from '@core/ingest/transaction-builder.js';
@@ -23,7 +22,7 @@ export type TransactionBuilderFactory =
   (accounts: readonly AccountConfig[]) => Pick<TransactionBuilder, 'buildAll'>;
 
 export interface IngestCommandDeps {
-  readonly configService: Pick<ConfigService, 'load'>;
+  readonly config: AppConfig;
   readonly csvParser: Pick<CsvParser, 'parse'>;
   readonly idempotencyService: Pick<IdempotencyService, 'filterNew'>;
   readonly transactionBuilder: TransactionBuilderFactory;
@@ -44,17 +43,9 @@ function writeln(stream: Writable, msg: string): void {
 
 async function loadAndParse(
   opts: IngestCommandOptions,
-  deps: Pick<IngestCommandDeps, 'configService' | 'csvParser' | 'pickSourceAccount' | 'readFile' | 'stderr' | 'exitCode'>,
-): Promise<{ config: AppConfig; account: AccountConfig; parseOutcome: ParseOutcome } | null> {
-  const { configService, csvParser, pickSourceAccount, readFile, stderr, exitCode } = deps;
-
-  const configResult = configService.load();
-  if (configResult.isFailure) {
-    writeln(stderr, `Configuration error: ${configResult.error}`);
-    exitCode(1);
-    return null;
-  }
-  const config = configResult.value;
+  deps: Pick<IngestCommandDeps, 'config' | 'csvParser' | 'pickSourceAccount' | 'readFile' | 'stderr' | 'exitCode'>,
+): Promise<{ account: AccountConfig; parseOutcome: ParseOutcome } | null> {
+  const { config, csvParser, pickSourceAccount, readFile, stderr, exitCode } = deps;
 
   const accountResult = pickSourceAccount(opts.file, config.accounts);
   if (accountResult.isFailure) {
@@ -90,14 +81,14 @@ async function loadAndParse(
     }
   }
 
-  return { config, account, parseOutcome };
+  return { account, parseOutcome };
 }
 
 export async function runIngestCommand(
   opts: IngestCommandOptions,
   deps: IngestCommandDeps,
 ): Promise<void> {
-  const { idempotencyService, transactionBuilder, prompt, stdout, stderr, exitCode, transactionRepository, snapshotService, dbPath } = deps;
+  const { config, idempotencyService, transactionBuilder, prompt, stdout, stderr, exitCode, transactionRepository, snapshotService, dbPath } = deps;
 
   const parsed = await loadAndParse(opts, deps);
   if (parsed === null) return;
@@ -110,7 +101,7 @@ export async function runIngestCommand(
   }
   const { fresh, duplicates } = idempotencyResult.value;
 
-  const builder = transactionBuilder(parsed.config.accounts);
+  const builder = transactionBuilder(config.accounts);
   const buildResult = builder.buildAll(fresh);
   if (buildResult.isFailure) {
     writeln(stderr, `Build error: ${buildResult.error}`);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -16,6 +16,43 @@ import { runIngestCommand } from './commands/ingest-command.js';
 import { runMigrate } from './migrate.js';
 import { assertMigrated } from '../infra/db/migration-check.js';
 import { validateDbPath } from '../infra/db/db-path-validator.js';
+import type { AppConfig } from '../core/config/app-config.js';
+import { Result } from '../core/shared/result.js';
+
+interface DbPathError {
+  code: number;
+  message: string;
+}
+
+interface ResolvedDb {
+  config: AppConfig;
+  resolvedDbPath: string;
+}
+
+function resolveDbPathForCommand(
+  options: { dbPathOverride?: string },
+  projectDir: string,
+  stderr: NodeJS.WritableStream,
+): Result<ResolvedDb, DbPathError> {
+  const configService = new FileConfigService({ projectDir });
+  const configResult = configService.load();
+  if (configResult.isFailure) {
+    return Result.fail({ code: 1, message: configResult.error });
+  }
+  const config = configResult.value;
+
+  if (options.dbPathOverride !== undefined) {
+    stderr.write('[warning] --db-path-override is set; YAML dbPath ignored. Use only for recovery.\n');
+  }
+  const effectiveDbPath = options.dbPathOverride ?? config.dbPath;
+
+  const validation = validateDbPath(effectiveDbPath);
+  if (validation.isFailure) {
+    return Result.fail({ code: 2, message: validation.error });
+  }
+
+  return Result.ok({ config, resolvedDbPath: validation.value });
+}
 
 const program = new Command();
 
@@ -29,25 +66,13 @@ program
   .description('Run database migrations')
   .option('--db-path-override <path>', 'Override the YAML dbPath (for recovery only; emits a warning)')
   .action((options: { dbPathOverride?: string }) => {
-    const configService = new FileConfigService({ projectDir: process.cwd() });
-    const configResult = configService.load();
-    if (configResult.isFailure) {
-      process.stderr.write(`error: ${configResult.error}\n`);
-      process.exit(1);
+    const result = resolveDbPathForCommand(options, process.cwd(), process.stderr);
+    if (result.isFailure) {
+      process.stderr.write(`error: ${result.error.message}\n`);
+      process.exit(result.error.code);
     }
-    const config = configResult.value;
-
-    if (options.dbPathOverride !== undefined) {
-      process.stderr.write('[warning] --db-path-override is set; YAML dbPath ignored. Use only for recovery.\n');
-    }
-    const effectiveDbPath = options.dbPathOverride ?? config.dbPath;
-
-    const validation = validateDbPath(effectiveDbPath);
-    if (validation.isFailure) {
-      process.stderr.write(`error: ${validation.error}\n`);
-      process.exit(2);
-    }
-    runMigrate(validation.value);
+    const { resolvedDbPath } = result.value;
+    runMigrate(resolvedDbPath);
   });
 
 program
@@ -58,25 +83,12 @@ program
   .option('--json', 'Output JSON instead of a table', false)
   .option('--db-path-override <path>', 'Override the YAML dbPath (for recovery only; emits a warning)')
   .action(async (options: { file: string; nonInteractive: boolean; json: boolean; dbPathOverride?: string }) => {
-    const configService = new FileConfigService({ projectDir: process.cwd() });
-    const configResult = configService.load();
-    if (configResult.isFailure) {
-      process.stderr.write(`error: ${configResult.error}\n`);
-      process.exit(1);
+    const result = resolveDbPathForCommand(options, process.cwd(), process.stderr);
+    if (result.isFailure) {
+      process.stderr.write(`error: ${result.error.message}\n`);
+      process.exit(result.error.code);
     }
-    const config = configResult.value;
-
-    if (options.dbPathOverride !== undefined) {
-      process.stderr.write('[warning] --db-path-override is set; YAML dbPath ignored. Use only for recovery.\n');
-    }
-    const effectiveDbPath = options.dbPathOverride ?? config.dbPath;
-
-    const validation = validateDbPath(effectiveDbPath);
-    if (validation.isFailure) {
-      process.stderr.write(`error: ${validation.error}\n`);
-      process.exit(2);
-    }
-    const resolvedDb = validation.value;
+    const { config, resolvedDbPath: resolvedDb } = result.value;
     const db = getDb(resolvedDb);
 
     const migrationCheck = assertMigrated(db, resolvedDb);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -27,9 +27,22 @@ program
 program
   .command('migrate')
   .description('Run database migrations')
-  .option('--db-path <path>', 'Path to the SQLite database', 'accounting.db')
-  .action((options: { dbPath: string }) => {
-    const validation = validateDbPath(options.dbPath);
+  .option('--db-path-override <path>', 'Override the YAML dbPath (for recovery only; emits a warning)')
+  .action((options: { dbPathOverride?: string }) => {
+    const configService = new FileConfigService({ projectDir: process.cwd() });
+    const configResult = configService.load();
+    if (configResult.isFailure) {
+      process.stderr.write(`error: ${configResult.error}\n`);
+      process.exit(1);
+    }
+    const config = configResult.value;
+
+    if (options.dbPathOverride !== undefined) {
+      process.stderr.write('[warning] --db-path-override is set; YAML dbPath ignored. Use only for recovery.\n');
+    }
+    const effectiveDbPath = options.dbPathOverride ?? config.dbPath;
+
+    const validation = validateDbPath(effectiveDbPath);
     if (validation.isFailure) {
       process.stderr.write(`error: ${validation.error}\n`);
       process.exit(2);
@@ -43,9 +56,22 @@ program
   .requiredOption('-f, --file <path>', 'Path to the bank CSV file')
   .option('--non-interactive', 'Fail if any item needs review (CI mode)', false)
   .option('--json', 'Output JSON instead of a table', false)
-  .option('--db-path <path>', 'Path to the SQLite database', 'accounting.db')
-  .action(async (options: { file: string; nonInteractive: boolean; json: boolean; dbPath: string }) => {
-    const validation = validateDbPath(options.dbPath);
+  .option('--db-path-override <path>', 'Override the YAML dbPath (for recovery only; emits a warning)')
+  .action(async (options: { file: string; nonInteractive: boolean; json: boolean; dbPathOverride?: string }) => {
+    const configService = new FileConfigService({ projectDir: process.cwd() });
+    const configResult = configService.load();
+    if (configResult.isFailure) {
+      process.stderr.write(`error: ${configResult.error}\n`);
+      process.exit(1);
+    }
+    const config = configResult.value;
+
+    if (options.dbPathOverride !== undefined) {
+      process.stderr.write('[warning] --db-path-override is set; YAML dbPath ignored. Use only for recovery.\n');
+    }
+    const effectiveDbPath = options.dbPathOverride ?? config.dbPath;
+
+    const validation = validateDbPath(effectiveDbPath);
     if (validation.isFailure) {
       process.stderr.write(`error: ${validation.error}\n`);
       process.exit(2);
@@ -59,7 +85,6 @@ program
       process.exit(2);
     }
 
-    const configService = new FileConfigService({ projectDir: process.cwd() });
     const csvParser = new NodeCsvParser();
     const hashRepo = new SqliteHashRepository(db);
     const idempotencyService = new IdempotencyService(nodeHashFn, hashRepo);
@@ -71,7 +96,7 @@ program
     await runIngestCommand(
       { file: options.file, nonInteractive: options.nonInteractive, json: options.json },
       {
-        configService,
+        config,
         csvParser,
         idempotencyService,
         transactionBuilder,

--- a/src/core/ingest/idempotency-service.ts
+++ b/src/core/ingest/idempotency-service.ts
@@ -24,22 +24,17 @@ export class IdempotencyService {
       hashes.push(this.hash(canonResult.value));
     }
 
-    const knownResult = this.repo.listKnownHashes(hashes);
-    if (knownResult.isFailure) {
-      return Result.fail(knownResult.error);
-    }
-    const known = knownResult.value;
-
-    const fresh: FreshIngestItem[] = [];
-    const duplicates: DuplicateIngestItem[] = [];
-    for (let i = 0; i < items.length; i++) {
-      if (known.has(hashes[i])) {
-        duplicates.push({ item: items[i], idempotencyHash: hashes[i] });
-      } else {
-        fresh.push({ item: items[i], idempotencyHash: hashes[i] });
+    return this.repo.listKnownHashes(hashes).flatMap((known) => {
+      const fresh: FreshIngestItem[] = [];
+      const duplicates: DuplicateIngestItem[] = [];
+      for (let i = 0; i < items.length; i++) {
+        if (known.has(hashes[i])) {
+          duplicates.push({ item: items[i], idempotencyHash: hashes[i] });
+        } else {
+          fresh.push({ item: items[i], idempotencyHash: hashes[i] });
+        }
       }
-    }
-
-    return Result.ok({ fresh, duplicates });
+      return Result.ok({ fresh, duplicates });
+    });
   }
 }

--- a/src/core/ingest/transaction-builder.ts
+++ b/src/core/ingest/transaction-builder.ts
@@ -62,7 +62,7 @@ function makeOutcome(
   confidence: Confidence,
   idempotencyHash: string,
 ): Result<BuildOutcome> {
-  const txResult = Transaction.create({
+  return Transaction.create({
     id,
     occurredAt: item.occurredAt,
     description: item.description,
@@ -70,9 +70,7 @@ function makeOutcome(
       { account: debitAccount, side: 'debit', amount: item.amount },
       { account: creditAccount, side: 'credit', amount: item.amount },
     ],
-  });
-  if (txResult.isFailure) return Result.fail(txResult.error);
-  return Result.ok({ transaction: txResult.value, category, classification, confidence, idempotencyHash });
+  }).map((transaction) => ({ transaction, category, classification, confidence, idempotencyHash }));
 }
 
 export class TransactionBuilder {

--- a/src/core/shared/result.ts
+++ b/src/core/shared/result.ts
@@ -64,11 +64,4 @@ export class Result<T, E = string> {
     return Result.ok(values);
   }
 
-  /** @deprecated Use Result.all(...).map(() => undefined) for the discard case. */
-  public static combine(results: Result<unknown>[]): Result<unknown> {
-    for (const result of results) {
-      if (result.isFailure) return result;
-    }
-    return Result.ok();
-  }
 }

--- a/src/core/shared/result.ts
+++ b/src/core/shared/result.ts
@@ -33,6 +33,20 @@ export class Result<T, E = string> {
     return this._error as E;
   }
 
+  public map<U>(fn: (t: T) => U): Result<U, E> {
+    if (this.isFailure) return Result.fail(this._error as E);
+    return Result.ok(fn(this._value as T));
+  }
+
+  public flatMap<U, F = E>(fn: (t: T) => Result<U, F>): Result<U, E | F> {
+    if (this.isFailure) return Result.fail(this._error as E | F);
+    return fn(this._value as T) as Result<U, E | F>;
+  }
+
+  public getOrElse<U>(fallback: U): T | U {
+    return this.isSuccess ? (this._value as T) : fallback;
+  }
+
   public static ok<U>(value?: U): Result<U, never> {
     return new Result<U, never>(true, undefined, value);
   }
@@ -41,6 +55,16 @@ export class Result<T, E = string> {
     return new Result<U, E>(false, error);
   }
 
+  public static all<U, E = string>(results: readonly Result<U, E>[]): Result<readonly U[], E> {
+    const values: U[] = [];
+    for (const r of results) {
+      if (r.isFailure) return Result.fail(r.error);
+      values.push(r.value);
+    }
+    return Result.ok(values);
+  }
+
+  /** @deprecated Use Result.all(...).map(() => undefined) for the discard case. */
   public static combine(results: Result<unknown>[]): Result<unknown> {
     for (const result of results) {
       if (result.isFailure) return result;

--- a/src/infra/config/config-schema.ts
+++ b/src/infra/config/config-schema.ts
@@ -4,6 +4,20 @@ import { Result } from '@core/shared/result.js';
 import { Money } from '@core/shared/money.js';
 import type { AppConfig } from '@core/config/app-config.js';
 
+function findDuplicateIndices<T>(items: readonly T[], keyFn: (t: T) => string): number[] {
+  const seen = new Map<string, number>();
+  const dupes: number[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const key = keyFn(items[i]);
+    if (seen.has(key)) {
+      dupes.push(i);
+    } else {
+      seen.set(key, i);
+    }
+  }
+  return dupes;
+}
+
 const SplitRuleSchema = z.object({
   partner: z.string().min(1),
   ratio: z.number().min(0).max(1),
@@ -27,16 +41,13 @@ const SplitWindowSchema = z
         message: `ratios must sum to 1.0 (got ${sum.toFixed(4)})`,
       });
     }
-    const names = win.rules.map(r => r.partner);
-    names.forEach((n, i) => {
-      if (names.indexOf(n) !== i) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['rules', i, 'partner'],
-          message: 'duplicate partner',
-        });
-      }
-    });
+    for (const i of findDuplicateIndices(win.rules, r => r.partner)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['rules', i, 'partner'],
+        message: 'duplicate partner',
+      });
+    }
   });
 
 const BufferBucketRawSchema = z.object({
@@ -91,18 +102,12 @@ const RawConfigSchema = z
       .array(AccountConfigSchema)
       .min(1)
       .superRefine((accts, ctx) => {
-        const ids = accts.map(a => a.id);
-        const prefixes = accts.map(a => a.filenamePrefix);
-        ids.forEach((id, i) => {
-          if (ids.indexOf(id) !== i) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, path: [i, 'id'], message: 'duplicate id' });
-          }
-        });
-        prefixes.forEach((p, i) => {
-          if (prefixes.indexOf(p) !== i) {
-            ctx.addIssue({ code: z.ZodIssueCode.custom, path: [i, 'filenamePrefix'], message: 'duplicate prefix' });
-          }
-        });
+        for (const i of findDuplicateIndices(accts, a => a.id)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: [i, 'id'], message: 'duplicate id' });
+        }
+        for (const i of findDuplicateIndices(accts, a => a.filenamePrefix)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: [i, 'filenamePrefix'], message: 'duplicate prefix' });
+        }
       }),
     splits: z
       .array(SplitWindowSchema)
@@ -145,16 +150,13 @@ const RawConfigSchema = z
         });
       })
       .superRefine((buffers, ctx) => {
-        const names = buffers.map(b => b.name);
-        names.forEach((name, i) => {
-          if (names.indexOf(name) !== i) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: [i, 'name'],
-              message: 'duplicate name',
-            });
-          }
-        });
+        for (const i of findDuplicateIndices(buffers, b => b.name)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [i, 'name'],
+            message: 'duplicate name',
+          });
+        }
       }),
   })
   .strict();

--- a/src/infra/db/migration-check.ts
+++ b/src/infra/db/migration-check.ts
@@ -6,7 +6,7 @@ export function assertMigrated(db: Database.Database, dbPath: string): Result<vo
   if (userVersion === 0) {
     return Result.fail(
       `database not initialised at ${dbPath}\n` +
-      `hint: run 'accounting migrate --db-path ${dbPath}' first`,
+      `hint: run 'accounting migrate' first (or set dbPath in accounting.yaml)`,
     );
   }
   return Result.ok(undefined);

--- a/src/infra/db/sqlite-client.ts
+++ b/src/infra/db/sqlite-client.ts
@@ -2,18 +2,27 @@ import fs from 'fs';
 import Database from 'better-sqlite3';
 
 let dbInstance: Database.Database | null = null;
+let dbOpenedPath: string | null = null;
 
-export function getDb(dbPath: string = 'accounting.db'): Database.Database {
-  if (!dbInstance) {
-    const isNewFile = dbPath !== ':memory:' && !fs.existsSync(dbPath);
-    dbInstance = new Database(dbPath);
-    // WAL mode defaults to synchronous = FULL, satisfying NFR7 (>= NORMAL).
-    dbInstance.pragma('journal_mode = WAL');
-    // Enforce FK constraints at the connection level (defense-in-depth).
-    dbInstance.pragma('foreign_keys = ON');
-    if (isNewFile && process.platform !== 'win32') {
-      fs.chmodSync(dbPath, 0o600);
+export function getDb(dbPath: string): Database.Database {
+  if (dbInstance) {
+    if (dbOpenedPath !== dbPath) {
+      throw new Error('getDb: already opened with a different path; call closeDb() first');
     }
+    return dbInstance;
+  }
+  const isNewFile = dbPath !== ':memory:' && !fs.existsSync(dbPath);
+  dbInstance = new Database(dbPath);
+  dbOpenedPath = dbPath;
+  // WAL mode defaults to synchronous = FULL, satisfying NFR7 (>= NORMAL).
+  dbInstance.pragma('journal_mode = WAL');
+  // Enforce FK constraints at the connection level (defense-in-depth).
+  dbInstance.pragma('foreign_keys = ON');
+  // 5-second busy-wait prevents spurious SQLITE_BUSY during snapshot+commit
+  // concurrency introduced in Story 2.5.
+  dbInstance.pragma('busy_timeout = 5000');
+  if (isNewFile && process.platform !== 'win32') {
+    fs.chmodSync(dbPath, 0o600);
   }
   return dbInstance;
 }
@@ -22,5 +31,6 @@ export function closeDb(): void {
   if (dbInstance) {
     dbInstance.close();
     dbInstance = null;
+    dbOpenedPath = null;
   }
 }

--- a/tests/features/ingest.feature
+++ b/tests/features/ingest.feature
@@ -46,3 +46,23 @@ Feature: Ingest CLI builds and reviews transactions from bank CSVs
     # fails if: --json output hardcodes duplicates: [] or omits the array entirely.
     # Story 2.4 retro action A: mock-diversity check — assertions run against a
     # non-default fixture (5 duplicates, not 0).
+
+  Scenario: dbPath in accounting.yaml is honoured (closes #65) (story-maint-11)
+    Given a fresh tmp dir
+    And an accounting.yaml at tmp dir with dbPath: "./ledger.db"
+    When I run migrate with no --db-path-override
+    Then the migration creates the file at "ledger.db"
+    And no file exists at "accounting.db"
+    # fails if: program.ts uses the hardcoded 'accounting.db' default instead of
+    # config.dbPath, leaving ledger.db non-existent and accounting.db populated.
+
+  Scenario: --db-path-override warns and overrides YAML dbPath (story-maint-11)
+    Given a fresh tmp dir
+    And an accounting.yaml at tmp dir with dbPath: "./ledger.db"
+    When I run migrate with --db-path-override "recovery.db"
+    Then the migration creates the file at "recovery.db"
+    And no file exists at "ledger.db"
+    And stderr contains "[warning]"
+    And stderr contains "--db-path-override is set"
+    # fails if: --db-path-override is silently honoured (no warn), or the rename
+    # didn't propagate (CLI parses old --db-path), or YAML dbPath wins over the override.

--- a/tests/features/steps/commit.steps.ts
+++ b/tests/features/steps/commit.steps.ts
@@ -49,6 +49,10 @@ async function runIngestInProcess(
   db.pragma('foreign_keys = ON');
 
   const configService = new FileConfigService({ projectDir: state.tmpDir! });
+  const configResult = configService.load();
+  if (configResult.isFailure) throw new Error(`Config load failed: ${configResult.error}`);
+  const config = configResult.value;
+
   const csvParser = new NodeCsvParser();
   const hashRepo = new SqliteHashRepository(db);
   const idempotencyService = new IdempotencyService(nodeHashFn, hashRepo);
@@ -71,7 +75,7 @@ async function runIngestInProcess(
   await runIngestCommand(
     { file: state.csvPath!, nonInteractive: false, json: false },
     {
-      configService,
+      config,
       csvParser,
       idempotencyService,
       transactionBuilder: transactionBuilderFactory,

--- a/tests/features/steps/ingest.steps.ts
+++ b/tests/features/steps/ingest.steps.ts
@@ -51,8 +51,10 @@ Given('a fresh migrated DB and accounting.yaml at a temp dir', function (state: 
   const tmpDir = makeTmpDir();
   state.tmpDir = tmpDir;
   state.dbPath = path.join(tmpDir, 'test.db');
+  // dbPath in YAML uses relative './test.db'; cwd=tmpDir makes it resolve to tmpDir/test.db
   writeStubYaml(tmpDir);
-  spawnCli(['migrate', '--db-path', state.dbPath], { cwd: tmpDir });
+  // YAML-authoritative: no --db-path flag after #65 (story-maint-11)
+  spawnCli(['migrate'], { cwd: tmpDir });
 });
 
 Given('a BPCE CSV copied to that temp dir as {string}', function (state: IngestWorld, filename: string) {
@@ -71,6 +73,10 @@ Given('the CSV has been committed interactively', async function (state: IngestW
   db.pragma('foreign_keys = ON');
 
   const configService = new FileConfigService({ projectDir: state.tmpDir! });
+  const configResult = configService.load();
+  if (configResult.isFailure) throw new Error(`Config load failed: ${configResult.error}`);
+  const config = configResult.value;
+
   const csvParser = new NodeCsvParser();
   const hashRepo = new SqliteHashRepository(db);
   const idempotencyService = new IdempotencyService(nodeHashFn, hashRepo);
@@ -85,7 +91,7 @@ Given('the CSV has been committed interactively', async function (state: IngestW
   await runIngestCommand(
     { file: state.csvPath!, nonInteractive: false, json: false },
     {
-      configService,
+      config,
       csvParser,
       idempotencyService,
       transactionBuilder: transactionBuilderFactory,
@@ -109,7 +115,8 @@ Given('the CSV has been committed interactively', async function (state: IngestW
 
 When('I run ingest with {string}', function (state: IngestWorld, flagsStr: string) {
   const flags = flagsStr.trim().split(/\s+/);
-  const args = ['ingest', '--file', state.csvPath!, ...flags, '--db-path', state.dbPath!];
+  // YAML-authoritative dbPath after #65: no --db-path flag; cwd=tmpDir resolves ./test.db
+  const args = ['ingest', '--file', state.csvPath!, ...flags];
   state.lastResult = spawnCli(args, { cwd: state.tmpDir });
 });
 

--- a/tests/features/steps/ingest.steps.ts
+++ b/tests/features/steps/ingest.steps.ts
@@ -188,3 +188,33 @@ Then('the JSON payload contains no partner names verbatim', function (state: Ing
   expect(raw).not.toContain('Alice');
   expect(raw).not.toContain('Bob');
 });
+
+// Step definitions for YAML-authoritative dbPath scenarios (story-maint-11)
+
+Given('a fresh tmp dir', function (state: IngestWorld) {
+  const tmpDir = makeTmpDir();
+  state.tmpDir = tmpDir;
+});
+
+Given('an accounting.yaml at tmp dir with dbPath: {string}', function (state: IngestWorld, dbPathValue: string) {
+  writeStubYaml(state.tmpDir!, { dbPath: dbPathValue });
+});
+
+When('I run migrate with no --db-path-override', function (state: IngestWorld) {
+  state.lastResult = spawnCli(['migrate'], { cwd: state.tmpDir });
+});
+
+When('I run migrate with --db-path-override {string}', function (state: IngestWorld, overridePath: string) {
+  const resolvedOverride = path.join(state.tmpDir!, overridePath);
+  state.lastResult = spawnCli(['migrate', '--db-path-override', resolvedOverride], { cwd: state.tmpDir });
+});
+
+Then('the migration creates the file at {string}', function (state: IngestWorld, relativePath: string) {
+  const fullPath = path.join(state.tmpDir!, relativePath);
+  expect(fs.existsSync(fullPath)).toBe(true);
+});
+
+Then('no file exists at {string}', function (state: IngestWorld, relativePath: string) {
+  const fullPath = path.join(state.tmpDir!, relativePath);
+  expect(fs.existsSync(fullPath)).toBe(false);
+});

--- a/tests/integration/cli/ingest-commit.test.ts
+++ b/tests/integration/cli/ingest-commit.test.ts
@@ -91,7 +91,7 @@ function makeRealDeps(
   };
 
   const deps: IngestCommandDeps = {
-    configService: { load: () => Result.ok(config) },
+    config,
     csvParser: new NodeCsvParser(),
     idempotencyService,
     transactionBuilder: (accounts) => new TransactionBuilder(accounts, undefined, nodeUuidGen),

--- a/tests/integration/cli/ingest-end-to-end-wiring.test.ts
+++ b/tests/integration/cli/ingest-end-to-end-wiring.test.ts
@@ -46,16 +46,15 @@ describe('ingest end-to-end wiring against real BPCE CSV', () => {
     //   would exit 0 (zero low-confidence rows) instead of 2 (3 low-confidence rows).
     const tmpDir = makeTmpDir();
     const csvPath = path.join(tmpDir, 'bpce-valid_real.csv');
-    const dbPath = path.join(tmpDir, 'test.db');
 
     fs.copyFileSync(FIXTURE_CSV, csvPath);
     writeStubYaml(tmpDir);
 
-    // Seed the DB schema
-    spawnCli(['migrate', '--db-path', dbPath], { cwd: tmpDir });
+    // Seed the DB schema via YAML-authoritative dbPath (no flag needed after #65)
+    spawnCli(['migrate'], { cwd: tmpDir });
 
     const result = spawnCli(
-      ['ingest', '--file', csvPath, '--non-interactive', '--json', '--db-path', dbPath],
+      ['ingest', '--file', csvPath, '--non-interactive', '--json'],
       { cwd: tmpDir },
     );
 

--- a/tests/integration/cli/symlink-dbpath-refuse.test.ts
+++ b/tests/integration/cli/symlink-dbpath-refuse.test.ts
@@ -10,6 +10,9 @@
  *   better-sqlite3 would follow the symlink and write SQLite bytes into an unintended
  *   target file (no stderr refusal, no exit 2). This test proves the guard is in place
  *   at the CLI composition root for both commands.
+ *
+ * Uses --db-path-override (the recovery flag) to pass a symlinked path explicitly,
+ * bypassing the YAML-authoritative path so validateDbPath is exercised directly.
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
@@ -17,12 +20,14 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { writeStubYaml } from '../../_helpers/inline-config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const TSX_BIN = path.join(__dirname, '../../../node_modules/.bin/tsx');
 const CLI_SRC = path.join(__dirname, '../../../src/cli/program.ts');
+const TSCONFIG = path.join(__dirname, '../../../tsconfig.json');
 
 const FIXTURE_CSV = path.join(__dirname, '../../fixtures/csv/bpce-valid.csv');
 
@@ -50,12 +55,15 @@ describe('migrate against symlinked dbPath', () => {
     const linkPath = path.join(tmpDir, 'link.db');
     fs.writeFileSync(realFile, '');
     fs.symlinkSync(realFile, linkPath);
+    // Stub YAML so the config load succeeds; --db-path-override passes the symlinked path
+    writeStubYaml(tmpDir);
 
     let error: { status: number | null; stderr: Buffer | string; stdout: Buffer | string } | null = null;
 
     try {
-      execFileSync(TSX_BIN, [CLI_SRC, 'migrate', '--db-path', linkPath], {
+      execFileSync(TSX_BIN, ['--tsconfig', TSCONFIG, CLI_SRC, 'migrate', '--db-path-override', linkPath], {
         encoding: 'utf8',
+        cwd: tmpDir,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
     } catch (e) {
@@ -86,12 +94,15 @@ describe('ingest against symlinked dbPath', () => {
     fs.writeFileSync(realFile, '');
     fs.symlinkSync(realFile, linkPath);
     fs.copyFileSync(FIXTURE_CSV, csvPath);
+    // Stub YAML so the config load succeeds; --db-path-override passes the symlinked path
+    writeStubYaml(tmpDir);
 
     let error: { status: number | null; stderr: Buffer | string; stdout: Buffer | string } | null = null;
 
     try {
-      execFileSync(TSX_BIN, [CLI_SRC, 'ingest', '--file', csvPath, '--db-path', linkPath], {
+      execFileSync(TSX_BIN, ['--tsconfig', TSCONFIG, CLI_SRC, 'ingest', '--file', csvPath, '--db-path-override', linkPath], {
         encoding: 'utf8',
+        cwd: tmpDir,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
     } catch (e) {

--- a/tests/integration/cli/uninit-db-hint.test.ts
+++ b/tests/integration/cli/uninit-db-hint.test.ts
@@ -15,6 +15,7 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { spawnCli } from '../../_helpers/spawn-cli.js';
+import { writeStubYaml } from '../../_helpers/inline-config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -41,11 +42,13 @@ describe('ingest against uninitialised DB', () => {
     //   without the check, SqliteTransactionRepository constructor throws a raw SqliteError
     //   with a stack trace that would reach the user. This test proves the user-visible fix.
     const tmpDir = makeTmpDir();
-    const dbPath = path.join(tmpDir, 'uninit.db');
-    const csvPath = path.join(tmpDir, 'bpce-valid.csv');
+    const csvPath = path.join(tmpDir, 'bpce-valid_real.csv');
     fs.copyFileSync(FIXTURE_CSV, csvPath);
+    // YAML carries dbPath — no --db-path flag needed after #65 (story-maint-11)
+    writeStubYaml(tmpDir);
+    // No migrate — DB is intentionally uninitialised
 
-    const result = spawnCli(['ingest', '--file', csvPath, '--db-path', dbPath]);
+    const result = spawnCli(['ingest', '--file', csvPath], { cwd: tmpDir });
 
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('database not initialised');

--- a/tests/integration/infra/db/migration-check.test.ts
+++ b/tests/integration/infra/db/migration-check.test.ts
@@ -37,10 +37,11 @@ afterEach(() => {
 });
 
 describe('assertMigrated', () => {
-  it('(a) empty DB (user_version=0) returns Result.fail with friendly message containing dbPath', () => {
+  it('(a) empty DB (user_version=0) returns Result.fail with friendly YAML-authoritative hint', () => {
     // fails if: assertMigrated returns ok on an uninitialised DB
     //   (the migration guard would be bypassed, SqliteTransactionRepository constructor
     //    would throw a raw SqliteError that reaches the user as a stack trace)
+    // story-maint-11: hint updated to not reference --db-path flag (YAML is authoritative)
     const db = makeEmptyDb();
     const dbPath = '/tmp/test-uninit.db';
 
@@ -48,8 +49,10 @@ describe('assertMigrated', () => {
 
     expect(result.isFailure).toBe(true);
     expect(result.error).toContain('database not initialised');
-    expect(result.error).toContain("hint: run 'accounting migrate");
     expect(result.error).toContain(dbPath);
+    expect(result.error).toContain("hint: run 'accounting migrate' first");
+    expect(result.error).toContain('accounting.yaml');
+    expect(result.error).not.toContain('--db-path');
   });
 
   it('(b) migrated DB (after runMigrations) returns Result.ok', () => {

--- a/tests/perf/ingest-throughput.test.ts
+++ b/tests/perf/ingest-throughput.test.ts
@@ -39,7 +39,6 @@ import { nodeHashFn } from '../../src/infra/crypto/node-hash-fn.js';
 import { nodeUuidGen } from '../../src/infra/crypto/node-uuid-gen.js';
 import { pickSourceAccount } from '../../src/infra/fs/pick-source-account.js';
 import { readBpceCsv } from '../../src/infra/fs/read-bpce-csv.js';
-import { Result } from '@core/shared/result.js';
 import type { AppConfig } from '@core/config/app-config.js';
 
 // Perf test threshold: 3000 ms (2000 ms local target + 1.5× CI headroom)
@@ -148,7 +147,7 @@ describe('ingest-throughput (perf)', () => {
       const exitCodes: number[] = [];
 
       const deps: IngestCommandDeps = {
-        configService: { load: () => Result.ok(config) },
+        config,
         csvParser: new NodeCsvParser(),
         idempotencyService,
         transactionBuilder: (accounts) => new TransactionBuilder(accounts, undefined, nodeUuidGen),

--- a/tests/unit/cli/commands/ingest-command-flags.test.ts
+++ b/tests/unit/cli/commands/ingest-command-flags.test.ts
@@ -87,7 +87,7 @@ describe('--non-interactive mode', () => {
     const prompter = { selectCategory: vi.fn(), confirmBatch: vi.fn() };
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: { parse: () => Result.ok({ items: outcomes.map(o => ({ sourceAccount: 'main-X', occurredAt: o.transaction.occurredAt, description: o.transaction.description, direction: 'outflow' as const, amount: EUR })), errors: [] }) },
       idempotencyService: { filterNew: (items) => Result.ok({ fresh: items.map((i) => ({ item: i, idempotencyHash: `hash-${i.description}` })), duplicates: [] }) },
       transactionBuilder: () => ({ buildAll: () => Result.ok({ built: outcomes, failed: [] }) }),
@@ -116,7 +116,7 @@ describe('--non-interactive mode', () => {
     const prompter = { selectCategory: vi.fn(), confirmBatch: vi.fn() };
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: { parse: () => Result.ok({ items: outcomes.map(o => ({ sourceAccount: 'main-X', occurredAt: o.transaction.occurredAt, description: o.transaction.description, direction: 'outflow' as const, amount: EUR })), errors: [] }) },
       idempotencyService: { filterNew: (items) => Result.ok({ fresh: items.map((i) => ({ item: i, idempotencyHash: `hash-${i.description}` })), duplicates: [] }) },
       transactionBuilder: () => ({ buildAll: () => Result.ok({ built: outcomes, failed: [] }) }),
@@ -148,7 +148,7 @@ describe('--json mode', () => {
     const parseErrorRow = { line: 1, reason: 'bad date', raw: 'x' };
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: outcomes[0].transaction.description, direction: 'outflow' as const, amount: EUR }], errors: [parseErrorRow] }) },
       idempotencyService: { filterNew: (items) => Result.ok({ fresh: items.map((i) => ({ item: i, idempotencyHash: `hash-${i.description}` })), duplicates: [dupItem] }) },
       transactionBuilder: () => ({ buildAll: () => Result.ok({ built: outcomes, failed: [] }) }),
@@ -192,7 +192,7 @@ describe('--json mode', () => {
     const parseErrorRow = { line: 2, reason: 'missing amount', raw: 'y' };
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: outcomes[0].transaction.occurredAt, description: outcomes[0].transaction.description, direction: 'outflow' as const, amount: EUR }], errors: [parseErrorRow, parseErrorRow] }) },
       idempotencyService: { filterNew: (items) => Result.ok({ fresh: items.map((i) => ({ item: i, idempotencyHash: `hash-${i.description}` })), duplicates: [dupItem, dupItem] }) },
       transactionBuilder: () => ({ buildAll: () => Result.ok({ built: outcomes, failed: [] }) }),
@@ -231,7 +231,7 @@ describe('--json mode', () => {
     const exitCodes: number[] = [];
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: { parse: vi.fn() },
       idempotencyService: { filterNew: vi.fn() },
       transactionBuilder: () => ({ buildAll: vi.fn() }),

--- a/tests/unit/cli/commands/ingest-command.test.ts
+++ b/tests/unit/cli/commands/ingest-command.test.ts
@@ -95,7 +95,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
     };
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: {
         parse: () => Result.ok({
           items: [
@@ -149,7 +149,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
     };
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: {
         parse: () => Result.ok({
           items: [{ sourceAccount: 'main-X', occurredAt: '2026-04-20T00:00:00+02:00', description: 'UBER TRIP', direction: 'outflow', amount: EUR }],
@@ -188,7 +188,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
     };
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: '2026-04-20T00:00:00+02:00', description: 'CARREFOUR', direction: 'outflow', amount: EUR }], errors: [] }) },
       idempotencyService: { filterNew: (items) => Result.ok({ fresh: items.map((i) => ({ item: i, idempotencyHash: `hash-${i.description}` })), duplicates: [] }) },
       transactionBuilder: () => ({ buildAll: () => Result.ok({ built: outcomes, failed: [] }) }),
@@ -222,7 +222,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
     };
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: { parse: () => Result.ok({ items: [{ sourceAccount: 'main-X', occurredAt: '2026-04-20T00:00:00+02:00', description: 'UBER TRIP', direction: 'outflow', amount: EUR }], errors: [] }) },
       idempotencyService: { filterNew: (items) => Result.ok({ fresh: items.map((i) => ({ item: i, idempotencyHash: `hash-${i.description}` })), duplicates: [] }) },
       transactionBuilder: () => ({ buildAll: () => Result.ok({ built: outcomes, failed: [] }) }),
@@ -250,7 +250,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
     const capturedExitCode: number[] = [];
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: { parse: vi.fn() },
       idempotencyService: { filterNew: vi.fn() },
       transactionBuilder: () => ({ buildAll: vi.fn() }),
@@ -297,7 +297,7 @@ describe('runIngestCommand — interactive re-categorisation preserves idempoten
     };
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: {
         parse: () => Result.ok({
           items: [{ sourceAccount: 'main-X', occurredAt: '2026-04-20T00:00:00+02:00', description: 'UBER TRIP', direction: 'outflow', amount: EUR }],
@@ -356,7 +356,7 @@ describe('runIngestCommand — commitBatch flow (Story 2.5)', () => {
     ];
 
     const deps: IngestCommandDeps = {
-      configService: { load: () => Result.ok(baseConfig) },
+      config: baseConfig,
       csvParser: { parse: () => Result.ok({
         items: outcomes.map((o) => ({ sourceAccount: 'main-X', occurredAt: o.transaction.occurredAt, description: o.transaction.description, direction: 'outflow' as const, amount: EUR })),
         errors: [],

--- a/tests/unit/core/shared/result.test.ts
+++ b/tests/unit/core/shared/result.test.ts
@@ -19,7 +19,7 @@ describe('Result.map', () => {
 
   it('map identity: r.map(x => x) === r (failure)', () => {
     fc.assert(
-      fc.property(fc.string(), (err) => {
+      fc.property(fc.string({ minLength: 1 }), (err) => {
         const r = Result.fail<string>(err);
         const mapped = r.map((x) => x);
         expect(mapped.isFailure).toBe(true);
@@ -83,7 +83,7 @@ describe('Result.flatMap', () => {
 
   it('flatMap short-circuit: Result.fail(e).flatMap(f) === Result.fail(e)', () => {
     fc.assert(
-      fc.property(fc.string(), (err) => {
+      fc.property(fc.string({ minLength: 1 }), (err) => {
         let callCount = 0;
         const f = (x: string): Result<string> => {
           callCount++;
@@ -108,7 +108,7 @@ describe('Result.flatMap', () => {
 
   it('flatMap short-circuits on first failure', () => {
     const r = Result.ok(5)
-      .flatMap((_) => Result.fail<number>('mid-chain error'))
+      .flatMap(() => Result.fail<number>('mid-chain error'))
       .flatMap((x) => Result.ok(x * 2));
     expect(r.isFailure).toBe(true);
     expect(r.error).toBe('mid-chain error');
@@ -127,7 +127,7 @@ describe('Result.getOrElse', () => {
 
   it('getOrElse: Result.fail(e).getOrElse(y) === y', () => {
     fc.assert(
-      fc.property(fc.string(), fc.string(), (err, fallback) => {
+      fc.property(fc.string({ minLength: 1 }), fc.string(), (err, fallback) => {
         const r = Result.fail<string>(err);
         expect(r.getOrElse(fallback)).toBe(fallback);
       }),
@@ -151,7 +151,7 @@ describe('Result.all', () => {
   it('Result.all short-circuits on first failure', () => {
     fc.assert(
       fc.property(
-        fc.array(fc.string(), { minLength: 1, maxLength: 5 }),
+        fc.array(fc.string({ minLength: 1 }), { minLength: 1, maxLength: 5 }),
         fc.nat({ max: 4 }),
         (values, failIdx) => {
           const actualFailIdx = failIdx % values.length;

--- a/tests/unit/core/shared/result.test.ts
+++ b/tests/unit/core/shared/result.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { Result } from '@core/shared/result.js';
+
+// Property tests for Result combinators: map, flatMap, getOrElse, Result.all
+// All fail until the combinators are implemented on the Result class.
+
+describe('Result.map', () => {
+  it('map identity: r.map(x => x) === r (success)', () => {
+    fc.assert(
+      fc.property(fc.string(), (val) => {
+        const r = Result.ok(val);
+        const mapped = r.map((x) => x);
+        expect(mapped.isSuccess).toBe(r.isSuccess);
+        expect(mapped.value).toBe(r.value);
+      }),
+    );
+  });
+
+  it('map identity: r.map(x => x) === r (failure)', () => {
+    fc.assert(
+      fc.property(fc.string(), (err) => {
+        const r = Result.fail<string>(err);
+        const mapped = r.map((x) => x);
+        expect(mapped.isFailure).toBe(true);
+        expect(mapped.error).toBe(err);
+      }),
+    );
+  });
+
+  it('map composition: r.map(g(f(x))) === r.map(f).map(g)', () => {
+    fc.assert(
+      fc.property(fc.integer(), (val) => {
+        const f = (x: number): string => String(x);
+        const g = (x: string): boolean => x.length > 0;
+        const r = Result.ok(val);
+        const composed = r.map((x) => g(f(x)));
+        const chained = r.map(f).map(g);
+        expect(composed.isSuccess).toBe(chained.isSuccess);
+        expect(composed.value).toBe(chained.value);
+      }),
+    );
+  });
+
+  it('map transforms success value', () => {
+    const r = Result.ok(42);
+    const mapped = r.map((x) => x * 2);
+    expect(mapped.isSuccess).toBe(true);
+    expect(mapped.value).toBe(84);
+  });
+
+  it('map passes through failure unchanged', () => {
+    const r = Result.fail<number>('some error');
+    const mapped = r.map((x) => x * 2);
+    expect(mapped.isFailure).toBe(true);
+    expect(mapped.error).toBe('some error');
+  });
+});
+
+describe('Result.flatMap', () => {
+  it('flatMap left identity: Result.ok(x).flatMap(f) === f(x)', () => {
+    fc.assert(
+      fc.property(fc.integer(), (val) => {
+        const f = (x: number): Result<string> => Result.ok(String(x));
+        const r = Result.ok(val).flatMap(f);
+        const direct = f(val);
+        expect(r.isSuccess).toBe(direct.isSuccess);
+        expect(r.value).toBe(direct.value);
+      }),
+    );
+  });
+
+  it('flatMap right identity: r.flatMap(Result.ok) === r (success)', () => {
+    fc.assert(
+      fc.property(fc.string(), (val) => {
+        const r = Result.ok(val);
+        const chained = r.flatMap((x) => Result.ok(x));
+        expect(chained.isSuccess).toBe(r.isSuccess);
+        expect(chained.value).toBe(r.value);
+      }),
+    );
+  });
+
+  it('flatMap short-circuit: Result.fail(e).flatMap(f) === Result.fail(e)', () => {
+    fc.assert(
+      fc.property(fc.string(), (err) => {
+        let callCount = 0;
+        const f = (x: string): Result<string> => {
+          callCount++;
+          return Result.ok(x);
+        };
+        const r = Result.fail<string>(err);
+        const chained = r.flatMap(f);
+        expect(chained.isFailure).toBe(true);
+        expect(chained.error).toBe(err);
+        expect(callCount).toBe(0);
+      }),
+    );
+  });
+
+  it('flatMap chains two successful results', () => {
+    const r = Result.ok(5)
+      .flatMap((x) => Result.ok(x + 1))
+      .flatMap((x) => Result.ok(x * 2));
+    expect(r.isSuccess).toBe(true);
+    expect(r.value).toBe(12);
+  });
+
+  it('flatMap short-circuits on first failure', () => {
+    const r = Result.ok(5)
+      .flatMap((_) => Result.fail<number>('mid-chain error'))
+      .flatMap((x) => Result.ok(x * 2));
+    expect(r.isFailure).toBe(true);
+    expect(r.error).toBe('mid-chain error');
+  });
+});
+
+describe('Result.getOrElse', () => {
+  it('getOrElse: Result.ok(x).getOrElse(y) === x', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (val, fallback) => {
+        const r = Result.ok(val);
+        expect(r.getOrElse(fallback)).toBe(val);
+      }),
+    );
+  });
+
+  it('getOrElse: Result.fail(e).getOrElse(y) === y', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (err, fallback) => {
+        const r = Result.fail<string>(err);
+        expect(r.getOrElse(fallback)).toBe(fallback);
+      }),
+    );
+  });
+});
+
+describe('Result.all', () => {
+  it('Result.all([]) returns Result.ok([])', () => {
+    const r = Result.all([]);
+    expect(r.isSuccess).toBe(true);
+    expect(r.value).toEqual([]);
+  });
+
+  it('Result.all with all successes accumulates values', () => {
+    const r = Result.all([Result.ok(1), Result.ok(2), Result.ok(3)]);
+    expect(r.isSuccess).toBe(true);
+    expect(r.value).toEqual([1, 2, 3]);
+  });
+
+  it('Result.all short-circuits on first failure', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string(), { minLength: 1, maxLength: 5 }),
+        fc.nat({ max: 4 }),
+        (values, failIdx) => {
+          const actualFailIdx = failIdx % values.length;
+          const results = values.map((v, i) =>
+            i === actualFailIdx ? Result.fail<string>('fail-at-' + i) : Result.ok(v),
+          );
+          const combined = Result.all(results);
+          if (results.every((r) => r.isSuccess)) {
+            expect(combined.isSuccess).toBe(true);
+          } else {
+            expect(combined.isFailure).toBe(true);
+          }
+        },
+      ),
+    );
+  });
+
+  it('Result.all first-failure: the error is the first failing element error', () => {
+    const r = Result.all([
+      Result.ok('a'),
+      Result.fail<string>('first error'),
+      Result.fail<string>('second error'),
+    ]);
+    expect(r.isFailure).toBe(true);
+    expect(r.error).toBe('first error');
+  });
+});

--- a/tests/unit/infra/config/config-schema.test.ts
+++ b/tests/unit/infra/config/config-schema.test.ts
@@ -590,4 +590,76 @@ describe('parseRawConfig', () => {
       );
     });
   });
+
+  // Helper unit tests for findDuplicateIndices semantics (story-maint-11 / #56)
+  // The helper is private to config-schema; tested via schema duplicate-detection paths.
+  describe('findDuplicateIndices semantics (via schema duplicate paths)', () => {
+    it('empty input: no duplicates reported (accounts list of one)', () => {
+      // Empty dedup domain: single-account config has no duplicates to find.
+      const result = parseRawConfig({
+        ...minimalValid,
+        accounts: [{ id: 'sole', type: 'bank', filenamePrefix: 'sole_' }],
+      });
+      expect(result.isSuccess).toBe(true);
+    });
+
+    it('all-unique: no duplicate error', () => {
+      // All keys distinct: findDuplicateIndices returns [].
+      const result = parseRawConfig({
+        ...minimalValid,
+        accounts: [
+          { id: 'a', type: 'bank', filenamePrefix: 'a_' },
+          { id: 'b', type: 'bank', filenamePrefix: 'b_' },
+          { id: 'c', type: 'bank', filenamePrefix: 'c_' },
+        ],
+      });
+      expect(result.isSuccess).toBe(true);
+    });
+
+    it('all-duplicate: every element after the first is flagged', () => {
+      // All same key: indices 1 and 2 are duplicates; index 0 is canonical.
+      const result = parseRawConfig({
+        ...minimalValid,
+        buffers: [
+          { name: 'X', target: 100 },
+          { name: 'X', target: 200 },
+          { name: 'X', target: 300 },
+        ],
+      });
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('duplicate');
+    });
+
+    it('mixed: only later-occurring duplicates are flagged, not the first', () => {
+      // [A, B, A]: index 2 is duplicate; index 0 is canonical. B is not a duplicate.
+      const result = parseRawConfig({
+        ...minimalValid,
+        buffers: [
+          { name: 'Alpha', target: 100 },
+          { name: 'Beta', target: 200 },
+          { name: 'Alpha', target: 300 },
+        ],
+      });
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('duplicate');
+      // Error path must cite index 2 (0-indexed), not index 0
+      expect(result.error).toContain('buffers.2.name');
+    });
+
+    it('non-adjacent duplicate: third element duplicates first', () => {
+      // [A, B, C, A]: index 3 is duplicate of index 0. B and C are unique.
+      const result = parseRawConfig({
+        ...minimalValid,
+        buffers: [
+          { name: 'First', target: 100 },
+          { name: 'Second', target: 200 },
+          { name: 'Third', target: 300 },
+          { name: 'First', target: 400 },
+        ],
+      });
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toContain('duplicate');
+      expect(result.error).toContain('buffers.3.name');
+    });
+  });
 });

--- a/tests/unit/infra/db/migration-check.test.ts
+++ b/tests/unit/infra/db/migration-check.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit tests for assertMigrated hint string — verifies #65 fix (story-maint-11).
+ *
+ * fails if: the hint still reads "run 'accounting migrate --db-path ...' first"
+ *   (old behaviour), instead of the new YAML-authoritative form
+ *   "run 'accounting migrate' first (or set dbPath in accounting.yaml)".
+ *   The old hint misleads users by suggesting --db-path is the primary workflow;
+ *   after #65, YAML dbPath is authoritative and --db-path-override is for recovery only.
+ */
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { assertMigrated } from '../../../../src/infra/db/migration-check.js';
+
+describe('assertMigrated — hint string (story-maint-11)', () => {
+  it('hint does not reference --db-path flag (YAML is authoritative after #65)', () => {
+    // fails if: hint still says "run 'accounting migrate --db-path <path>' first"
+    //   (references the renamed/removed flag); the new hint should guide users to
+    //   'accounting migrate' (YAML-driven) not a flag-based invocation.
+    const db = new Database(':memory:');
+    db.pragma('journal_mode = WAL');
+    const result = assertMigrated(db, '/tmp/test.db');
+    db.close();
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error).not.toContain('--db-path');
+    expect(result.error).toContain('accounting.yaml');
+  });
+});

--- a/tests/unit/infra/db/sqlite-client.test.ts
+++ b/tests/unit/infra/db/sqlite-client.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getDb, closeDb } from '../../../../src/infra/db/sqlite-client.js';
+
+// fails if: busy_timeout pragma is not set in getDb — default is 0 (immediate error
+// on contention). The 5000ms value is the standard busy-timeout for SQLite-backed CLIs
+// and prevents spurious SQLITE_BUSY during snapshot+commit concurrency (Story 2.5).
+
+const tmpDirs: string[] = [];
+
+function makeTmpDb(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-sqlite-client-test-'));
+  tmpDirs.push(dir);
+  return path.join(dir, 'test.db');
+}
+
+afterEach(() => {
+  closeDb();
+  for (const dir of tmpDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+describe('getDb — pragma configuration', () => {
+  it('sets busy_timeout to 5000ms', () => {
+    const dbPath = makeTmpDb();
+    const db = getDb(dbPath);
+    const timeout = db.prepare('PRAGMA busy_timeout').pluck().get() as number;
+    expect(timeout).toBe(5000);
+  });
+
+  it('sets journal_mode to WAL', () => {
+    const dbPath = makeTmpDb();
+    const db = getDb(dbPath);
+    const mode = db.prepare('PRAGMA journal_mode').pluck().get() as string;
+    expect(mode).toBe('wal');
+  });
+
+  it('throws on second call with a different path', () => {
+    const dbPath1 = makeTmpDb();
+    const dbPath2 = makeTmpDb();
+    getDb(dbPath1);
+    expect(() => getDb(dbPath2)).toThrow('getDb: already opened with a different path');
+  });
+});


### PR DESCRIPTION
## 1. Story

Second story of the **Refactor epic** (Epic M-A) per the senior-engineer refactor backlog plan. Bundles four code-health improvements that pay back during Epic 3.

Closes [#65](https://github.com/xavierbriand/accounting/issues/65) (`dbPath` in `accounting.yaml` silently ignored), [#56](https://github.com/xavierbriand/accounting/issues/56) (extract `findDuplicateIndices`).

## 2. Intent

Four scope-independent code improvements bundled in one PR:

1. **`Result` combinators.** `if (r.isFailure) return Result.fail(r.error); const x = r.value;` appeared 16 times in Core. Epic 3 (Predictive Transfer Engine) will chain `Money` operations, ledger lookups, and validity-window resolutions — boilerplate would multiply. Added `map`, `flatMap`, `getOrElse`, and `Result.all`.

2. **SQLite `busy_timeout` pragma.** `journal_mode = WAL` and `foreign_keys = ON` were set; `busy_timeout` was not. Snapshot+commit contention (Story 2.5) could surface as immediate `SQLITE_BUSY` rather than the customary 5s wait.

3. **YAML-authoritative `dbPath` (#65 fix) + `--db-path-override` flag.** `program.ts` ignored `accounting.yaml`'s `dbPath` field and used the `--db-path` flag's `'accounting.db'` default — bait-and-switch. Per the user's refactor-backlog direction: config is authoritative; the flag is renamed `--db-path-override` and warns on use (preserves the operator escape hatch with raised friction).

4. **Issue [#56](https://github.com/xavierbriand/accounting/issues/56).** Four near-identical `indexOf`-based duplicate-detection patterns in `config-schema.ts`. Extracted to a single helper, dropped O(n²) to O(n).

## 3. Alternatives considered

**Bundle vs split:** could have split into 11a + 11b (combinators+busy_timeout vs dbPath+#56) for smaller PRs. Bundled because each item is small (≤30 LOC of production code) and partial revert is per-commit.

**Result API shape:** `Result.combine` (existing) vs `Result.all` (new). Slice 3 grep-checked for `Result.combine` consumers; zero found — `combine` removed in favour of `all`.

**Removing `--db-path` entirely** (per #65's "Fix" item 2) vs keeping `--db-path-override` (user direction). Chose user direction: preserves operator escape hatch for recovery scenarios at the cost of a single warn-once log on use.

**`getDb` removal of default** — the `'accounting.db'` default was a footgun. Dropped entirely; require explicit `dbPath`. Slice 7 grep-checked all call sites first.

## 4. Selected solution & rationale

Full design in [docs/plans/story-maint-11.md](docs/plans/story-maint-11.md).

**Production-code surface** (per the maint-10 retro rule, CLAUDE.md § 6.1 phase 1):
- `Result` class — adds 4 instance methods + 1 static method; removes `Result.combine`.
- `IngestCommandDeps` — `configService` replaced with `config: AppConfig`.
- `getDb` signature — drops default; throws on re-open with mismatched path.
- CLI flag rename — `--db-path` → `--db-path-override` on both `migrate` and `ingest`.
- Migration hint string — updated to not reference the renamed flag.

Subprocess tests pivoted to inline-YAML `dbPath`; the new `--db-path-override` warning gets its own dedicated test.

## 5. Gherkin scenarios

Two new scenarios in [tests/features/ingest.feature](tests/features/ingest.feature) (extends the existing 4):

- `dbPath in accounting.yaml is honoured (closes #65)` — fresh tmpdir + YAML with `dbPath: ./ledger.db`, no `--db-path-override` → migration creates `./ledger.db`, no `accounting.db`.
- `--db-path-override warns and overrides YAML dbPath` — same setup + `--db-path-override <tmp>/recovery.db` → migration creates `recovery.db`, no `ledger.db`, stderr contains `[warning]` + `--db-path-override is set`.

Both subprocess via `spawnCli` against the dist binary.

## 6. Plan for Sonnet

10 commits total: 9 planned slices (test→feat→refactor pairs) + retrospective, plus 1 Phase 4 refactor commit. Slice plan in [docs/plans/story-maint-11.md § "Slice plan for Sonnet"](docs/plans/story-maint-11.md).

## 7. Suggestion log

Phase 2 (P1 / P2 / P3) by Opus on 2026-04-26.

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P1 | Slice 7 bundles a lot (rename + deps shape + getDb signature + hint + 6 test files). | adopted (defended) | TS compile fails until production + mocks move together. Adapter-rule analogue per CLAUDE.md § 6.6. |
| P1 | `getDb` default removal could break a forgotten call site. | adopted | Slice 7 grep-checked all `getDb(` call sites; all passed an explicit path. |
| P1 | `--db-path-override` warning timing — per-process or per-call? | adopted (clarified) | Per-process; warn fires before getDb in program.ts action. Single code path. |
| P2 | `Result.all` deprecates `Result.combine`. Hard rename or keep both? | adopted | Slice 3 grep-checked; zero consumers; removed cleanly. |
| P2 | Privacy: dbPath leaking in test stderr? | rejected | dbPath is just a file path; no PII. |
| P2 | `findDuplicateIndices` algorithmic complexity change. | rejected | Strictly improves perf; preserves "first-canonical" semantic. |
| P3 | `findDuplicateIndices` placement (co-located vs shared module). | adopted | Sonnet kept co-located in `config-schema.ts` (13 LOC, single consumer). |
| P3 | Subprocess test: drop flag entirely or pass `--db-path-override`? | adopted (clarified) | Drop flag for non-warning tests (use inline-YAML dbPath); warning scenario passes the flag. |
| P3 | [#34](https://github.com/xavierbriand/accounting/issues/34) (999-row chunking) — fold in? | rejected | Out of scope; defer until Epic 3 needs it. |
| P3 | `writeStubYaml` dbPath default — make absolute? | deferred | Works with `cwd=<tmp>` today; revisit on first failure. |
| **P4 (retro-check)** | **`program.ts` duplicates a 12-line config-load → warn → resolve → validateDbPath block across the migrate and ingest actions.** | **adopted** | **Phase 4 refactor delegated to Sonnet (commit `43fa770`). Extracted `resolveDbPathForCommand(options, projectDir, stderr)` returning `Result<{config, resolvedDbPath}, {code, message}>`. Both action callbacks compress to a 6-line unwrap. Exit-code distinction (1 for config load, 2 for validation) preserved via the discriminated error type.** |

**Tally:** 7 adopted / 2 rejected / 1 deferred (Phase 2) + 1 adopted (Phase 4 retro-check). DoR + DoD gates met.

## 8. Sonnet's learnings

### What was built (Phase 3, Sonnet)

The four Gherkin/unit scenarios from the plan now pass: (1) `Result` combinators (`map`/`flatMap`/`getOrElse`/`all`) with property tests, (2) SQLite `busy_timeout=5000` pragma + path-mismatch guard in `getDb`, (3) YAML-authoritative `dbPath` — `accounting migrate` reads `config.dbPath` by default; `--db-path-override` warns to stderr and overrides — closes #65, (4) `findDuplicateIndices` extracted from four O(n²) patterns in `config-schema.ts` — closes #56.

The `IngestCommandDeps` interface lost `configService` (replaced by `config: AppConfig` passed directly), `getDb` dropped its default parameter, and `migration-check.ts` hint no longer references the renamed flag.

### Phase 4 refactor (Sonnet, after Opus retro-check)

Extracted the byte-identical 12-line config-load → warn-on-override → resolve-dbPath → validateDbPath block from both `migrate` and `ingest` actions of `program.ts` into a single `resolveDbPathForCommand(options, projectDir, stderr)` helper returning `Result<ResolvedDb, DbPathError>` where `DbPathError = { code: number; message: string }` carries the exit code. Both action callbacks compress to 6 lines; exit codes (1 for config load, 2 for validation) preserved via the discriminated error type.

### Red → green sequence

- `test(core): Result combinators property tests — failing` · `ba4cc13` · proved the combinators didn't exist
- `feat(core): Result.map / flatMap / getOrElse / all combinators — minimal green` · `5e68713`
- `refactor(core): migrate exemplar call sites + remove Result.combine` · `f848e9d` · grep confirmed zero external consumers; combine removed
- `test(infra): SQLite busy_timeout pragma probe — failing` · `f1a694e` · path-mismatch test was failing; busy_timeout was already at 5000 in the installed driver (noted in commit body)
- `feat(infra): set busy_timeout=5000 + path-mismatch guard — minimal green` · `723b828` · pragma set explicitly + `dbOpenedPath` sentinel + `closeDb` cleanup
- `test(cli): YAML-authoritative dbPath + --db-path-override warn — failing` · `33d9fd4` · two new Gherkin scenarios + new step defs + `migration-check` unit test; all three failing on current production code
- `feat(cli): #65 fix + --db-path-override rename + warn-on-use — minimal green` · `afb80df` · 13 test files migrated mechanically; all green
- `refactor(infra): extract findDuplicateIndices helper (#56)` · `35cf37b` · 4 call sites replaced + 5 helper-semantic tests
- `chore(retro): story-maint-11 retrospective` · `bfa76f6`
- `refactor(cli): extract resolveDbPathForCommand helper from migrate+ingest actions` · `43fa770` (Phase 4)

### Deviations from plan

- **`busy_timeout` probe test was green-on-landing.** The installed `better-sqlite3` already returns `5000` as the driver default, so the slice 4 test was already green before slice 5 set the pragma. The pragma is still set explicitly (self-documenting intent; doesn't rely on driver default). Called out in slice 4 commit body per CLAUDE.md § 6.4.
- **`symlink-dbpath-refuse.test.ts` now requires `writeStubYaml`.** After the flag rename, the test pivots to `--db-path-override`, which requires config load to succeed first. A `writeStubYaml` call was added; the test still exercises `validateDbPath` as before.
- **`findDuplicateIndices` kept co-located in `config-schema.ts`.** Plan said "Sonnet decides based on diff size." The helper is 13 LOC with no cross-module consumers; a separate file would be over-abstraction.
- **Unit tests for `findDuplicateIndices` test via schema, not directly.** The helper is private to the module; tests verify the 5 semantics cases by constructing schema inputs that exercise each path.
- **Phase 4 refactor used a discriminated error type** (Option a from the brief). Smallest diff while preserving the exit-code distinction.

### Gherkin coverage checklist

- ✓ `dbPath in accounting.yaml is honoured (closes #65)` → `tests/features/steps/ingest.steps.ts` (subprocess via `spawnCli`)
- ✓ `--db-path-override warns and overrides YAML dbPath` → `tests/features/steps/ingest.steps.ts` (subprocess via `spawnCli`)
- ✓ All four pre-existing Story 2.x scenarios from maint-10's BDD backfill remain green.

### Files touched

24 files. Production: `src/core/shared/result.ts`, `src/core/ingest/transaction-builder.ts`, `src/core/ingest/idempotency-service.ts`, `src/infra/db/sqlite-client.ts`, `src/infra/db/migration-check.ts`, `src/cli/program.ts`, `src/cli/commands/ingest-command.ts`, `src/infra/config/config-schema.ts`. Tests: result.test.ts (new), sqlite-client.test.ts (new), migration-check.test.ts (new + integration update), config-schema.test.ts, ingest-command.test.ts, ingest-command-flags.test.ts, ingest-commit.test.ts, ingest-end-to-end-wiring.test.ts, uninit-db-hint.test.ts, symlink-dbpath-refuse.test.ts, ingest-throughput.test.ts. Features: ingest.feature, ingest.steps.ts, commit.steps.ts. Docs: docs/plans/story-maint-11.md, docs/retrospectives/story-maint-11.md.

## 9. Retrospective

Full retro at [docs/retrospectives/story-maint-11.md](docs/retrospectives/story-maint-11.md).

**Keep:**
- **Bundling scope-independent small items in one PR works well** — four deliverables landed as clean per-commit slices, each independently revertable.
- **The "grep contract before deletion" pattern** (slice 3 for `Result.combine`, slice 7 for `getDb`) was surfaced explicitly in commit bodies. Reviewer can confirm removals were safe without re-running the search.
- **Slice 7 as a single large commit** (the plan's "adapter-story coarser slices" analogy) was the right call. TypeScript compile forced production + all mock-surface changes to land together.

**Change:**
- **`uninit-db-hint` test fixture filename change.** Updating to YAML-authoritative dbPath also required the fixture CSV filename to match the YAML's `filenamePrefix: "bpce-valid_"` (the original used `bpce-valid.csv`, the updated uses `bpce-valid_real.csv`). If this test breaks in future, the likely cause is a mismatch between the YAML filenamePrefix and the fixture CSV filename.

**Try:**
- **`gh issue close` in the post-merge checklist.** `Closes #65 / Closes #56` in commit bodies works, but a manual close-on-merge step keeps the issue board tidy without depending on GitHub's auto-close timing.
- **`Result.combine` migration note in JSDoc.** If a future Epic 3 consumer wants the discard-array shape, document `Result.all(...).map(() => undefined)` as the replacement at the class level.

### Phase 4 retro-check outcomes

P1 (Functional) — pass. Both Gherkin scenarios exist; subprocess-tier; `fails if` clauses honest. Mock-diversity check (Story 2.4 retro action A) inherited from maint-10's `--json` non-default fixture coverage.

P2 (QA) — pass. No accounting-correctness changes. No PII in dbPath (just a file path). Migration hint update is strictly less leaky (no embedded path in the suggestion line; dbPath still in error context above).

P3 (Engineering / Architecture / Security) — one finding adopted. The `program.ts` duplication was extracted (commit `43fa770`). No other P3 issues in scope.

## 10. Merge checklist

- [x] `lint` / `build` / `test` green locally — 292 tests pass; CI will reconfirm.
- [x] PR out of draft (user gate).
- [x] Retrospective file committed at `docs/retrospectives/story-maint-11.md`.
- [x] All suggestion-log items resolved (no blank Resolution cells; Phase 4 added one row).
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation; one P3 adopted via refactor commit).
- [x] User approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)