### PR TITLE
chore(infra): ignore .claude/worktrees/ (closes #51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ data/*.db
 .vscode/
 .idea/
 .claude/settings.local.json
+.claude/worktrees/
 
 # Testing
 coverage/


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to `.gitignore` — silences the `??` noise from agent-spawned worktrees
- `.claude/settings.local.json` was already ignored; this completes the conservative fix proposed in #51

## Test plan
- [ ] `git status` shows clean working tree (no `?? .claude/worktrees/` lines)
- [ ] `git ls-files .claude/` still tracks `agents/` and `settings.json` (intentionally committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)