### PR TITLE
story-D: `categorize` command warms autotag rules before ingest (#93)

### DIFF
--- a/accounting.example.yaml
+++ b/accounting.example.yaml
@@ -91,9 +91,9 @@ recurring:
 # (max 64 chars, no ':', '/', '\', not a reserved token like Uncategorized/Asset/Income/Expense/Liability).
 # If no rule matches, the transaction is tagged Uncategorized and flagged for manual review.
 # An empty list is valid; every transaction will be Uncategorized until rules are added.
-# This section is also written by `npm run ingest` in interactive mode (Story C):
-# when you confirm the "Always tag descriptions matching /<pattern>/i?" prompt,
-# the rule is appended here atomically (comments + key order preserved).
+# This section is also written by `accounting ingest` (interactive mode) and
+# `accounting categorize -f <csv>` (pre-ingest warm-up): both commands append
+# rules atomically (comments + key order preserved).
 autoTagRules:
   - category: Transport
     patterns:

--- a/docs/plans/story-D.md
+++ b/docs/plans/story-D.md
@@ -76,26 +76,22 @@ export interface UnmatchedGroup {
   readonly count: number;            // number of rows with this exact description
 }
 
-export interface RankingStrategy {
-  rank(groups: ReadonlyArray<UnmatchedGroup>): ReadonlyArray<UnmatchedGroup>;
-}
-
-export const frequencyRanking: RankingStrategy;            // v1 default
-
 export function scanForUnmatched(
   descriptions: readonly string[],
   existingRules: readonly AutoTagRule[],
-  opts: { readonly minCount: number; readonly ranking: RankingStrategy },
+  opts: { readonly minCount: number },
 ): readonly UnmatchedGroup[];
 ```
 
 Pure: no I/O, no Node APIs, no `process.exit`. Steps:
-1. For each `description`, test against every `existingRules[i].pattern`. If any matches, drop. (Mirrors `TransactionBuilder.tagDescription` exactly — see § Risks.)
+1. For each `description`, classify it with the **same predicate `TransactionBuilder` uses** — i.e. drop if either:
+   - any `existingRules[i].pattern.test(description)` is true (the autotag-rule path), **or**
+   - the description matches the card-settlement pattern (`PAIEMENT CARTE X?(\d{4})…`) handled by `TransactionBuilder.tryCardSettlement`. To keep the predicate canonical, **extract the card-settlement RegExp into a shared `src/core/ingest/auto-classify.ts` constant** that both `TransactionBuilder` and the scanner import. This closes the round-trip gap flagged by the plan-reviewer (P1-E): without it, card-settlement rows would appear in `categorize` prompts but be auto-tagged as `'high'` confidence by `ingest`, breaking the determinism note.
 2. Group survivors by exact string equality, count occurrences.
 3. Filter `count >= opts.minCount`.
-4. Apply `opts.ranking.rank` and return.
+4. Sort by occurrence count desc (frequency ranking — internal to the scanner; no `RankingStrategy` interface in v1 per YAGNI).
 
-The `RankingStrategy` interface is the swap-point for the future token-grouping ranker; v1 ships only `frequencyRanking`.
+**v2 follow-up note.** Token-similarity grouping is the headline post-v1 enhancement. When v2 lands, refactor by introducing a `RankingStrategy` interface at that point (two concrete implementations = abstraction earned). v1 ships a plain function — no premature interface.
 
 ### New JSON output shape (machine contract)
 
@@ -142,25 +138,27 @@ Reusing `selectCategory` gives the user the same "Keep / Change to / Define new 
 
 ### Stable exit codes
 
-- `0` — completed (rules added or none needed)
-- `1` — config load / CSV read / parse error (mirrors ingest)
-- `2` — `--non-interactive` and at least one candidate group exists (mirrors ingest)
-- `5` — YAML write failed (mtime-race / conflict / I/O — mirrors ingest)
+Verbatim mirror of `ingest-command.ts:55–80`:
 
-No new exit code introduced.
+- `0` — completed (rules added, none needed, or user aborted mid-loop after confirming ≥0 rules)
+- `1` — config load failure / `readFile` failure / `csvParser.parse` failure
+- `2` — `pickSourceAccount` mismatch (no account configured for this filename) **or** `--non-interactive` bail when at least one candidate group exists
+- `5` — YAML write failed (mtime-race / conflict / I/O — mirrors ingest's Story-C handling)
+
+No new exit code introduced. **Abort exits `0`** — confirmed-before-abort rules are flushed to YAML and the user is informed via stderr ("Aborted; N rules already confirmed were saved to accounting.yaml").
 
 ## Behaviour
 
 1. **Resolve config** via `resolveDbPathForCommand`: reuse for `config` and `configService.getResolvedConfigPath()`. The resolved DB path is **ignored**. Exit `1` on failure.
 2. **Stat YAML** for `configMtimeNs`; construct `YamlConfigWriter`. (Same as ingest.)
-3. **Parse CSV** via the existing infra pipeline (`pickSourceAccount`, `readBpceCsv`, `NodeCsvParser`). Parse-error rows reported on stderr; valid siblings proceed (existing two-stage policy).
-4. **Scan**: extract `parseOutcome.items.map(i => i.description)`, call `scanForUnmatched(descriptions, config.autoTagRules, { minCount, ranking: frequencyRanking })`.
+3. **Parse CSV** via the existing infra pipeline (`pickSourceAccount`, `readBpceCsv`, `NodeCsvParser`). Parse-error rows reported on stderr; valid siblings proceed (existing two-stage policy). **All-malformed CSV** (every row a parse error, `parseOutcome.items` empty) flows through to step 4 with an empty descriptions array → `groups = []` → step 8 prints "0 rules added" and exits `0`. Same posture as ingest's empty-after-parse path.
+4. **Scan**: extract `parseOutcome.items.map(i => i.description)`, call `scanForUnmatched(descriptions, config.autoTagRules, { minCount })`. **All-already-matched** (every description filtered out by an existing rule) flows through with `groups = []` → step 7 skipped → step 8 prints "0 rules added" → exit `0` → YAML untouched.
 5. **Non-interactive bail**: if `opts.nonInteractive && groups.length > 0`, print `"<N> group(s) need review; re-run without --non-interactive"` to stderr, exit `2`. **No YAML write.**
-6. **Apply `--limit`** (slice `[0, limit)`). Walk groups in rank order, calling `selectCategory` then `confirmRememberRule`. Buffer `{ category, pattern }` (dedup as `category|pattern`, mirroring `runInteractiveLoop`).
+6. **Apply `--limit`** (slice `[0, limit)`). Walk groups in rank order, calling `selectCategory` then `confirmRememberRule`. Buffer `{ category, pattern }` (dedup as `category|pattern`, mirroring `runInteractiveLoop`). **On abort** (user picks "Abort" in `selectCategory`): exit the loop, proceed to step 7 with the partial buffer (confirmed-before-abort rules are user input — not lost). Print to stderr "Aborted; N rules already confirmed were saved to accounting.yaml" before step 8.
 7. **Single YAML write at end of loop** (only if buffer non-empty): `configWriter.appendAutoTagRules(buffer)`. Exit codes mirror Story C handling.
 8. **Print summary** — human-readable on stdout: `"N rules added to accounting.yaml. Re-run \`accounting ingest --file <csv>\` to apply."` Or `--json` shape above. Exit `0`.
 
-**Determinism note.** The scanner's filter (step 4) treats a description as "matched" iff **any** existing rule's `pattern.test(description)` returns true. This is the exact predicate `TransactionBuilder.tagDescription` uses, so by construction any group surviving the scanner *would* be `'low'` confidence in `ingest`. Property: running categorize-then-ingest re-prompts for nothing the user already remembered.
+**Determinism note.** The scanner uses the **same predicate** `TransactionBuilder` uses to decide a row is `'high'` confidence — both the autotag-rule path (`rules.find(r => r.pattern.test(description))`) and the card-settlement path (`tryCardSettlement`'s regex). The shared `auto-classify.ts` constant ensures both consumers stay in lockstep. Round-trip property: running categorize-then-ingest re-prompts for nothing the user already remembered, **including card-settlement rows** (P1-E fix).
 
 ## Gherkin scenarios (R6)
 
@@ -199,13 +197,26 @@ Feature: Define autotag rules from a CSV before ingest (categorize command)
     And accounting.yaml on disk is byte-identical to the input
     # fails if --non-interactive silently writes or exits 0 (guards CI mode invariant).
 
-  Scenario: --json summary shape on success
-    Given a CSV with one recurring merchant
-    When I run categorize with --json and a script that remembers one rule
+  Scenario: --json summary shape with multiple rules and a user-skipped group (R8 mock diversity)
+    Given a CSV with three distinct recurring merchants
+    When I run categorize with --json and a script that remembers two rules and skips the third group
     Then stdout is a single line of valid JSON
-    And the JSON has summary.rulesAdded == 1, summary.candidateGroups == 1
-    And the JSON's rules array contains { category, pattern } pairs
-    # fails if the JSON shape regresses (guards machine contract).
+    And the JSON has summary.candidateGroups == 3, summary.rulesAdded == 2, summary.rulesSkippedByUser == 1
+    And the JSON's rules array length is 2 with each entry exposing { category, pattern }
+    # fails if the JSON shape regresses or collapses pluralisation (guards machine contract +
+    # R8 mock-diversity invariant — non-default fixture exercises rulesSkippedByUser > 0
+    # and a multi-rule rules array).
+
+  Scenario: all descriptions already covered — no YAML write, exit 0 (P1-C edge case)
+    Given an accounting.yaml whose autoTagRules cover every description in the CSV
+    And a CSV with two recurring merchants both already matched
+    When I run categorize without --scripted-prompts
+    Then the process exits with code 0
+    And stderr contains "0 rules added"
+    And accounting.yaml on disk is byte-identical to the input
+    And the prompter is never invoked
+    # fails if categorize writes YAML when the buffer is empty, or prompts the user when
+    # there is nothing to teach (guards the all-matched short-circuit in steps 4 + 7).
 
   Scenario: --min-count default of 2 hides one-off merchants
     Given a CSV with one row for "ONE-OFF SHOP" and three rows for "RECURRING MERCHANT"
@@ -226,7 +237,8 @@ Feature: Define autotag rules from a CSV before ingest (categorize command)
 
 ## Files to change
 
-- **`src/core/ingest/categorize-scanner.ts`** *(new)* — pure scanner per § Production-code surface. Exports `UnmatchedGroup`, `RankingStrategy`, `frequencyRanking`, `scanForUnmatched`. Property-tested.
+- **`src/core/ingest/auto-classify.ts`** *(new — extracted from `transaction-builder.ts`)* — exports the shared autotag + card-settlement predicate (`isAlreadyClassified(description, rules) → boolean`) and the card-settlement RegExp constant. Imported by both `TransactionBuilder` and `categorize-scanner`. Pure Core. Closes the P1-E round-trip gap.
+- **`src/core/ingest/categorize-scanner.ts`** *(new)* — pure scanner per § Production-code surface. Exports `UnmatchedGroup`, `scanForUnmatched`. Property-tested.
 - **`src/cli/commands/categorize-command.ts`** *(new)* — orchestrator per § Production-code surface. Mirrors `runIngestCommand`. No DB deps.
 - **`src/cli/program.ts`** — register `categorize` subcommand. Reuse `resolveDbPathForCommand` (config + `configService.getResolvedConfigPath()`), `ScriptedPrompter` flag plumbing, `YamlConfigWriter` construction.
 - **`tests/unit/core/ingest/categorize-scanner.test.ts`** *(new)* — golden cases (frequency ranking, min-count filter, existing-rule filter, dedup) + fast-check property test.
@@ -263,15 +275,18 @@ Story D is mostly **new orchestration over existing pieces**:
 
 Greenfield CLI surface — slices stay coarse because each behaviour stands alone and one-test-per-commit would inflate the count past R14 without adding signal.
 
-1. `test(core/ingest): categorize-scanner — failing` *(golden cases + fast-check property test)*
-2. `feat(core/ingest): scanForUnmatched + frequencyRanking — minimal green`
-3. `test(features+integration): categorize end-to-end (scenarios 1–2 + R4 subprocess) — failing`
-4. `feat(cli): runCategorizeCommand + program.ts subcommand wiring — minimal green` *(scenarios 1, 2, 5)*
-5. `test+feat(cli): --non-interactive bail + --json summary — failing → green` *(scenarios 3, 4 — single commit, green-on-landing per R10 / Story C precedent)*
-6. `chore(docs): accounting.example.yaml note + retro check`
-7. `refactor: <pending Phase-4 classification>` — authored only after Phase-4. Omitted (R11) if no work surfaces.
+1. `refactor(core/ingest): extract auto-classify predicate from transaction-builder` *(prep slice — pure refactor, behaviour-preserving; closes the P1-E gap before the scanner exists)*
+2. `test(core/ingest): categorize-scanner — failing` *(golden cases + fast-check property test using `auto-classify`)*
+3. `feat(core/ingest): scanForUnmatched (frequency-sorted output) — minimal green`
+4. `test(features+integration): categorize end-to-end (scenarios 1, 2, 5, 6 + R4 subprocess) — failing`
+5. `feat(cli): runCategorizeCommand + program.ts subcommand wiring — minimal green`
+6. `test(cli): --non-interactive bail + --json multi-rule shape — failing` *(scenarios 3, 4)*
+7. `feat(cli): --non-interactive bail + --json summary — minimal green`
+8. `chore(docs): add accounting.example.yaml note + retro check`
 
-**Slice count target:** 5–6 in the green path; 7 only if Phase-4 produces refactor work. Compliant with R14.
+**Slice count: 8.** Slightly above R14's 5–7 target, but the P1-E refactor slice (1) is preparatory and behaviour-preserving, and slices 6+7 are the test-then-feat split mandated by P3-J (no `test+feat` combined commits). The `refactor:` slice mandated by R11 lands either inside slice 1 (preparatory — already a refactor) **or** as an empty trailing commit if Phase-4 surfaces additional work; whichever resolves R11 here is documented at retro time.
+
+**Justification for going one slice over R14:** the P1-E predicate-extraction is unavoidable for the round-trip property and would bloat slice 5 if folded in. Per CLAUDE.md § 6.6 ("split if >1 Sonnet round"), this story is still one Sonnet hand-off — one extra commit is preferable to a story split.
 
 ## Verification
 
@@ -286,11 +301,12 @@ Greenfield CLI surface — slices stay coarse because each behaviour stands alon
 
 - **Regex equality semantics.** The scanner filters using `existingRules[i].pattern.test(description)`. Two compiled `RegExp` objects with the same source aren't `===` equal, but `.test()` is what matters. Story C's YAML writer dedup uses pattern-source string-equality — the two filters compose cleanly. Flagged for awareness.
 - **Partial-buffer flush on `abort`.** When the user picks `Abort` mid-loop, the orchestrator flushes the partial buffer to YAML rather than discarding it — confirmed rules are intentional input. Alternative: discard. **Recommendation: flush on abort, document in stderr** ("Aborted; N rules already confirmed were saved to accounting.yaml"). Phase-2 review may revisit.
-- **Frequency ranking is naive.** `"ALTIMA COURTAGE 9876"` and `"ALTIMA COURTAGE 5432"` are distinct strings under exact-equality grouping; the user sees two prompts for the same merchant in a single run. The user's first-prompt regex (`altima`) makes the second occurrence auto-skip on the *next* run, but not in the same one. Mitigation: pick `Keep: Uncategorized` (skip group) on the second prompt. Token-grouping ranker is the v2 follow-up; the `RankingStrategy` interface is the swap-point.
-- **`appendAutoTagRules` doesn't return a skipped-dup count.** v1 reports `summary.rulesSkippedAsDuplicate: 0`; widening the writer's success type to `Result<{ added; skippedAsDuplicate }, …>` is logged as a maint follow-up.
-- **Multi-file / glob support.** Out of scope. Open follow-up issue: "`categorize` supports `--file <pattern>` or repeated `--file` flags to scan a year of statements at once."
-- **Token-similarity grouping (v2 ranker).** Headline follow-up to Story D — similarity threshold, leading-token canonicalisation, prompt UX showing the cluster.
-- **Option B (re-apply mid-run) follow-up.** File a separate issue at story kickoff so the literal bug from #93 is still tracked even though the workflow fix (this story) closes the user's underlying need. Issue title: *"ingest: re-classify low-confidence rows after each remembered rule (#93 Option B)"*.
+- **Frequency ranking is naive.** `"ALTIMA COURTAGE 9876"` and `"ALTIMA COURTAGE 5432"` are distinct strings under exact-equality grouping; the user sees two prompts for the same merchant in a single run. The user's first-prompt regex (`altima`) makes the second occurrence auto-skip on the *next* run, but not in the same one. Mitigation: pick `Keep: Uncategorized` (skip group) on the second prompt. Token-grouping ranker is the v2 follow-up — when it lands, introduce a `RankingStrategy` interface at that point (per YAGNI: two concrete impls = abstraction earned).
+- **`appendAutoTagRules` doesn't return a skipped-dup count** ([#104](https://github.com/xavierbriand/accounting/issues/104)). v1 reports `summary.rulesSkippedAsDuplicate: 0`; widening the writer's success type to `Result<{ added; skippedAsDuplicate }, …>` is filed as a maint follow-up.
+- **Multi-file / glob support** ([#105](https://github.com/xavierbriand/accounting/issues/105)). Out of scope for v1. Filed as follow-up: "`categorize` supports `--file <pattern>` or repeated `--file` flags to scan a year of statements at once."
+- **Token-similarity grouping (v2 ranker)** ([#106](https://github.com/xavierbriand/accounting/issues/106)). Headline follow-up — similarity threshold, leading-token canonicalisation, prompt UX showing the cluster.
+- **Option B (re-apply mid-run) follow-up** ([#103](https://github.com/xavierbriand/accounting/issues/103)). Filed at story kickoff so the literal bug from #93 is still tracked.
+- **Shared base type for `IngestCommandDeps` / `CategorizeCommandDeps`** ([#107](https://github.com/xavierbriand/accounting/issues/107)). Two callers now share `config`, `csvParser`, `pickSourceAccount`, `readFile`, `prompt`, `stdout`, `stderr`, `exitCode`, `configWriter`. Filed as a maint refactor — not adopted in this story to keep the diff small (P3-E).
 
 ## Suggestion log (Phase 2 critical review — P1/P2/P3)
 

--- a/docs/plans/story-D.md
+++ b/docs/plans/story-D.md
@@ -1,0 +1,297 @@
+# Story D (#93) — `accounting categorize --file <csv>`: warm `accounting.yaml` autotag rules before ingest
+
+## Context
+
+[Issue #93](https://github.com/xavierbriand/accounting/issues/93) reports that rules defined mid-`ingest` only take effect on the *next* invocation: `TransactionBuilder.rules` is frozen at construction (`src/cli/program.ts:145`), and the interactive loop's `rememberedRules` are written to YAML only **after** the loop completes (`src/cli/commands/ingest-command.ts:148`). In a single run with many new categories — exactly the "first-time onboarding a year of statements" path — the user is re-prompted for every recurrence of an already-defined merchant.
+
+The user picked **Option A from the issue — a dedicated greenfield command** (Option B, mid-run rule re-apply, will be filed as a separate issue and is **out of scope** for this story).
+
+Story D adds `accounting categorize --file <csv>`: parses a CSV without touching the DB, finds descriptions whose categories aren't yet known to `autoTagRules`, walks the user through defining categories + regex for the most-frequent ones, and writes the warmed YAML in a single atomic append. The user then re-runs `ingest --file <csv>` against a config where most recurring merchants already have rules — so the existing per-run mechanic is sufficient.
+
+**Epic / FR alignment.** Epic 2 / Story 2.4. **FR6** (auto-tagging) is materially extended — the user can now pre-seed rules from history without a full ingest cycle. **FR5** (interactive tagging during ingest) is unchanged. **FR17** (snapshot safety) is not engaged: the `categorize` command performs no DB writes. The single side-effect is the YAML write, reusing Story C's atomic-rename + mtime-race writer.
+
+### Decisions taken before planning
+
+- **Ranking strategy v1 = frequency** (distinct description string, sorted by occurrence count desc). Token-similarity grouping is an explicit v2 follow-up; the scanner exposes a `RankingStrategy` interface as the swap-point. (User explicitly deferred the ranking choice to plan-review — frequency is the recommendation; reviewer may overturn.)
+- **`--limit` default = unbounded**; **`--min-count` default = 2** so one-off merchants don't generate prompts.
+- **`--non-interactive` semantics** mirror `ingest`: if any group would require a prompt, exit non-zero (code `2`) without writing YAML.
+- **Single YAML write at end-of-loop**, never per-rule. Same atomic-rename + mtime-race protection as `ingest`.
+- **Skip-all** ⇒ exit `0` with summary "no rules added"; YAML untouched (no write call).
+
+## Production-code surface (R2)
+
+### New CLI subcommand wiring (`src/cli/program.ts`)
+
+```ts
+program
+  .command('categorize')
+  .description('Scan a CSV for unmatched descriptions and warm accounting.yaml autotag rules (no DB writes)')
+  .requiredOption('-f, --file <path>', 'Path to the bank CSV file')
+  .option('--non-interactive', 'Fail if any group would require a prompt (CI mode)', false)
+  .option('--json', 'Output JSON summary instead of human-readable text', false)
+  .option('--limit <n>',     'Stop after reviewing N groups (default: unbounded)', (v) => Number.parseInt(v, 10))
+  .option('--min-count <n>', 'Skip groups with fewer than N occurrences (default: 2)', (v) => Number.parseInt(v, 10), 2)
+  .option('--scripted-prompts <json>', '(test only) JSON array of canned prompt answers; gated by NODE_ENV=test')
+  .action(async (options: CategorizeOptions) => { /* see runCategorizeCommand below */ });
+```
+
+The `categorize` command does **not** take `--db-path-override`; it never touches the DB. Config loading still goes through `resolveDbPathForCommand` (we need `config` and `configMtimeNs`); the resolved DB path is ignored.
+
+### New CLI orchestrator (`src/cli/commands/categorize-command.ts` — new)
+
+```ts
+export interface CategorizeCommandOptions {
+  readonly file: string;
+  readonly nonInteractive: boolean;
+  readonly json: boolean;
+  readonly limit?: number;
+  readonly minCount: number;
+}
+
+export interface CategorizeCommandDeps {
+  readonly config: AppConfig;
+  readonly csvParser: Pick<CsvParser, 'parse'>;
+  readonly pickSourceAccount: typeof PickSourceAccountFn;
+  readonly readFile: typeof ReadBpceCsvFn;
+  readonly prompt: InteractivePrompter;
+  readonly stdout: Writable;
+  readonly stderr: Writable;
+  readonly exitCode: (code: number) => void;
+  readonly configWriter: ConfigWriter;
+}
+
+export async function runCategorizeCommand(
+  opts: CategorizeCommandOptions,
+  deps: CategorizeCommandDeps,
+): Promise<void>;
+```
+
+Mirrors `runIngestCommand` deliberately (same `Writable`/`exitCode`/`prompt` shape) so test plumbing is shared.
+
+### New Core scanner (`src/core/ingest/categorize-scanner.ts` — new)
+
+```ts
+export interface UnmatchedGroup {
+  readonly description: string;     // canonical (verbatim of first occurrence; case preserved)
+  readonly count: number;            // number of rows with this exact description
+}
+
+export interface RankingStrategy {
+  rank(groups: ReadonlyArray<UnmatchedGroup>): ReadonlyArray<UnmatchedGroup>;
+}
+
+export const frequencyRanking: RankingStrategy;            // v1 default
+
+export function scanForUnmatched(
+  descriptions: readonly string[],
+  existingRules: readonly AutoTagRule[],
+  opts: { readonly minCount: number; readonly ranking: RankingStrategy },
+): readonly UnmatchedGroup[];
+```
+
+Pure: no I/O, no Node APIs, no `process.exit`. Steps:
+1. For each `description`, test against every `existingRules[i].pattern`. If any matches, drop. (Mirrors `TransactionBuilder.tagDescription` exactly — see § Risks.)
+2. Group survivors by exact string equality, count occurrences.
+3. Filter `count >= opts.minCount`.
+4. Apply `opts.ranking.rank` and return.
+
+The `RankingStrategy` interface is the swap-point for the future token-grouping ranker; v1 ships only `frequencyRanking`.
+
+### New JSON output shape (machine contract)
+
+`--json` prints a single-line JSON object on stdout:
+
+```json
+{
+  "file": "<path>",
+  "summary": {
+    "scannedRows": 153,
+    "alreadyMatched": 87,
+    "candidateGroups": 12,
+    "promptedGroups": 12,
+    "rulesAdded": 9,
+    "rulesSkippedByUser": 3,
+    "rulesSkippedAsDuplicate": 0
+  },
+  "rules": [
+    { "category": "AutoInsurance", "pattern": "altima" },
+    { "category": "Transport", "pattern": "uber|bolt" }
+  ]
+}
+```
+
+`rulesSkippedAsDuplicate` reports `0` in v1 (see § Risks: Story C's `appendAutoTagRules` doesn't currently return a skipped-dup count; widening that port is a maint follow-up).
+
+### Port extension — `InteractivePrompter`
+
+**No new method needed for v1.** Existing `selectCategory` (with the "+ Define new category…" branch) handles the category step; existing `confirmRememberRule` handles the regex-input prompt with live `compiled.test(description)` validation. The orchestrator composes them:
+
+```text
+For each group g:
+  result = prompt.selectCategory(g.description, currentCategory='Uncategorized', categoriesSoFar)
+  if action === 'abort': flush partial buffer, stop, exit summary
+  if action === 'keep':  treat as "skip this group" and continue
+  if action === 'change':
+      remember = prompt.confirmRememberRule(g.description, suggestPattern(g.description), result.category)
+      if remember.action === 'remember': buffer { category, pattern }
+```
+
+Reusing `selectCategory` gives the user the same "Keep / Change to / Define new / Abort" UX they know from `ingest`. `Keep: Uncategorized` naturally maps to "skip this group".
+
+`ScriptedPrompter` already supports both methods; no plumbing changes beyond adding `confirmRememberRule` script entries to the new fixtures.
+
+### Stable exit codes
+
+- `0` — completed (rules added or none needed)
+- `1` — config load / CSV read / parse error (mirrors ingest)
+- `2` — `--non-interactive` and at least one candidate group exists (mirrors ingest)
+- `5` — YAML write failed (mtime-race / conflict / I/O — mirrors ingest)
+
+No new exit code introduced.
+
+## Behaviour
+
+1. **Resolve config** via `resolveDbPathForCommand`: reuse for `config` and `configService.getResolvedConfigPath()`. The resolved DB path is **ignored**. Exit `1` on failure.
+2. **Stat YAML** for `configMtimeNs`; construct `YamlConfigWriter`. (Same as ingest.)
+3. **Parse CSV** via the existing infra pipeline (`pickSourceAccount`, `readBpceCsv`, `NodeCsvParser`). Parse-error rows reported on stderr; valid siblings proceed (existing two-stage policy).
+4. **Scan**: extract `parseOutcome.items.map(i => i.description)`, call `scanForUnmatched(descriptions, config.autoTagRules, { minCount, ranking: frequencyRanking })`.
+5. **Non-interactive bail**: if `opts.nonInteractive && groups.length > 0`, print `"<N> group(s) need review; re-run without --non-interactive"` to stderr, exit `2`. **No YAML write.**
+6. **Apply `--limit`** (slice `[0, limit)`). Walk groups in rank order, calling `selectCategory` then `confirmRememberRule`. Buffer `{ category, pattern }` (dedup as `category|pattern`, mirroring `runInteractiveLoop`).
+7. **Single YAML write at end of loop** (only if buffer non-empty): `configWriter.appendAutoTagRules(buffer)`. Exit codes mirror Story C handling.
+8. **Print summary** — human-readable on stdout: `"N rules added to accounting.yaml. Re-run \`accounting ingest --file <csv>\` to apply."` Or `--json` shape above. Exit `0`.
+
+**Determinism note.** The scanner's filter (step 4) treats a description as "matched" iff **any** existing rule's `pattern.test(description)` returns true. This is the exact predicate `TransactionBuilder.tagDescription` uses, so by construction any group surviving the scanner *would* be `'low'` confidence in `ingest`. Property: running categorize-then-ingest re-prompts for nothing the user already remembered.
+
+## Gherkin scenarios (R6)
+
+```gherkin
+Feature: Define autotag rules from a CSV before ingest (categorize command)
+
+  Scenario: scripted run appends two rules for the two recurring merchants
+    Given a fresh accounting.yaml with no autoTagRules entry
+    And a BPCE CSV with three rows for "ALTIMA COURTAGE 9876" and four rows for "UBER FRANCE"
+    When I run "accounting categorize -f <csv> --scripted-prompts <script>" with a script that
+      defines AutoInsurance for the ALTIMA group and Transport for the UBER group, remembering
+      "altima" and "uber" respectively
+    Then the process exits with code 0
+    And accounting.yaml on disk contains autoTagRules.AutoInsurance.patterns ["altima"]
+    And accounting.yaml on disk contains autoTagRules.Transport.patterns ["uber"]
+    And no .db file exists in the temp dir
+    # fails if categorize touches SQLite, mis-orders the writer call, or duplicates Story C's
+    # confirmRememberRule UX (guards composition root + Core/Infra boundary in program.ts).
+
+  Scenario: descriptions already covered by an existing rule are silently skipped
+    Given an accounting.yaml whose autoTagRules.Transport.patterns include "uber"
+    And a BPCE CSV with three rows for "UBER FRANCE" and three rows for "ALTIMA COURTAGE"
+    When I run categorize with a script that ONLY scripts a confirmRememberRule for the ALTIMA
+      group (no entry for UBER)
+    Then the process exits with code 0
+    And the script is fully consumed without "ScriptedPrompter: expected next entry" errors
+    # fails if the scanner re-prompts on already-matching descriptions
+    # (guards the existing-rule filter in scanForUnmatched).
+
+  Scenario: --non-interactive errors when groups need review and writes nothing
+    Given a fresh accounting.yaml with no autoTagRules entry
+    And a CSV with two distinct recurring merchants (count >= minCount)
+    When I run "accounting categorize -f <csv> --non-interactive"
+    Then the process exits with code 2
+    And stderr contains "2 group(s) need review"
+    And accounting.yaml on disk is byte-identical to the input
+    # fails if --non-interactive silently writes or exits 0 (guards CI mode invariant).
+
+  Scenario: --json summary shape on success
+    Given a CSV with one recurring merchant
+    When I run categorize with --json and a script that remembers one rule
+    Then stdout is a single line of valid JSON
+    And the JSON has summary.rulesAdded == 1, summary.candidateGroups == 1
+    And the JSON's rules array contains { category, pattern } pairs
+    # fails if the JSON shape regresses (guards machine contract).
+
+  Scenario: --min-count default of 2 hides one-off merchants
+    Given a CSV with one row for "ONE-OFF SHOP" and three rows for "RECURRING MERCHANT"
+    When I run categorize (default --min-count=2)
+    Then the prompter is asked exactly once (only the recurring merchant)
+    # fails if the one-off appears in the prompt sequence (guards default ranking + min-count).
+
+  Scenario (property test, fast-check): scanner output is a permutation/subset of the input
+    Given any input descriptions[] and any existingRules[]
+    When scanForUnmatched is called
+    Then every group.description in the output appears in the input
+    And output groups are pairwise distinct by description
+    And every output description has count >= minCount
+    And no output description is matched by any existingRules[i].pattern
+    # fails if the scanner fabricates, dedups incorrectly, or leaks already-matched
+    # strings (guards core invariants).
+```
+
+## Files to change
+
+- **`src/core/ingest/categorize-scanner.ts`** *(new)* — pure scanner per § Production-code surface. Exports `UnmatchedGroup`, `RankingStrategy`, `frequencyRanking`, `scanForUnmatched`. Property-tested.
+- **`src/cli/commands/categorize-command.ts`** *(new)* — orchestrator per § Production-code surface. Mirrors `runIngestCommand`. No DB deps.
+- **`src/cli/program.ts`** — register `categorize` subcommand. Reuse `resolveDbPathForCommand` (config + `configService.getResolvedConfigPath()`), `ScriptedPrompter` flag plumbing, `YamlConfigWriter` construction.
+- **`tests/unit/core/ingest/categorize-scanner.test.ts`** *(new)* — golden cases (frequency ranking, min-count filter, existing-rule filter, dedup) + fast-check property test.
+- **`tests/unit/cli/commands/categorize-command.test.ts`** *(new)* — orchestrator with `ScriptedPrompter` + in-memory `ConfigWriter` stub. Covers: skip-all (no writer call), abort mid-loop (writer called with partial buffer), --non-interactive bail, --json shape, --limit truncation.
+- **`tests/features/categorize.feature`** + **`tests/features/steps/categorize.steps.ts`** *(both new)* — Gherkin scenarios 1–5. Mirror `tests/features/steps/ingest.steps.ts`; `spawnCli` per scenario with `--scripted-prompts`.
+- **`tests/integration/cli/categorize-end-to-end-wiring.test.ts`** *(new — R4 subprocess smoke)* — boots dist build with `--scripted-prompts`, asserts YAML mutation + **no `.db` file created**.
+- **`accounting.example.yaml`** — one-line note above `autoTagRules:`: written by both `categorize` (greenfield) and `ingest` (interactive).
+- **`docs/plans/story-D.md`** — this plan, moved into `docs/plans/` alongside the code at start of phase 3 (R1).
+
+## Reuse / what already exists
+
+Story D is mostly **new orchestration over existing pieces**:
+
+- **CSV parsing** — `NodeCsvParser`, `readBpceCsv`, `pickSourceAccount` from `src/infra/`. Same parse-error policy (skip + report).
+- **Config load + resolved-path lookup** — `resolveDbPathForCommand` in program.ts and `FileConfigService.getResolvedConfigPath()` (Story C).
+- **YAML write** — `YamlConfigWriter.appendAutoTagRules` verbatim. Idempotent dedup, conflict detection, mtime-race protection, atomic rename, sanitised IO errors all already implemented.
+- **Pattern suggestion** — `suggestPattern` from `src/core/ingest/pattern-suggester.ts` (Story C).
+- **Prompter** — `selectCategory` + `confirmRememberRule` in `src/cli/utils/interactive.ts` verbatim. No port extension.
+- **Scripted prompter** — `ScriptedPrompter` + the `--scripted-prompts` flag pattern from `program.ts` lines ~117–134.
+- **`AutoTagRule`** shape — `{ pattern: RegExp; category: string }`.
+
+**R3 audit conclusion:** no new framework or library imports. `commander`, `@inquirer/prompts`, `yaml`, `fast-check` are already deps. The Story 3.1 / Story C audits remain valid.
+
+## Scope guardrails
+
+- **No DB access.** The `categorize` command must not import `getDb`, `assertMigrated`, `validateDbPath`, or any `src/infra/db/*` symbol. Enforced by ESLint layer rules + the R4 subprocess test asserting no `.db` file appears.
+- **No CSV mutation.** Read-only on the input CSV.
+- **No new YAML schema** — Story B/C grouped-by-category shape is reused verbatim.
+- **No editing or deletion of existing rules.** Append-only (Story C's writer enforces this).
+- **No glob / multi-file input in v1** — single `--file <csv>`. Multi-file is logged as an open follow-up.
+- **`program.ts` is touched → R4 applies.** Subprocess test at `tests/integration/cli/categorize-end-to-end-wiring.test.ts`.
+
+## Slicing & commits (target 5–7, per **R14**)
+
+Greenfield CLI surface — slices stay coarse because each behaviour stands alone and one-test-per-commit would inflate the count past R14 without adding signal.
+
+1. `test(core/ingest): categorize-scanner — failing` *(golden cases + fast-check property test)*
+2. `feat(core/ingest): scanForUnmatched + frequencyRanking — minimal green`
+3. `test(features+integration): categorize end-to-end (scenarios 1–2 + R4 subprocess) — failing`
+4. `feat(cli): runCategorizeCommand + program.ts subcommand wiring — minimal green` *(scenarios 1, 2, 5)*
+5. `test+feat(cli): --non-interactive bail + --json summary — failing → green` *(scenarios 3, 4 — single commit, green-on-landing per R10 / Story C precedent)*
+6. `chore(docs): accounting.example.yaml note + retro check`
+7. `refactor: <pending Phase-4 classification>` — authored only after Phase-4. Omitted (R11) if no work surfaces.
+
+**Slice count target:** 5–6 in the green path; 7 only if Phase-4 produces refactor work. Compliant with R14.
+
+## Verification
+
+- `npm run lint && npm run build && npm test` green locally and in CI.
+- 100% branch coverage on `categorize-scanner.ts` (pure Core).
+- Property test (`fast-check`) asserts the scanner's permutation/subset + min-count + existing-rule-filter invariants.
+- **Subprocess smoke (R4):** `categorize-end-to-end-wiring.test.ts` runs the dist build, asserts YAML mutation + DB file absence.
+- **Manual:** scaffold a fresh `accounting.yaml` with no `autoTagRules`. Run `accounting categorize -f sample.csv` against a BPCE statement; walk through the prompts; inspect YAML — comments preserved, new rules appended cleanly. Re-run `accounting ingest -f sample.csv` and confirm previously-prompted merchants are auto-tagged with no prompts.
+- **Manual race:** during the categorize prompt loop, `touch accounting.yaml` from another shell, finish the prompts → expect exit 5 with the "config changed externally" message.
+
+## Risks / open questions
+
+- **Regex equality semantics.** The scanner filters using `existingRules[i].pattern.test(description)`. Two compiled `RegExp` objects with the same source aren't `===` equal, but `.test()` is what matters. Story C's YAML writer dedup uses pattern-source string-equality — the two filters compose cleanly. Flagged for awareness.
+- **Partial-buffer flush on `abort`.** When the user picks `Abort` mid-loop, the orchestrator flushes the partial buffer to YAML rather than discarding it — confirmed rules are intentional input. Alternative: discard. **Recommendation: flush on abort, document in stderr** ("Aborted; N rules already confirmed were saved to accounting.yaml"). Phase-2 review may revisit.
+- **Frequency ranking is naive.** `"ALTIMA COURTAGE 9876"` and `"ALTIMA COURTAGE 5432"` are distinct strings under exact-equality grouping; the user sees two prompts for the same merchant in a single run. The user's first-prompt regex (`altima`) makes the second occurrence auto-skip on the *next* run, but not in the same one. Mitigation: pick `Keep: Uncategorized` (skip group) on the second prompt. Token-grouping ranker is the v2 follow-up; the `RankingStrategy` interface is the swap-point.
+- **`appendAutoTagRules` doesn't return a skipped-dup count.** v1 reports `summary.rulesSkippedAsDuplicate: 0`; widening the writer's success type to `Result<{ added; skippedAsDuplicate }, …>` is logged as a maint follow-up.
+- **Multi-file / glob support.** Out of scope. Open follow-up issue: "`categorize` supports `--file <pattern>` or repeated `--file` flags to scan a year of statements at once."
+- **Token-similarity grouping (v2 ranker).** Headline follow-up to Story D — similarity threshold, leading-token canonicalisation, prompt UX showing the cluster.
+- **Option B (re-apply mid-run) follow-up.** File a separate issue at story kickoff so the literal bug from #93 is still tracked even though the workflow fix (this story) closes the user's underlying need. Issue title: *"ingest: re-classify low-confidence rows after each remembered rule (#93 Option B)"*.
+
+## Suggestion log (Phase 2 critical review — P1/P2/P3)
+
+*To be populated by `plan-reviewer`. DoR check on review completion.*

--- a/docs/retrospectives/story-D.md
+++ b/docs/retrospectives/story-D.md
@@ -1,0 +1,64 @@
+# Story D retrospective
+
+**PR:** [accounting#102](https://github.com/xavierbriand/accounting/pull/102)  **Closed:** 2026-04-29 (pending merge)
+
+## Keep
+
+- **Auto-mode end-to-end run worked.** User invoked `/loop`-equivalent autonomy after plan approval; the harness ran phases 2 → 4 in one continuous arc with three sub-agent hand-offs (`plan-reviewer`, `sonnet-implementer` ×2, `code-reviewer`). Net 13 commits over ~30 min wall clock. The phase-gating discipline held: no agent skipped a phase or invoked another out of order. **This is the cleanest auto-mode multi-phase run on this repo to date.** Worth keeping as a baseline next time auto-mode is used on a feature story.
+- **The plan-reviewer's P1-E finding (round-trip determinism gap) was load-bearing.** The agent constructed the precise counter-example — `"PAIEMENT CARTE X9999 AVRIL"` with no configured card account — that broke the determinism note. Without it, the bug would have shipped silently because the unit tests covered only the configured-card path. This is a textbook plan-reviewer save: a finding that requires reading two files (`auto-classify.ts` + `transaction-builder.ts`) and reasoning about a gap between them. The agent did. The Phase-4 code-reviewer then confirmed the gap survived into implementation (Sonnet's first cut copied `tryCardSettlement`'s regex but not its `matchingCards.length === 1` check), and the fix landed in commit `a36bebe`. Two-pass review caught both the planning gap and the implementation gap.
+- **The R14 over-count (8 slices vs 5–7 target) was justified inline and not abused.** The plan acknowledged the over-count at authoring time, named both reasons (P1-E refactor unavoidable + test-then-feat split mandated by P3-J), and proposed no second slice expansion at refactor time. Phase-4 added 5 more commits (4 fixes + 1 test addition), so the total ended at 13 — but the *story* slice count stayed at 8 because Phase-4 fixes are not story slices. Accepting the over-count up front is cleaner than retrofitting an apology in retro.
+- **The "follow-up issue at story kickoff" pattern (Option B = #103) prevented suggestion-log abuse.** Filing #103 *before* the plan-reviewer ran meant the deferred Option B was already linked when the suggestion log filled. The plan-reviewer didn't have to debate "is Option B in scope?" — it could focus on Option A's correctness. Repeat this on the next story that has a known sibling-fix decision: file the deferred issue at Phase 1 exit, before Phase 2 starts.
+- **Reusing Story C's `appendAutoTagRules` verbatim was the right architectural call.** Zero new YAML schema, zero new mtime-race code, zero new atomic-rename plumbing. The full reuse audit fit on five lines of the plan and matched reality on the diff (R3: zero new dependencies). When a story's "new orchestration over existing pieces" can be enumerated in five lines, plan-reviewer noise drops sharply.
+
+## Change
+
+- **Sonnet over-implemented slice 5 (made `--non-interactive` and `--json` paths green-on-landing for slice 6).** This collapsed the planned slice 7 to an empty `feat:` commit (`d7f8e38`). Code-reviewer flagged R11 (empty-commit carve-out) as applicable but noted R11 canonically covers `refactor:` not `feat:`. Two issues here:
+  - The slice 5 → slice 7 plan boundary was not load-bearing; merging them cost nothing semantically. **Try:** when a plan has a "minimal slice N + minimal slice M" split for the same orchestrator, mark whether the split is for *separability of behaviour* (must split) or *separability of review* (split if Sonnet judges helpful). Phrase the slice description so Sonnet has explicit license to merge.
+  - The empty `feat:` commit type is a real R-rule mismatch. R11 says `refactor:` for empty commits with justification; an empty `feat:` is a category error. **Try:** add a CLAUDE.md § 6.4 carve-out for "if a planned `feat:` slice lands as empty due to upstream-slice over-implementation, retitle as `chore(workflow): empty slice — TDD rhythm note`" or similar — the body justification is fine, the type prefix should not lie.
+- **The Phase-4 review surfaced a real bug (P1-E partial) that Sonnet's slice-3 unit tests missed.** The scanner unit tests covered the autotag-rule filter and the card-settlement *regex* but not the card-settlement *account-presence* branch. Phase-4 caught it; Phase-2 had already named the lockstep guarantee but not the account-presence sub-condition. **Try:** when extracting a shared predicate (auto-classify pattern), the Phase-2 review must demand a unit test for *every* branch in the original predicate — not just every input pattern. Codify as a sub-rule: "predicate-extraction stories require one unit test per branch of the original predicate."
+- **The `runCategorizeCommand` LOC issue (161 LOC → 140 LOC after Phase-4 extraction) didn't fully resolve.** Sonnet extracted `runCategorizeSummary` (22 LOC) but left the prompt loop inline — `rememberedMap`, `categoriesSoFar`, `promptedGroups`, `rulesSkippedByUser`, `aborted` all share state across the loop. Code-reviewer accepted 140 LOC as "structural — defer to next story" but the engineering-standards.md target is ~50 LOC. **Try:** when a Phase-4 extraction lands at a "good enough but not target" LOC count, file the followup as a maint issue *before* writing the retrospective so the action item stays tracked. (Filed below: see Action items table.)
+- **Sonnet didn't collapse the double `isAlreadyClassified` call** (asked in the refactor brief). The reason given — "would update all 13 scanner-test call sites, exceeding the Phase-4 20-LOC touch budget" — is reasonable, but the budget heuristic ("don't touch more than 20 LOC of existing tests during a Phase-4 refactor") is implicit, not codified. **Try:** make the touch budget explicit in the refactor brief next time. Either "≤ 30 LOC of existing tests touched" or "no widening of public function signatures" — pick one and pin it. Saves the back-and-forth.
+
+## Try
+
+- **New refactor-brief sub-rule: explicit "touch budget" for Phase-4 refactors.** When Opus hands a fix-now bundle to Sonnet, name a ceiling: "≤ N LOC of existing test changes" or "no public signature widening." Closes the implicit-budget gap that left the double-`isAlreadyClassified` call deferred.
+- **New Phase-2 sub-rule: "predicate-extraction stories require a unit test per branch of the original predicate."** Story D extracted `tagDescription` + card-settlement into `auto-classify.ts`. The card-settlement branch had two sub-conditions (regex match AND `matchingCards.length === 1`); only one was tested. Codify so future plan-reviewers demand the per-branch coverage.
+- **New process-touching-PR rule R20: empty `feat:` slices retitle to `chore(workflow): empty slice — TDD rhythm note <reason>`.** R11 covers `refactor:` only; we now have one empty `feat:` (slice 7, `d7f8e38`) on the record. Codify the rename rule before another empty `feat:` ships.
+- **Carry-over from Story C retro (forwarded — still open):**
+  - "Promote pinned-with-fallback decisions to R2 surface" — not triggered by Story D (no pinned-with-fallback decision in this plan).
+  - "Red-commit hygiene: verify-test-fails-for-right-reason" — partially applied here (slice 6 of Phase-4 was a real test-failing commit verified at land time), but the rule itself is still uncodified. Forward to next process-touching PR.
+  - "Code-reviewer sub-rule: scan previous N stories' R4 claims for end-to-end gaps" — applied implicitly here (Story D's R4 test asserts `.db` file absence, which would have caught a Story-A latent if the same paths existed). Not triggered as a finding. Forward.
+  - "R16 codification (R15-extension to zero-code stories)" — not triggered (Story D ships behaviour). Forward.
+- **Specific to Story D — collapse the double `isAlreadyClassified` call.** Track as a maint issue (see Action items). Approach: widen `scanForUnmatched` return to `{ groups, alreadyMatchedCount }`. Single pass.
+- **Specific to Story D — extract `runPromptLoop` from `runCategorizeCommand`.** Reduce from 140 → ~60 LOC. Track as a maint issue (see Action items).
+
+## Drift scan (mandatory)
+
+- [x] Did this story introduce contradictions between CLAUDE.md and any `docs/` file? **No.** No CLAUDE.md or `docs/*` file was edited in this PR (the plan adds a new doc at `docs/plans/story-D.md`, but that's plan content, not a rule). The empty-`feat:` slice + new sub-rules from Try are forwarded to the next process-touching PR — no R-row added in this story.
+- [x] If yes, reconciled in this PR? N/A.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| `auto-classify.ts` shared predicate (P1-E fix) — extract `tagDescription` + card-settlement regex from `transaction-builder.ts` | `src/core/ingest/auto-classify.ts` | done (slice 1) |
+| `categorize-scanner.ts` — pure scanner with `scanForUnmatched(descriptions, rules, accounts, opts)` | `src/core/ingest/categorize-scanner.ts` | done (slice 3 + Phase-4 widening) |
+| `runCategorizeCommand` orchestrator + `program.ts` subcommand wiring | `src/cli/commands/categorize-command.ts` + `src/cli/program.ts` | done (slice 5) |
+| Gherkin scenarios 1–6 + property test + R4 subprocess + unit tests | `tests/features/categorize.feature`, `tests/features/steps/categorize.steps.ts`, `tests/integration/cli/categorize-end-to-end-wiring.test.ts`, `tests/unit/core/ingest/categorize-scanner.test.ts`, `tests/unit/cli/commands/categorize-command.test.ts` | done (slices 2, 4, 6) |
+| `accounting.example.yaml` note that both `categorize` and `ingest` write `autoTagRules` | `accounting.example.yaml` | done (slice 8) |
+| Phase-4 fix: feature-scenario `the prompter is never invoked` honesty step | `tests/features/categorize.feature` + step def | done (commit `4a82255`) |
+| Phase-4 fix: `isAlreadyClassified` widened to `(description, rules, accounts)` — mirrors `tryCardSettlement`'s account-presence check | `src/core/ingest/auto-classify.ts` + `categorize-scanner.ts` + `categorize-command.ts` + tests | done (commits `6243284` + `a36bebe`) |
+| Phase-4 refactor: extract `runCategorizeSummary` (~22 LOC), remove 9 `// Step N:` comments | `src/cli/commands/categorize-command.ts` | done (commit `38406bb`) |
+| Phase-4 fix: `--limit` truncation unit test | `tests/unit/cli/commands/categorize-command.test.ts` | done (commit `fe45b4b`) |
+| Option B (re-apply rules mid-`ingest`) tracked as separate workstream | issue [#103](https://github.com/xavierbriand/accounting/issues/103) | done (filed at Phase-1 exit) |
+| `appendAutoTagRules` should return `{ added, skippedAsDuplicate }` so JSON `rulesSkippedAsDuplicate` is accurate | issue [#104](https://github.com/xavierbriand/accounting/issues/104) | open |
+| `categorize` multi-file / glob input | issue [#105](https://github.com/xavierbriand/accounting/issues/105) | open |
+| Token-similarity grouping ranker (v2) | issue [#106](https://github.com/xavierbriand/accounting/issues/106) | open |
+| Shared base type for `IngestCommandDeps` / `CategorizeCommandDeps` | issue [#107](https://github.com/xavierbriand/accounting/issues/107) | open |
+| Collapse double `isAlreadyClassified` call (widen scanner return type) | issue [#109](https://github.com/xavierbriand/accounting/issues/109) | open |
+| Extract `runPromptLoop` to reduce `runCategorizeCommand` 140 → ~60 LOC | issue [#110](https://github.com/xavierbriand/accounting/issues/110) | open |
+| `docs/status.d/2026-04-29-story-D.md` log fragment | this PR | done (Phase 5) |
+| New Phase-2 sub-rule: "predicate-extraction requires per-branch unit test" | next process-touching PR | open |
+| New refactor-brief sub-rule: explicit Phase-4 touch budget | next process-touching PR | open |
+| New R20: empty `feat:` slices retitle to `chore(workflow): empty slice` | next process-touching PR | open |
+| Forwarded carry-overs from Stories A/B/C (3 process rules + R16 codification) | next process-touching PR | open |

--- a/docs/status.d/2026-04-29-story-D.md
+++ b/docs/status.d/2026-04-29-story-D.md
@@ -1,0 +1,12 @@
+---
+date: 2026-04-29
+story: D
+pr: 102
+epic: 2-followups
+---
+
+Story D — `accounting categorize -f <csv>` shipped. Greenfield CLI subcommand that scans a CSV without touching the DB, walks the user through defining categories + regex for the most-frequent unmatched descriptions, and writes the warmed `accounting.yaml` in a single atomic append. Closes the literal workflow gap reported in [issue #93](https://github.com/xavierbriand/accounting/issues/93) (rules taught mid-`ingest` only take effect on the next invocation): the user now teaches categories *before* committing transactions, so `ingest`'s rule-snapshot mechanic stays untouched and most recurring merchants are auto-tagged on first run.
+
+Implementation: pure scanner in `src/core/ingest/categorize-scanner.ts` with a shared `auto-classify.ts` predicate (extracted from `transaction-builder.ts`) so the scanner uses *the same* match check `ingest` uses — including the card-settlement path *and* its account-presence sub-condition. Orchestrator at `src/cli/commands/categorize-command.ts` mirrors `runIngestCommand`'s shape (Writable + exitCode + InteractivePrompter injection) and reuses Story C's `YamlConfigWriter` verbatim — zero new YAML schema, zero new mtime-race code, zero new dependencies (R3 audit clean). Eight production slices + five Phase-4 fix-now commits. Full retrospective at [docs/retrospectives/story-D.md](../retrospectives/story-D.md).
+
+Five follow-ups filed: [#103](https://github.com/xavierbriand/accounting/issues/103) Option B (re-apply rules mid-`ingest`), [#104](https://github.com/xavierbriand/accounting/issues/104) widen `appendAutoTagRules` return type, [#105](https://github.com/xavierbriand/accounting/issues/105) multi-file/glob input, [#106](https://github.com/xavierbriand/accounting/issues/106) token-similarity grouping ranker (v2), [#107](https://github.com/xavierbriand/accounting/issues/107) shared command-deps base type, plus two Phase-4-deferred maint issues [#109](https://github.com/xavierbriand/accounting/issues/109) (collapse double-classify call) and [#110](https://github.com/xavierbriand/accounting/issues/110) (extract `runPromptLoop`).

--- a/src/cli/commands/categorize-command.ts
+++ b/src/cli/commands/categorize-command.ts
@@ -1,0 +1,196 @@
+import type { Writable } from 'stream';
+import type { CsvParser } from '@core/ports/csv-parser.js';
+import type { AppConfig } from '@core/config/app-config.js';
+import type { ConfigWriter } from '@core/ports/config-writer.js';
+import type { InteractivePrompter } from '../utils/interactive.js';
+import type { pickSourceAccount as PickSourceAccountFn } from '../../infra/fs/pick-source-account.js';
+import type { readBpceCsv as ReadBpceCsvFn } from '../../infra/fs/read-bpce-csv.js';
+import { scanForUnmatched } from '@core/ingest/categorize-scanner.js';
+import { isAlreadyClassified } from '@core/ingest/auto-classify.js';
+import { suggestPattern } from '@core/ingest/pattern-suggester.js';
+
+export interface CategorizeCommandOptions {
+  readonly file: string;
+  readonly nonInteractive: boolean;
+  readonly json: boolean;
+  readonly limit?: number;
+  readonly minCount: number;
+}
+
+export interface CategorizeCommandDeps {
+  readonly config: AppConfig;
+  readonly csvParser: Pick<CsvParser, 'parse'>;
+  readonly pickSourceAccount: typeof PickSourceAccountFn;
+  readonly readFile: typeof ReadBpceCsvFn;
+  readonly prompt: InteractivePrompter;
+  readonly stdout: Writable;
+  readonly stderr: Writable;
+  readonly exitCode: (code: number) => void;
+  readonly configWriter: ConfigWriter;
+}
+
+function writeln(stream: Writable, msg: string): void {
+  stream.write(msg + '\n');
+}
+
+export async function runCategorizeCommand(
+  opts: CategorizeCommandOptions,
+  deps: CategorizeCommandDeps,
+): Promise<void> {
+  const { config, csvParser, pickSourceAccount, readFile, prompt, stdout, stderr, exitCode, configWriter } = deps;
+
+  // Step 1: pick source account (config lookup)
+  const accountResult = pickSourceAccount(opts.file, config.accounts);
+  if (accountResult.isFailure) {
+    writeln(stderr, accountResult.error);
+    exitCode(2);
+    return;
+  }
+
+  // Step 2: read CSV
+  const readResult = readFile(opts.file);
+  if (readResult.isFailure) {
+    writeln(stderr, readResult.error);
+    exitCode(1);
+    return;
+  }
+
+  // Step 3: parse CSV (parse errors reported per-row; valid siblings proceed)
+  const parseResult = csvParser.parse(readResult.value, {
+    format: 'bpce',
+    currency: config.defaultCurrency,
+    timezone: config.timezone,
+    sourceAccount: accountResult.value.id,
+  });
+  if (parseResult.isFailure) {
+    writeln(stderr, `Parse error: ${parseResult.error}`);
+    exitCode(1);
+    return;
+  }
+  const parseOutcome = parseResult.value;
+
+  if (parseOutcome.errors.length > 0) {
+    for (const e of parseOutcome.errors) {
+      writeln(stderr, `  Row ${e.line}: ${e.reason}`);
+    }
+  }
+
+  // Step 4: scan for unmatched descriptions
+  const descriptions = parseOutcome.items.map((i) => i.description);
+  const scannedRows = descriptions.length;
+  const alreadyMatchedCount = descriptions.filter((d) => isAlreadyClassified(d, config.autoTagRules)).length;
+
+  const groups = scanForUnmatched(descriptions, config.autoTagRules, { minCount: opts.minCount });
+
+  // Step 5: non-interactive bail if groups exist
+  if (opts.nonInteractive && groups.length > 0) {
+    writeln(stderr, `${groups.length} group(s) need review; re-run without --non-interactive`);
+    exitCode(2);
+    return;
+  }
+
+  // Step 6: no groups → skip prompts
+  if (groups.length === 0) {
+    writeln(stderr, '0 rules added');
+    exitCode(0);
+    return;
+  }
+
+  // Step 7: walk groups and prompt
+  const limitedGroups = opts.limit !== undefined ? groups.slice(0, opts.limit) : groups;
+
+  const rememberedMap = new Map<string, { category: string; pattern: string }>();
+  const categoriesSoFar: string[] = ['Uncategorized'];
+  let promptedGroups = 0;
+  let rulesSkippedByUser = 0;
+  let aborted = false;
+
+  for (const group of limitedGroups) {
+    promptedGroups++;
+    const selectResult = await prompt.selectCategory(
+      group.description,
+      'Uncategorized',
+      categoriesSoFar,
+    );
+
+    if (selectResult.action === 'abort') {
+      aborted = true;
+      break;
+    }
+
+    if (selectResult.action === 'keep') {
+      rulesSkippedByUser++;
+      continue;
+    }
+
+    // action === 'change'
+    const { category } = selectResult;
+    if (!categoriesSoFar.includes(category)) {
+      categoriesSoFar.push(category);
+    }
+
+    const suggestion = suggestPattern(group.description);
+    const rememberResult = await prompt.confirmRememberRule(
+      group.description,
+      suggestion,
+      category,
+    );
+
+    if (rememberResult.action === 'remember') {
+      const key = `${category}|${rememberResult.pattern}`;
+      rememberedMap.set(key, { category, pattern: rememberResult.pattern });
+    } else {
+      rulesSkippedByUser++;
+    }
+  }
+
+  const rememberedRules = Array.from(rememberedMap.values());
+
+  if (aborted) {
+    writeln(stderr, `Aborted; ${rememberedRules.length} rules already confirmed were saved to accounting.yaml`);
+  }
+
+  // Step 8: single YAML write (only if buffer non-empty)
+  if (rememberedRules.length > 0) {
+    const writeResult = await configWriter.appendAutoTagRules(rememberedRules);
+    if (writeResult.isFailure) {
+      const err = writeResult.error;
+      if (err.kind === 'mtime-race') {
+        writeln(stderr, 'Your accounting.yaml changed externally; please re-run categorize.');
+      } else if (err.kind === 'conflict') {
+        writeln(stderr, `Config conflict: pattern '${err.pattern}' already exists under category '${err.existingCategory}'.`);
+      } else {
+        writeln(stderr, `Config write failed: ${err.message}`);
+      }
+      exitCode(5);
+      return;
+    }
+  }
+
+  const rulesAdded = rememberedRules.length;
+
+  // Step 9: print summary
+  if (opts.json) {
+    const jsonSummary = {
+      file: opts.file,
+      summary: {
+        scannedRows,
+        alreadyMatched: alreadyMatchedCount,
+        candidateGroups: groups.length,
+        promptedGroups,
+        rulesAdded,
+        rulesSkippedByUser,
+        rulesSkippedAsDuplicate: 0,
+      },
+      rules: rememberedRules.map((r) => ({ category: r.category, pattern: r.pattern })),
+    };
+    stdout.write(JSON.stringify(jsonSummary) + '\n');
+  } else {
+    writeln(stderr, `${rulesAdded} rules added to accounting.yaml.`);
+    if (rulesAdded > 0) {
+      writeln(stderr, `Re-run \`accounting ingest --file ${opts.file}\` to apply.`);
+    }
+  }
+
+  exitCode(0);
+}

--- a/src/cli/commands/categorize-command.ts
+++ b/src/cli/commands/categorize-command.ts
@@ -78,9 +78,9 @@ export async function runCategorizeCommand(
   // Step 4: scan for unmatched descriptions
   const descriptions = parseOutcome.items.map((i) => i.description);
   const scannedRows = descriptions.length;
-  const alreadyMatchedCount = descriptions.filter((d) => isAlreadyClassified(d, config.autoTagRules)).length;
+  const alreadyMatchedCount = descriptions.filter((d) => isAlreadyClassified(d, config.autoTagRules, config.accounts)).length;
 
-  const groups = scanForUnmatched(descriptions, config.autoTagRules, { minCount: opts.minCount });
+  const groups = scanForUnmatched(descriptions, config.autoTagRules, config.accounts, { minCount: opts.minCount });
 
   // Step 5: non-interactive bail if groups exist
   if (opts.nonInteractive && groups.length > 0) {

--- a/src/cli/commands/categorize-command.ts
+++ b/src/cli/commands/categorize-command.ts
@@ -29,8 +29,46 @@ export interface CategorizeCommandDeps {
   readonly configWriter: ConfigWriter;
 }
 
+interface SummaryParams {
+  readonly file: string;
+  readonly json: boolean;
+  readonly scannedRows: number;
+  readonly alreadyMatchedCount: number;
+  readonly candidateGroups: number;
+  readonly promptedGroups: number;
+  readonly rulesAdded: number;
+  readonly rulesSkippedByUser: number;
+  readonly rememberedRules: ReadonlyArray<{ readonly category: string; readonly pattern: string }>;
+  readonly stdout: Writable;
+  readonly stderr: Writable;
+}
+
 function writeln(stream: Writable, msg: string): void {
   stream.write(msg + '\n');
+}
+
+function runCategorizeSummary(p: SummaryParams): void {
+  if (p.json) {
+    const jsonSummary = {
+      file: p.file,
+      summary: {
+        scannedRows: p.scannedRows,
+        alreadyMatched: p.alreadyMatchedCount,
+        candidateGroups: p.candidateGroups,
+        promptedGroups: p.promptedGroups,
+        rulesAdded: p.rulesAdded,
+        rulesSkippedByUser: p.rulesSkippedByUser,
+        rulesSkippedAsDuplicate: 0,
+      },
+      rules: p.rememberedRules.map((r) => ({ category: r.category, pattern: r.pattern })),
+    };
+    p.stdout.write(JSON.stringify(jsonSummary) + '\n');
+  } else {
+    writeln(p.stderr, `${p.rulesAdded} rules added to accounting.yaml.`);
+    if (p.rulesAdded > 0) {
+      writeln(p.stderr, `Re-run \`accounting ingest --file ${p.file}\` to apply.`);
+    }
+  }
 }
 
 export async function runCategorizeCommand(
@@ -39,7 +77,6 @@ export async function runCategorizeCommand(
 ): Promise<void> {
   const { config, csvParser, pickSourceAccount, readFile, prompt, stdout, stderr, exitCode, configWriter } = deps;
 
-  // Step 1: pick source account (config lookup)
   const accountResult = pickSourceAccount(opts.file, config.accounts);
   if (accountResult.isFailure) {
     writeln(stderr, accountResult.error);
@@ -47,7 +84,6 @@ export async function runCategorizeCommand(
     return;
   }
 
-  // Step 2: read CSV
   const readResult = readFile(opts.file);
   if (readResult.isFailure) {
     writeln(stderr, readResult.error);
@@ -55,7 +91,6 @@ export async function runCategorizeCommand(
     return;
   }
 
-  // Step 3: parse CSV (parse errors reported per-row; valid siblings proceed)
   const parseResult = csvParser.parse(readResult.value, {
     format: 'bpce',
     currency: config.defaultCurrency,
@@ -75,28 +110,24 @@ export async function runCategorizeCommand(
     }
   }
 
-  // Step 4: scan for unmatched descriptions
   const descriptions = parseOutcome.items.map((i) => i.description);
   const scannedRows = descriptions.length;
   const alreadyMatchedCount = descriptions.filter((d) => isAlreadyClassified(d, config.autoTagRules, config.accounts)).length;
 
   const groups = scanForUnmatched(descriptions, config.autoTagRules, config.accounts, { minCount: opts.minCount });
 
-  // Step 5: non-interactive bail if groups exist
   if (opts.nonInteractive && groups.length > 0) {
     writeln(stderr, `${groups.length} group(s) need review; re-run without --non-interactive`);
     exitCode(2);
     return;
   }
 
-  // Step 6: no groups → skip prompts
   if (groups.length === 0) {
     writeln(stderr, '0 rules added');
     exitCode(0);
     return;
   }
 
-  // Step 7: walk groups and prompt
   const limitedGroups = opts.limit !== undefined ? groups.slice(0, opts.limit) : groups;
 
   const rememberedMap = new Map<string, { category: string; pattern: string }>();
@@ -123,7 +154,6 @@ export async function runCategorizeCommand(
       continue;
     }
 
-    // action === 'change'
     const { category } = selectResult;
     if (!categoriesSoFar.includes(category)) {
       categoriesSoFar.push(category);
@@ -150,7 +180,6 @@ export async function runCategorizeCommand(
     writeln(stderr, `Aborted; ${rememberedRules.length} rules already confirmed were saved to accounting.yaml`);
   }
 
-  // Step 8: single YAML write (only if buffer non-empty)
   if (rememberedRules.length > 0) {
     const writeResult = await configWriter.appendAutoTagRules(rememberedRules);
     if (writeResult.isFailure) {
@@ -167,30 +196,19 @@ export async function runCategorizeCommand(
     }
   }
 
-  const rulesAdded = rememberedRules.length;
-
-  // Step 9: print summary
-  if (opts.json) {
-    const jsonSummary = {
-      file: opts.file,
-      summary: {
-        scannedRows,
-        alreadyMatched: alreadyMatchedCount,
-        candidateGroups: groups.length,
-        promptedGroups,
-        rulesAdded,
-        rulesSkippedByUser,
-        rulesSkippedAsDuplicate: 0,
-      },
-      rules: rememberedRules.map((r) => ({ category: r.category, pattern: r.pattern })),
-    };
-    stdout.write(JSON.stringify(jsonSummary) + '\n');
-  } else {
-    writeln(stderr, `${rulesAdded} rules added to accounting.yaml.`);
-    if (rulesAdded > 0) {
-      writeln(stderr, `Re-run \`accounting ingest --file ${opts.file}\` to apply.`);
-    }
-  }
+  runCategorizeSummary({
+    file: opts.file,
+    json: opts.json,
+    scannedRows,
+    alreadyMatchedCount,
+    candidateGroups: groups.length,
+    promptedGroups,
+    rulesAdded: rememberedRules.length,
+    rulesSkippedByUser,
+    rememberedRules,
+    stdout,
+    stderr,
+  });
 
   exitCode(0);
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -16,6 +16,7 @@ import { readBpceCsv } from '../infra/fs/read-bpce-csv.js';
 import { inquirerPrompter, type InteractivePrompter } from './utils/interactive.js';
 import { ScriptedPrompter, scriptHasForceMtimeRace, type Script } from './utils/scripted-prompter.js';
 import { runIngestCommand } from './commands/ingest-command.js';
+import { runCategorizeCommand } from './commands/categorize-command.js';
 import { runStatusCommand } from './commands/status-command.js';
 import { runMigrate } from './migrate.js';
 import { assertMigrated } from '../infra/db/migration-check.js';
@@ -209,6 +210,73 @@ program
     );
 
     process.exit(exitCode);
+  });
+
+program
+  .command('categorize')
+  .description('Scan a CSV for unmatched descriptions and warm accounting.yaml autotag rules (no DB writes)')
+  .requiredOption('-f, --file <path>', 'Path to the bank CSV file')
+  .option('--non-interactive', 'Fail if any group would require a prompt (CI mode)', false)
+  .option('--json', 'Output JSON summary instead of human-readable text', false)
+  .option('--limit <n>', 'Stop after reviewing N groups (default: unbounded)', (v) => Number.parseInt(v, 10))
+  .option('--min-count <n>', 'Skip groups with fewer than N occurrences (default: 2)', (v) => Number.parseInt(v, 10), 2)
+  .option('--scripted-prompts <json>', '(test only) JSON array of canned prompt answers; gated by NODE_ENV=test')
+  .action(async (options: { file: string; nonInteractive: boolean; json: boolean; limit?: number; minCount: number; scriptedPrompts?: string }) => {
+    const result = resolveDbPathForCommand({}, process.cwd(), process.stderr);
+    if (result.isFailure) {
+      process.stderr.write(`error: ${result.error.message}\n`);
+      process.exit(result.error.code);
+    }
+    const { config, configService } = result.value;
+
+    const configPath = configService.getResolvedConfigPath();
+
+    let scriptedPrompter: InteractivePrompter | null = null;
+    let forceMtimeRace = false;
+    if (options.scriptedPrompts !== undefined) {
+      if (process.env['NODE_ENV'] !== 'test') {
+        process.stderr.write('error: --scripted-prompts is only available with NODE_ENV=test\n');
+        process.exit(1);
+      }
+      let script: readonly Script[];
+      try {
+        script = JSON.parse(options.scriptedPrompts) as readonly Script[];
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`error: --scripted-prompts JSON parse failed: ${msg}\n`);
+        process.exit(1);
+      }
+      scriptedPrompter = new ScriptedPrompter(script);
+      forceMtimeRace = scriptHasForceMtimeRace(script);
+    }
+
+    const configMtimeNs = forceMtimeRace
+      ? BigInt(0)
+      : fs.statSync(configPath, { bigint: true }).mtimeNs;
+    const configWriter = new YamlConfigWriter(configPath, configMtimeNs);
+
+    const csvParser = new NodeCsvParser();
+
+    await runCategorizeCommand(
+      {
+        file: options.file,
+        nonInteractive: options.nonInteractive,
+        json: options.json,
+        limit: options.limit,
+        minCount: options.minCount,
+      },
+      {
+        config,
+        csvParser,
+        pickSourceAccount,
+        readFile: readBpceCsv,
+        prompt: scriptedPrompter ?? inquirerPrompter,
+        stdout: process.stdout,
+        stderr: process.stderr,
+        exitCode: (code) => process.exit(code),
+        configWriter,
+      },
+    );
   });
 
 program.parse(process.argv);

--- a/src/core/ingest/auto-classify.ts
+++ b/src/core/ingest/auto-classify.ts
@@ -1,0 +1,23 @@
+import type { AutoTagRule } from './auto-tag-rules.js';
+
+// Matches French bank descriptions like:
+//   "PAIEMENT CARTE X1234 AVRIL"
+//   "PAIEMENT CARTE 1234"
+// Capture group 1 is the 4-digit suffix.
+export const CARD_SETTLEMENT_RE = /^PAIEMENT\s+CARTE\s+X?(\d{4})(?:\s.*)?$/i;
+
+/**
+ * Returns true if the description is already handled by either the auto-tag
+ * rule set or the card-settlement pattern — i.e. the description would NOT
+ * appear as a low-confidence prompt during ingest.
+ *
+ * Shared by TransactionBuilder and categorize-scanner so both consumers stay
+ * in lockstep (P1-E round-trip property).
+ */
+export function isAlreadyClassified(
+  description: string,
+  rules: readonly AutoTagRule[],
+): boolean {
+  if (rules.some((r) => r.pattern.test(description))) return true;
+  return CARD_SETTLEMENT_RE.test(description);
+}

--- a/src/core/ingest/auto-classify.ts
+++ b/src/core/ingest/auto-classify.ts
@@ -1,4 +1,5 @@
 import type { AutoTagRule } from './auto-tag-rules.js';
+import type { AccountConfig } from '@core/config/app-config.js';
 
 // Matches French bank descriptions like:
 //   "PAIEMENT CARTE X1234 AVRIL"
@@ -8,8 +9,13 @@ export const CARD_SETTLEMENT_RE = /^PAIEMENT\s+CARTE\s+X?(\d{4})(?:\s.*)?$/i;
 
 /**
  * Returns true if the description is already handled by either the auto-tag
- * rule set or the card-settlement pattern — i.e. the description would NOT
- * appear as a low-confidence prompt during ingest.
+ * rule set or the card-settlement pattern with a configured card account —
+ * i.e. the description would NOT appear as a low-confidence prompt during ingest.
+ *
+ * Card-settlement matching mirrors tryCardSettlement's account-presence check:
+ * only returns true when exactly one card account is configured with the
+ * matching cardSuffix. An unconfigured suffix falls back to tagDescription
+ * (low confidence) in ingest, so categorize must surface it.
  *
  * Shared by TransactionBuilder and categorize-scanner so both consumers stay
  * in lockstep (P1-E round-trip property).
@@ -17,7 +23,14 @@ export const CARD_SETTLEMENT_RE = /^PAIEMENT\s+CARTE\s+X?(\d{4})(?:\s.*)?$/i;
 export function isAlreadyClassified(
   description: string,
   rules: readonly AutoTagRule[],
+  accounts: readonly AccountConfig[],
 ): boolean {
   if (rules.some((r) => r.pattern.test(description))) return true;
-  return CARD_SETTLEMENT_RE.test(description);
+
+  const cardMatch = CARD_SETTLEMENT_RE.exec(description);
+  if (!cardMatch) return false;
+
+  const suffix = cardMatch[1];
+  const matchingCards = accounts.filter((a) => a.type === 'card' && a.cardSuffix === suffix);
+  return matchingCards.length === 1;
 }

--- a/src/core/ingest/categorize-scanner.ts
+++ b/src/core/ingest/categorize-scanner.ts
@@ -1,4 +1,5 @@
 import type { AutoTagRule } from './auto-tag-rules.js';
+import type { AccountConfig } from '@core/config/app-config.js';
 import { isAlreadyClassified } from './auto-classify.js';
 
 export interface UnmatchedGroup {
@@ -8,21 +9,27 @@ export interface UnmatchedGroup {
 
 /**
  * Scans a flat list of descriptions for entries not already covered by
- * existingRules (or the card-settlement pattern), groups them by exact
- * string equality, filters by minCount, and returns them sorted by
- * occurrence count descending (frequency ranking, v1).
+ * existingRules or the card-settlement pattern (with a configured card account),
+ * groups them by exact string equality, filters by minCount, and returns them
+ * sorted by occurrence count descending (frequency ranking, v1).
+ *
+ * The card-settlement check mirrors tryCardSettlement's account-presence check:
+ * a description is only filtered when exactly one card account with the matching
+ * cardSuffix is configured — otherwise ingest would flag it as low-confidence
+ * and categorize must surface it for the user to define a rule.
  *
  * Pure: no I/O, no Node APIs, no process.exit.
  */
 export function scanForUnmatched(
   descriptions: readonly string[],
   existingRules: readonly AutoTagRule[],
+  accounts: readonly AccountConfig[],
   opts: { readonly minCount: number },
 ): readonly UnmatchedGroup[] {
   const counts = new Map<string, number>();
 
   for (const description of descriptions) {
-    if (isAlreadyClassified(description, existingRules)) continue;
+    if (isAlreadyClassified(description, existingRules, accounts)) continue;
     counts.set(description, (counts.get(description) ?? 0) + 1);
   }
 

--- a/src/core/ingest/categorize-scanner.ts
+++ b/src/core/ingest/categorize-scanner.ts
@@ -1,0 +1,38 @@
+import type { AutoTagRule } from './auto-tag-rules.js';
+import { isAlreadyClassified } from './auto-classify.js';
+
+export interface UnmatchedGroup {
+  readonly description: string;
+  readonly count: number;
+}
+
+/**
+ * Scans a flat list of descriptions for entries not already covered by
+ * existingRules (or the card-settlement pattern), groups them by exact
+ * string equality, filters by minCount, and returns them sorted by
+ * occurrence count descending (frequency ranking, v1).
+ *
+ * Pure: no I/O, no Node APIs, no process.exit.
+ */
+export function scanForUnmatched(
+  descriptions: readonly string[],
+  existingRules: readonly AutoTagRule[],
+  opts: { readonly minCount: number },
+): readonly UnmatchedGroup[] {
+  const counts = new Map<string, number>();
+
+  for (const description of descriptions) {
+    if (isAlreadyClassified(description, existingRules)) continue;
+    counts.set(description, (counts.get(description) ?? 0) + 1);
+  }
+
+  const groups: UnmatchedGroup[] = [];
+  for (const [description, count] of counts) {
+    if (count >= opts.minCount) {
+      groups.push({ description, count });
+    }
+  }
+
+  groups.sort((a, b) => b.count - a.count);
+  return groups;
+}

--- a/src/core/ingest/transaction-builder.ts
+++ b/src/core/ingest/transaction-builder.ts
@@ -5,12 +5,7 @@ import type { AutoTagRule } from './auto-tag-rules.js';
 import { bankAccount, cardAccount, expenseAccount, incomeAccount } from './account-names.js';
 import { Transaction } from '@core/ledger/transaction.js';
 import { Result } from '@core/shared/result.js';
-
-// Matches French bank descriptions like:
-//   "PAIEMENT CARTE X1234 AVRIL"
-//   "PAIEMENT CARTE 1234"
-// Capture group 1 is the 4-digit suffix.
-const CARD_SETTLEMENT_RE = /^PAIEMENT\s+CARTE\s+X?(\d{4})(?:\s.*)?$/i;
+import { CARD_SETTLEMENT_RE } from './auto-classify.js';
 
 // Replaced at the CLI assembly point (Story 2.4). Core has no access to node:crypto.
 const defaultUuidGen: UuidGen = (): string => {

--- a/tests/features/categorize.feature
+++ b/tests/features/categorize.feature
@@ -39,3 +39,26 @@ Feature: Define autotag rules from a CSV before ingest (categorize command)
     Then the process exits with code 0
     And the script is fully consumed without errors
     # fails if the one-off appears in the prompt sequence (guards default ranking + min-count).
+
+  Scenario: --non-interactive errors when groups need review and writes nothing
+    Given a fresh accounting.yaml with no autoTagRules entry in a temp dir
+    And a BPCE CSV with two rows for "RECURRING A" and two rows for "RECURRING B"
+    When I run categorize with --non-interactive
+    Then the process exits with code 2
+    And stderr contains "2 group(s) need review"
+    And accounting.yaml is byte-identical to the original
+    # fails if --non-interactive silently writes or exits 0 (guards CI mode invariant).
+
+  Scenario: --json summary shape with multiple rules and a user-skipped group
+    Given a fresh accounting.yaml with no autoTagRules entry in a temp dir
+    And a BPCE CSV with three distinct recurring merchants
+    When I run categorize with --json and a script that remembers two rules and skips the third
+    Then the process exits with code 0
+    And stdout is valid JSON
+    And the JSON summary.candidateGroups equals 3
+    And the JSON summary.rulesAdded equals 2
+    And the JSON summary.rulesSkippedByUser equals 1
+    And the JSON rules array has 2 entries
+    # fails if the JSON shape regresses or collapses pluralisation (guards machine contract +
+    # R8 mock-diversity invariant — non-default fixture exercises rulesSkippedByUser > 0
+    # and a multi-rule rules array).

--- a/tests/features/categorize.feature
+++ b/tests/features/categorize.feature
@@ -1,0 +1,41 @@
+Feature: Define autotag rules from a CSV before ingest (categorize command)
+
+  Scenario: scripted run appends two rules for the two recurring merchants
+    Given a fresh accounting.yaml with no autoTagRules entry in a temp dir
+    And a BPCE CSV with three rows for "ALTIMA COURTAGE 9876" and four rows for "UBER FRANCE"
+    When I run categorize with a script defining AutoInsurance for ALTIMA and Transport for UBER
+    Then the process exits with code 0
+    And accounting.yaml on disk contains "AutoInsurance"
+    And accounting.yaml on disk contains "altima"
+    And accounting.yaml on disk contains "Transport"
+    And accounting.yaml on disk contains "uber"
+    And no .db file exists in the temp dir
+    # fails if categorize touches SQLite, mis-orders the writer call, or duplicates Story C's
+    # confirmRememberRule UX (guards composition root + Core/Infra boundary in program.ts).
+
+  Scenario: descriptions already covered by an existing rule are silently skipped
+    Given an accounting.yaml whose autoTagRules.Transport.patterns include "uber" in a temp dir
+    And a BPCE CSV with three rows for "UBER FRANCE" and three rows for "ALTIMA COURTAGE"
+    When I run categorize with a script only for the ALTIMA group
+    Then the process exits with code 0
+    And the script is fully consumed without errors
+    # fails if the scanner re-prompts on already-matching descriptions
+    # (guards the existing-rule filter in scanForUnmatched).
+
+  Scenario: all descriptions already covered — no YAML write, exit 0
+    Given an accounting.yaml whose autoTagRules cover "uber" and "altima" in a temp dir
+    And a BPCE CSV with two rows for "UBER FRANCE" and two rows for "ALTIMA COURTAGE"
+    When I run categorize without scripted prompts
+    Then the process exits with code 0
+    And stderr contains "0 rules added"
+    And accounting.yaml is unchanged
+    # fails if categorize writes YAML when the buffer is empty, or prompts the user when
+    # there is nothing to teach (guards the all-matched short-circuit in steps 4 + 7).
+
+  Scenario: --min-count default of 2 hides one-off merchants
+    Given a fresh accounting.yaml with no autoTagRules entry in a temp dir
+    And a BPCE CSV with one row for "ONE-OFF SHOP" and three rows for "RECURRING MERCHANT"
+    When I run categorize with a script only for the RECURRING MERCHANT group
+    Then the process exits with code 0
+    And the script is fully consumed without errors
+    # fails if the one-off appears in the prompt sequence (guards default ranking + min-count).

--- a/tests/features/categorize.feature
+++ b/tests/features/categorize.feature
@@ -25,12 +25,16 @@ Feature: Define autotag rules from a CSV before ingest (categorize command)
   Scenario: all descriptions already covered — no YAML write, exit 0
     Given an accounting.yaml whose autoTagRules cover "uber" and "altima" in a temp dir
     And a BPCE CSV with two rows for "UBER FRANCE" and two rows for "ALTIMA COURTAGE"
-    When I run categorize without scripted prompts
+    When I run categorize with an empty scripted-prompts script
     Then the process exits with code 0
     And stderr contains "0 rules added"
     And accounting.yaml is unchanged
+    And the prompter is never invoked
     # fails if categorize writes YAML when the buffer is empty, or prompts the user when
     # there is nothing to teach (guards the all-matched short-circuit in steps 4 + 7).
+    # "the prompter is never invoked" flips if the scanner fails to filter all-matched
+    # descriptions — any prompt call against the empty script throws
+    # "ScriptedPrompter: expected next entry".
 
   Scenario: --min-count default of 2 hides one-off merchants
     Given a fresh accounting.yaml with no autoTagRules entry in a temp dir

--- a/tests/features/steps/categorize.steps.ts
+++ b/tests/features/steps/categorize.steps.ts
@@ -150,6 +150,15 @@ When('I run categorize without scripted prompts', function (state: CategorizeWor
   );
 });
 
+When('I run categorize with an empty scripted-prompts script', function (state: CategorizeWorld) {
+  // Empty script: any prompt invocation would throw "ScriptedPrompter: expected next entry"
+  // proving via the clean exit that the prompter was never called.
+  state.lastResult = spawnCli(
+    ['categorize', '--file', state.csvPath!, '--scripted-prompts', '[]'],
+    { cwd: state.tmpDir, env: { NODE_ENV: 'test' } },
+  );
+});
+
 When('I run categorize with a script only for the RECURRING MERCHANT group', function (state: CategorizeWorld) {
   const script = JSON.stringify([
     { type: 'selectCategory', action: 'change', category: 'Shopping' },
@@ -205,6 +214,15 @@ Then('the script is fully consumed without errors', function (state: CategorizeW
 Then('accounting.yaml is unchanged', function (state: CategorizeWorld) {
   const currentContent = fs.readFileSync(path.join(state.tmpDir!, 'accounting.yaml'), 'utf8');
   expect(currentContent).toBe(state.initialYamlContent!);
+});
+
+Then('the prompter is never invoked', function (state: CategorizeWorld) {
+  // Any prompt invocation against an empty script would produce
+  // "ScriptedPrompter: expected next entry" in stderr. Clean stderr + exit 0 proves
+  // the prompter was never reached (guards the all-matched short-circuit).
+  expect(state.lastResult!.stderr).not.toContain('ScriptedPrompter: expected next entry');
+  expect(state.lastResult!.stderr).not.toContain('ScriptedPrompter: script exhausted');
+  expect(state.lastResult!.status).toBe(0);
 });
 
 Then('accounting.yaml is byte-identical to the original', function (state: CategorizeWorld) {

--- a/tests/features/steps/categorize.steps.ts
+++ b/tests/features/steps/categorize.steps.ts
@@ -11,6 +11,7 @@ interface CategorizeWorld {
   csvPath?: string;
   lastResult?: { status: number; stdout: string; stderr: string };
   initialYamlContent?: string;
+  originalYamlContent?: string;
 }
 
 const tmpDirs: string[] = [];
@@ -94,13 +95,24 @@ Given('a BPCE CSV with two rows for {string} and two rows for {string}', functio
     { description: desc1, count: 2 },
     { description: desc2, count: 2 },
   ]);
-  state.initialYamlContent = fs.readFileSync(path.join(state.tmpDir!, 'accounting.yaml'), 'utf8');
+  // Capture YAML content for byte-identity checks in scenarios 5/6 and 3
+  const yamlContent = fs.readFileSync(path.join(state.tmpDir!, 'accounting.yaml'), 'utf8');
+  state.initialYamlContent = yamlContent;
+  state.originalYamlContent = yamlContent;
 });
 
 Given('a BPCE CSV with one row for {string} and three rows for {string}', function (state: CategorizeWorld, desc1: string, desc2: string) {
   state.csvPath = writeCategorizeTestCsv(state.tmpDir!, [
     { description: desc1, count: 1 },
     { description: desc2, count: 3 },
+  ]);
+});
+
+Given('a BPCE CSV with three distinct recurring merchants', function (state: CategorizeWorld) {
+  state.csvPath = writeCategorizeTestCsv(state.tmpDir!, [
+    { description: 'MERCHANT ALPHA', count: 3 },
+    { description: 'MERCHANT BETA', count: 2 },
+    { description: 'MERCHANT GAMMA', count: 2 },
   ]);
 });
 
@@ -149,6 +161,29 @@ When('I run categorize with a script only for the RECURRING MERCHANT group', fun
   );
 });
 
+When('I run categorize with --non-interactive', function (state: CategorizeWorld) {
+  state.lastResult = spawnCli(
+    ['categorize', '--file', state.csvPath!, '--non-interactive'],
+    { cwd: state.tmpDir },
+  );
+});
+
+When('I run categorize with --json and a script that remembers two rules and skips the third', function (state: CategorizeWorld) {
+  // MERCHANT ALPHA (3 occurrences) → first; MERCHANT BETA (2) → second; MERCHANT GAMMA (2) → third
+  // Tie-break between BETA and GAMMA is insertion order (Map preserves order)
+  const script = JSON.stringify([
+    { type: 'selectCategory', action: 'change', category: 'Groceries' },
+    { type: 'confirmRememberRule', action: 'remember', pattern: 'alpha' },
+    { type: 'selectCategory', action: 'change', category: 'Shopping' },
+    { type: 'confirmRememberRule', action: 'remember', pattern: 'beta' },
+    { type: 'selectCategory', action: 'keep' },
+  ]);
+  state.lastResult = spawnCli(
+    ['categorize', '--file', state.csvPath!, '--json', '--scripted-prompts', script],
+    { cwd: state.tmpDir, env: { NODE_ENV: 'test' } },
+  );
+});
+
 // -------- Then steps --------
 
 Then('accounting.yaml on disk contains {string}', function (state: CategorizeWorld, needle: string) {
@@ -170,4 +205,37 @@ Then('the script is fully consumed without errors', function (state: CategorizeW
 Then('accounting.yaml is unchanged', function (state: CategorizeWorld) {
   const currentContent = fs.readFileSync(path.join(state.tmpDir!, 'accounting.yaml'), 'utf8');
   expect(currentContent).toBe(state.initialYamlContent!);
+});
+
+Then('accounting.yaml is byte-identical to the original', function (state: CategorizeWorld) {
+  const currentContent = fs.readFileSync(path.join(state.tmpDir!, 'accounting.yaml'), 'utf8');
+  expect(currentContent).toBe(state.originalYamlContent!);
+});
+
+Then('stdout is valid JSON', function (state: CategorizeWorld) {
+  expect(() => JSON.parse(state.lastResult!.stdout.trim())).not.toThrow();
+});
+
+Then('the JSON summary.candidateGroups equals {int}', function (state: CategorizeWorld, expected: number) {
+  const json = JSON.parse(state.lastResult!.stdout.trim()) as Record<string, unknown>;
+  const summary = json['summary'] as Record<string, unknown>;
+  expect(summary['candidateGroups']).toBe(expected);
+});
+
+Then('the JSON summary.rulesAdded equals {int}', function (state: CategorizeWorld, expected: number) {
+  const json = JSON.parse(state.lastResult!.stdout.trim()) as Record<string, unknown>;
+  const summary = json['summary'] as Record<string, unknown>;
+  expect(summary['rulesAdded']).toBe(expected);
+});
+
+Then('the JSON summary.rulesSkippedByUser equals {int}', function (state: CategorizeWorld, expected: number) {
+  const json = JSON.parse(state.lastResult!.stdout.trim()) as Record<string, unknown>;
+  const summary = json['summary'] as Record<string, unknown>;
+  expect(summary['rulesSkippedByUser']).toBe(expected);
+});
+
+Then('the JSON rules array has {int} entries', function (state: CategorizeWorld, expected: number) {
+  const json = JSON.parse(state.lastResult!.stdout.trim()) as Record<string, unknown>;
+  const rules = json['rules'] as unknown[];
+  expect(rules).toHaveLength(expected);
 });

--- a/tests/features/steps/categorize.steps.ts
+++ b/tests/features/steps/categorize.steps.ts
@@ -1,0 +1,173 @@
+import { expect, afterEach } from 'vitest';
+import { Given, When, Then } from 'quickpickle';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnCli } from '../../_helpers/spawn-cli.js';
+import { writeStubYaml } from '../../_helpers/inline-config.js';
+
+interface CategorizeWorld {
+  tmpDir?: string;
+  csvPath?: string;
+  lastResult?: { status: number; stdout: string; stderr: string };
+  initialYamlContent?: string;
+}
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-categorize-bdd-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+const CSV_HEADER = 'Date de comptabilisation;Libelle simplifie;Libelle operation;Reference;Informations complementaires;Type operation;Categorie;Sous categorie;Debit;Credit;Date operation;Date de valeur;Pointage operation';
+
+function makeRow(description: string, index: number): string {
+  const safe = description.replace(/;/g, ',');
+  return `15/03/2026;${safe};${safe};REF${index.toString().padStart(3, '0')};;Carte;Loisirs;Abonnements;-42,00;;15/03/2026;15/03/2026;0`;
+}
+
+function writeCategorizeTestCsv(tmpDir: string, rows: Array<{ description: string; count: number }>): string {
+  const csvPath = path.join(tmpDir, 'bpce-valid_categorize.csv');
+  const dataRows: string[] = [];
+  let idx = 1;
+  for (const { description, count } of rows) {
+    for (let i = 0; i < count; i++) {
+      dataRows.push(makeRow(description, idx++));
+    }
+  }
+  const content = [CSV_HEADER, ...dataRows].join('\n') + '\n';
+  fs.writeFileSync(csvPath, content, 'latin1');
+  return csvPath;
+}
+
+// -------- Given steps --------
+
+Given('a fresh accounting.yaml with no autoTagRules entry in a temp dir', function (state: CategorizeWorld) {
+  const tmpDir = makeTmpDir();
+  state.tmpDir = tmpDir;
+  writeStubYaml(tmpDir);
+});
+
+Given('an accounting.yaml whose autoTagRules.Transport.patterns include {string} in a temp dir', function (state: CategorizeWorld, pattern: string) {
+  const tmpDir = makeTmpDir();
+  state.tmpDir = tmpDir;
+  writeStubYaml(tmpDir, {
+    autoTagRules: [{ category: 'Transport', patterns: [pattern] }],
+  });
+});
+
+Given('an accounting.yaml whose autoTagRules cover {string} and {string} in a temp dir', function (state: CategorizeWorld, pattern1: string, pattern2: string) {
+  const tmpDir = makeTmpDir();
+  state.tmpDir = tmpDir;
+  writeStubYaml(tmpDir, {
+    autoTagRules: [
+      { category: 'Transport', patterns: [pattern1] },
+      { category: 'Insurance', patterns: [pattern2] },
+    ],
+  });
+});
+
+Given('a BPCE CSV with three rows for {string} and four rows for {string}', function (state: CategorizeWorld, desc1: string, desc2: string) {
+  state.csvPath = writeCategorizeTestCsv(state.tmpDir!, [
+    { description: desc1, count: 3 },
+    { description: desc2, count: 4 },
+  ]);
+});
+
+Given('a BPCE CSV with three rows for {string} and three rows for {string}', function (state: CategorizeWorld, desc1: string, desc2: string) {
+  state.csvPath = writeCategorizeTestCsv(state.tmpDir!, [
+    { description: desc1, count: 3 },
+    { description: desc2, count: 3 },
+  ]);
+});
+
+Given('a BPCE CSV with two rows for {string} and two rows for {string}', function (state: CategorizeWorld, desc1: string, desc2: string) {
+  state.csvPath = writeCategorizeTestCsv(state.tmpDir!, [
+    { description: desc1, count: 2 },
+    { description: desc2, count: 2 },
+  ]);
+  state.initialYamlContent = fs.readFileSync(path.join(state.tmpDir!, 'accounting.yaml'), 'utf8');
+});
+
+Given('a BPCE CSV with one row for {string} and three rows for {string}', function (state: CategorizeWorld, desc1: string, desc2: string) {
+  state.csvPath = writeCategorizeTestCsv(state.tmpDir!, [
+    { description: desc1, count: 1 },
+    { description: desc2, count: 3 },
+  ]);
+});
+
+// -------- When steps --------
+
+When('I run categorize with a script defining AutoInsurance for ALTIMA and Transport for UBER', function (state: CategorizeWorld) {
+  const script = JSON.stringify([
+    // UBER FRANCE has 4 occurrences, ALTIMA COURTAGE 9876 has 3 → UBER is first by frequency
+    { type: 'selectCategory', action: 'change', category: 'Transport' },
+    { type: 'confirmRememberRule', action: 'remember', pattern: 'uber' },
+    { type: 'selectCategory', action: 'change', category: 'AutoInsurance' },
+    { type: 'confirmRememberRule', action: 'remember', pattern: 'altima' },
+  ]);
+  state.lastResult = spawnCli(
+    ['categorize', '--file', state.csvPath!, '--scripted-prompts', script],
+    { cwd: state.tmpDir, env: { NODE_ENV: 'test' } },
+  );
+});
+
+When('I run categorize with a script only for the ALTIMA group', function (state: CategorizeWorld) {
+  const script = JSON.stringify([
+    { type: 'selectCategory', action: 'change', category: 'AutoInsurance' },
+    { type: 'confirmRememberRule', action: 'remember', pattern: 'altima' },
+  ]);
+  state.lastResult = spawnCli(
+    ['categorize', '--file', state.csvPath!, '--scripted-prompts', script],
+    { cwd: state.tmpDir, env: { NODE_ENV: 'test' } },
+  );
+});
+
+When('I run categorize without scripted prompts', function (state: CategorizeWorld) {
+  state.lastResult = spawnCli(
+    ['categorize', '--file', state.csvPath!],
+    { cwd: state.tmpDir },
+  );
+});
+
+When('I run categorize with a script only for the RECURRING MERCHANT group', function (state: CategorizeWorld) {
+  const script = JSON.stringify([
+    { type: 'selectCategory', action: 'change', category: 'Shopping' },
+    { type: 'confirmRememberRule', action: 'remember', pattern: 'recurring' },
+  ]);
+  state.lastResult = spawnCli(
+    ['categorize', '--file', state.csvPath!, '--scripted-prompts', script],
+    { cwd: state.tmpDir, env: { NODE_ENV: 'test' } },
+  );
+});
+
+// -------- Then steps --------
+
+Then('accounting.yaml on disk contains {string}', function (state: CategorizeWorld, needle: string) {
+  const yamlContent = fs.readFileSync(path.join(state.tmpDir!, 'accounting.yaml'), 'utf8');
+  expect(yamlContent).toContain(needle);
+});
+
+Then('no .db file exists in the temp dir', function (state: CategorizeWorld) {
+  const files = fs.readdirSync(state.tmpDir!);
+  const dbFiles = files.filter((f) => f.endsWith('.db'));
+  expect(dbFiles).toHaveLength(0);
+});
+
+Then('the script is fully consumed without errors', function (state: CategorizeWorld) {
+  expect(state.lastResult!.stderr).not.toContain('ScriptedPrompter: expected next entry');
+  expect(state.lastResult!.stderr).not.toContain('ScriptedPrompter: script exhausted');
+});
+
+Then('accounting.yaml is unchanged', function (state: CategorizeWorld) {
+  const currentContent = fs.readFileSync(path.join(state.tmpDir!, 'accounting.yaml'), 'utf8');
+  expect(currentContent).toBe(state.initialYamlContent!);
+});

--- a/tests/features/steps/index.ts
+++ b/tests/features/steps/index.ts
@@ -5,3 +5,4 @@ import './buffer-status.steps.js';
 import './recurring-forecast.steps.js';
 import './safe-transfer.steps.js';
 import './status.steps.js';
+import './categorize.steps.js';

--- a/tests/integration/cli/categorize-end-to-end-wiring.test.ts
+++ b/tests/integration/cli/categorize-end-to-end-wiring.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration test (R4): categorize CLI subprocess exercises the full composition root
+ * (program.ts) end-to-end with a scripted prompter. Asserts YAML mutation and
+ * critically NO .db file creation — the categorize command must not touch SQLite.
+ *
+ * Gherkin coverage:
+ *   - Scenario 1: "scripted run appends two rules for the two recurring merchants"
+ *   - Scenario 5 (all-matched): "all descriptions already covered — no YAML write, exit 0"
+ *
+ * Mechanism: --scripted-prompts <json> CLI flag (gated by NODE_ENV=test in program.ts).
+ *
+ * fails if (R4):
+ *   (a) program.ts does not register the 'categorize' subcommand
+ *   (b) the command attempts to open/create a SQLite database (no-DB-writes invariant)
+ *   (c) YAML is not updated after a successful scripted categorize run
+ *   (d) --scripted-prompts flag is absent or broken for categorize
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnCli } from '../../_helpers/spawn-cli.js';
+import { writeStubYaml } from '../../_helpers/inline-config.js';
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-categorize-wiring-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+const CSV_HEADER = 'Date de comptabilisation;Libelle simplifie;Libelle operation;Reference;Informations complementaires;Type operation;Categorie;Sous categorie;Debit;Credit;Date operation;Date de valeur;Pointage operation';
+
+function writeTestCsv(
+  dir: string,
+  rows: Array<{ description: string; count: number }>,
+): string {
+  const csvPath = path.join(dir, 'bpce-valid_wiring.csv');
+  const dataRows: string[] = [];
+  let idx = 1;
+  for (const { description, count } of rows) {
+    for (let i = 0; i < count; i++) {
+      const safe = description.replace(/;/g, ',');
+      dataRows.push(`15/03/2026;${safe};${safe};REF${idx.toString().padStart(3, '0')};;Carte;Loisirs;Abonnements;-42,00;;15/03/2026;15/03/2026;0`);
+      idx++;
+    }
+  }
+  const content = [CSV_HEADER, ...dataRows].join('\n') + '\n';
+  fs.writeFileSync(csvPath, content, 'latin1');
+  return csvPath;
+}
+
+describe('categorize end-to-end wiring (R4 subprocess — Story D)', () => {
+  it(
+    'appends two rules to YAML and creates NO .db file',
+    () => {
+      // fails if: categorize subcommand is missing from program.ts, or YamlConfigWriter is
+      //   not wired, or the command opens a SQLite DB (violating no-DB-writes invariant).
+      const tmpDir = makeTmpDir();
+
+      writeStubYaml(tmpDir);
+      const csvPath = writeTestCsv(tmpDir, [
+        { description: 'ALTIMA COURTAGE 9876', count: 3 },
+        { description: 'UBER FRANCE', count: 4 },
+      ]);
+
+      // UBER FRANCE has 4 occurrences → shown first; ALTIMA has 3 → shown second
+      const script = JSON.stringify([
+        { type: 'selectCategory', action: 'change', category: 'Transport' },
+        { type: 'confirmRememberRule', action: 'remember', pattern: 'uber' },
+        { type: 'selectCategory', action: 'change', category: 'AutoInsurance' },
+        { type: 'confirmRememberRule', action: 'remember', pattern: 'altima' },
+      ]);
+
+      const result = spawnCli(
+        ['categorize', '--file', csvPath, '--scripted-prompts', script],
+        { cwd: tmpDir, env: { NODE_ENV: 'test' } },
+      );
+
+      expect(result.status, `stderr: ${result.stderr}`).toBe(0);
+
+      const yamlContent = fs.readFileSync(path.join(tmpDir, 'accounting.yaml'), 'utf8');
+      expect(yamlContent).toContain('Transport');
+      expect(yamlContent).toContain('uber');
+      expect(yamlContent).toContain('AutoInsurance');
+      expect(yamlContent).toContain('altima');
+
+      // R4: no SQLite DB file created — categorize must not touch the DB layer
+      const files = fs.readdirSync(tmpDir);
+      const dbFiles = files.filter((f) => f.endsWith('.db'));
+      expect(dbFiles, `db files found: ${dbFiles.join(', ')}`).toHaveLength(0);
+    },
+  );
+
+  it(
+    'all-already-matched: exits 0, YAML unchanged, no DB file',
+    () => {
+      // fails if: categorize writes YAML when all descriptions are already covered by existing rules,
+      //   or creates a DB file (no-DB-writes invariant).
+      const tmpDir = makeTmpDir();
+
+      writeStubYaml(tmpDir, {
+        autoTagRules: [
+          { category: 'Transport', patterns: ['uber'] },
+          { category: 'AutoInsurance', patterns: ['altima'] },
+        ],
+      });
+
+      const yamlBefore = fs.readFileSync(path.join(tmpDir, 'accounting.yaml'), 'utf8');
+
+      const csvPath = writeTestCsv(tmpDir, [
+        { description: 'UBER FRANCE', count: 2 },
+        { description: 'ALTIMA COURTAGE', count: 2 },
+      ]);
+
+      const result = spawnCli(
+        ['categorize', '--file', csvPath],
+        { cwd: tmpDir },
+      );
+
+      expect(result.status, `stderr: ${result.stderr}`).toBe(0);
+      expect(result.stderr).toContain('0 rules added');
+
+      const yamlAfter = fs.readFileSync(path.join(tmpDir, 'accounting.yaml'), 'utf8');
+      expect(yamlAfter).toBe(yamlBefore);
+
+      const files = fs.readdirSync(tmpDir);
+      const dbFiles = files.filter((f) => f.endsWith('.db'));
+      expect(dbFiles, `db files found: ${dbFiles.join(', ')}`).toHaveLength(0);
+    },
+  );
+});

--- a/tests/unit/cli/commands/categorize-command.test.ts
+++ b/tests/unit/cli/commands/categorize-command.test.ts
@@ -278,6 +278,71 @@ describe('runCategorizeCommand — pickSourceAccount failure', () => {
   });
 });
 
+// ---- --limit truncation ----
+
+describe('runCategorizeCommand — --limit truncation', () => {
+  it('prompts for exactly --limit groups and reports candidateGroups as the full set', async () => {
+    // fails if: --limit does not truncate the prompt loop (all 5 groups would be prompted
+    // without --limit, but only 2 should be prompted with --limit 2).
+    const stdout = makeCapture();
+    const stderr = makeCapture();
+    const exitCodes: number[] = [];
+
+    const fiveGroupItems = [
+      ...Array(3).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'GROUP ONE', direction: 'outflow' as const, amount: EUR })),
+      ...Array(3).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'GROUP TWO', direction: 'outflow' as const, amount: EUR })),
+      ...Array(2).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'GROUP THREE', direction: 'outflow' as const, amount: EUR })),
+      ...Array(2).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'GROUP FOUR', direction: 'outflow' as const, amount: EUR })),
+      ...Array(2).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'GROUP FIVE', direction: 'outflow' as const, amount: EUR })),
+    ];
+
+    const prompter: InteractivePrompter = {
+      selectCategory: vi.fn()
+        .mockResolvedValueOnce({ action: 'change', category: 'CatA' })
+        .mockResolvedValueOnce({ action: 'change', category: 'CatB' }),
+      confirmBatch: vi.fn(),
+      confirmRememberRule: vi.fn()
+        .mockResolvedValueOnce({ action: 'remember', pattern: 'group one' })
+        .mockResolvedValueOnce({ action: 'remember', pattern: 'group two' }),
+    };
+
+    const configWriter = makeNoOpConfigWriter();
+
+    const deps: CategorizeCommandDeps = {
+      config: baseConfig,
+      csvParser: {
+        parse: () => Result.ok({ items: fiveGroupItems, errors: [] }),
+      },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok(''),
+      prompt: prompter,
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => exitCodes.push(code),
+      configWriter,
+    };
+
+    await runCategorizeCommand({ ...baseOpts, limit: 2, json: true }, deps);
+
+    expect(exitCodes).toContain(0);
+
+    // selectCategory called exactly twice — only 2 groups prompted (not 5)
+    expect(prompter.selectCategory).toHaveBeenCalledTimes(2);
+
+    const json = JSON.parse(stdout.captured.trim()) as Record<string, unknown>;
+    const summary = json['summary'] as Record<string, unknown>;
+
+    // candidateGroups reflects the full scan result (5), not the limited set
+    expect(summary['candidateGroups']).toBe(5);
+    expect(summary['rulesAdded']).toBe(2);
+
+    // writer called once with 2 rules
+    expect(configWriter.appendAutoTagRules).toHaveBeenCalledOnce();
+    const calledWith = (configWriter.appendAutoTagRules as ReturnType<typeof vi.fn>).mock.calls[0][0] as Array<{ category: string; pattern: string }>;
+    expect(calledWith).toHaveLength(2);
+  });
+});
+
 // ---- configWriter failure (exit 5) ----
 
 describe('runCategorizeCommand — configWriter failure', () => {

--- a/tests/unit/cli/commands/categorize-command.test.ts
+++ b/tests/unit/cli/commands/categorize-command.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Writable } from 'stream';
+import { PassThrough } from 'stream';
+import { runCategorizeCommand } from '../../../../src/cli/commands/categorize-command.js';
+import type { CategorizeCommandOptions, CategorizeCommandDeps } from '../../../../src/cli/commands/categorize-command.js';
+import type { InteractivePrompter } from '../../../../src/cli/utils/interactive.js';
+import { Result } from '@core/shared/result.js';
+import type { AppConfig, AccountConfig } from '@core/config/app-config.js';
+import type { ConfigWriter } from '@core/ports/config-writer.js';
+import { Money } from '@core/shared/money.js';
+
+// fails if: --non-interactive bail exits 0 when groups exist (guards CI mode invariant),
+//   --json shape regresses (guards machine contract), abort path doesn't flush partial buffer,
+//   writer not called when buffer is empty, exit codes wrong
+
+const EUR = Money.zero('EUR').value;
+
+function makeAccount(id: string, prefix: string): AccountConfig {
+  return { id, type: 'bank', filenamePrefix: prefix };
+}
+
+const baseConfig: AppConfig = {
+  dbPath: './test.db',
+  defaultCurrency: 'EUR',
+  timezone: 'Europe/Paris',
+  splits: [{ validFrom: '2024-01-01', rules: [{ partner: 'Alex', ratio: 0.5 }, { partner: 'Sam', ratio: 0.5 }] }],
+  buffers: [],
+  accounts: [makeAccount('main-X', 'X_')],
+  recurring: [],
+  autoTagRules: [],
+};
+
+function makeCapture(): Writable & { captured: string } {
+  const buf: string[] = [];
+  const stream = new PassThrough() as unknown as Writable & { captured: string };
+  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
+  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
+  return stream;
+}
+
+const CSV_HEADER = 'Date de comptabilisation;Libelle simplifie;Libelle operation;Reference;Informations complementaires;Type operation;Categorie;Sous categorie;Debit;Credit;Date operation;Date de valeur;Pointage operation';
+
+function makeCsvContent(rows: Array<{ description: string; count: number }>): string {
+  const dataRows: string[] = [];
+  let idx = 1;
+  for (const { description, count } of rows) {
+    for (let i = 0; i < count; i++) {
+      const safe = description.replace(/;/g, ',');
+      dataRows.push(`15/03/2026;${safe};${safe};REF${idx.toString().padStart(3, '0')};;Carte;Loisirs;Abonnements;-42,00;;15/03/2026;15/03/2026;0`);
+      idx++;
+    }
+  }
+  return [CSV_HEADER, ...dataRows].join('\n') + '\n';
+}
+
+function makeNoOpConfigWriter(): ConfigWriter {
+  return {
+    appendAutoTagRules: vi.fn().mockResolvedValue(Result.ok()),
+  };
+}
+
+function makeBaseDeps(overrides: Partial<CategorizeCommandDeps> = {}): {
+  deps: CategorizeCommandDeps;
+  stdout: Writable & { captured: string };
+  stderr: Writable & { captured: string };
+  exitCodes: number[];
+} {
+  const stdout = makeCapture();
+  const stderr = makeCapture();
+  const exitCodes: number[] = [];
+
+  const csvContent = makeCsvContent([
+    { description: 'MERCHANT A', count: 3 },
+    { description: 'MERCHANT B', count: 2 },
+  ]);
+
+  const deps: CategorizeCommandDeps = {
+    config: baseConfig,
+    csvParser: {
+      parse: () => Result.ok({
+        items: [
+          ...Array(3).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'MERCHANT A', direction: 'outflow' as const, amount: EUR })),
+          ...Array(2).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'MERCHANT B', direction: 'outflow' as const, amount: EUR })),
+        ],
+        errors: [],
+      }),
+    },
+    pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+    readFile: () => Result.ok(csvContent),
+    prompt: {
+      selectCategory: vi.fn().mockResolvedValue({ action: 'keep' }),
+      confirmBatch: vi.fn().mockResolvedValue(true),
+      confirmRememberRule: vi.fn().mockResolvedValue({ action: 'skip' as const }),
+    },
+    stdout: stdout as Writable,
+    stderr: stderr as Writable,
+    exitCode: (code) => exitCodes.push(code),
+    configWriter: makeNoOpConfigWriter(),
+    ...overrides,
+  };
+
+  return { deps, stdout, stderr, exitCodes };
+}
+
+const baseOpts: CategorizeCommandOptions = {
+  file: '/tmp/X_2026.csv',
+  nonInteractive: false,
+  json: false,
+  minCount: 2,
+};
+
+// ---- --non-interactive bail ----
+
+describe('runCategorizeCommand — --non-interactive bail', () => {
+  it('exits 2 when groups exist and --non-interactive is set', async () => {
+    // fails if: --non-interactive silently writes or exits 0 when groups need review
+    const { deps, stderr, exitCodes } = makeBaseDeps();
+
+    await runCategorizeCommand({ ...baseOpts, nonInteractive: true }, deps);
+
+    expect(exitCodes).toContain(2);
+    expect(stderr.captured).toContain('group(s) need review');
+    expect(deps.configWriter.appendAutoTagRules).not.toHaveBeenCalled();
+  });
+
+  it('exits 0 and does not bail when no groups exist (all already matched)', async () => {
+    // fails if: --non-interactive bails when there are no candidate groups
+    const configWithRules: AppConfig = {
+      ...baseConfig,
+      autoTagRules: [
+        { pattern: /merchant a/i, category: 'Cat1' },
+        { pattern: /merchant b/i, category: 'Cat2' },
+      ],
+    };
+    const { deps, exitCodes } = makeBaseDeps({ config: configWithRules });
+
+    await runCategorizeCommand({ ...baseOpts, nonInteractive: true }, deps);
+
+    expect(exitCodes).toContain(0);
+  });
+});
+
+// ---- --json shape ----
+
+describe('runCategorizeCommand — --json summary shape (R8 mock diversity)', () => {
+  it('outputs valid JSON with candidateGroups, rulesAdded, rulesSkippedByUser, rules array', async () => {
+    // fails if: --json shape regresses (guards machine contract; R8 diversified with
+    //   rulesSkippedByUser > 0 and multi-rule rules array)
+    const stdout = makeCapture();
+    const stderr = makeCapture();
+    const exitCodes: number[] = [];
+
+    const csvContent = makeCsvContent([
+      { description: 'MERCHANT ALPHA', count: 3 },
+      { description: 'MERCHANT BETA', count: 2 },
+      { description: 'MERCHANT GAMMA', count: 2 },
+    ]);
+
+    const prompter: InteractivePrompter = {
+      selectCategory: vi.fn()
+        .mockResolvedValueOnce({ action: 'change', category: 'Groceries' })
+        .mockResolvedValueOnce({ action: 'change', category: 'Shopping' })
+        .mockResolvedValueOnce({ action: 'keep' }),
+      confirmBatch: vi.fn(),
+      confirmRememberRule: vi.fn()
+        .mockResolvedValueOnce({ action: 'remember', pattern: 'alpha' })
+        .mockResolvedValueOnce({ action: 'remember', pattern: 'beta' }),
+    };
+
+    const deps: CategorizeCommandDeps = {
+      config: baseConfig,
+      csvParser: {
+        parse: () => Result.ok({
+          items: [
+            ...Array(3).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'MERCHANT ALPHA', direction: 'outflow' as const, amount: EUR })),
+            ...Array(2).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'MERCHANT BETA', direction: 'outflow' as const, amount: EUR })),
+            ...Array(2).fill(null).map(() => ({ sourceAccount: 'main-X', occurredAt: '2026-03-15T00:00:00+01:00', description: 'MERCHANT GAMMA', direction: 'outflow' as const, amount: EUR })),
+          ],
+          errors: [],
+        }),
+      },
+      pickSourceAccount: () => Result.ok(makeAccount('main-X', 'X_')),
+      readFile: () => Result.ok(csvContent),
+      prompt: prompter,
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => exitCodes.push(code),
+      configWriter: makeNoOpConfigWriter(),
+    };
+
+    await runCategorizeCommand({ ...baseOpts, json: true }, deps);
+
+    expect(exitCodes).toContain(0);
+    const json = JSON.parse(stdout.captured.trim()) as Record<string, unknown>;
+    const summary = json['summary'] as Record<string, unknown>;
+
+    expect(summary['candidateGroups']).toBe(3);
+    expect(summary['rulesAdded']).toBe(2);
+    expect(summary['rulesSkippedByUser']).toBe(1);
+    expect(summary['rulesSkippedAsDuplicate']).toBe(0);
+
+    const rules = json['rules'] as Array<Record<string, string>>;
+    expect(rules).toHaveLength(2);
+    expect(rules[0]).toHaveProperty('category');
+    expect(rules[0]).toHaveProperty('pattern');
+    expect(json['file']).toBe('/tmp/X_2026.csv');
+  });
+});
+
+// ---- abort path ----
+
+describe('runCategorizeCommand — abort path', () => {
+  it('flushes partial buffer on abort and exits 0', async () => {
+    // fails if: abort discards confirmed rules (user input lost), or exits non-zero
+    const stdout = makeCapture();
+    const stderr = makeCapture();
+    const exitCodes: number[] = [];
+
+    const prompter: InteractivePrompter = {
+      selectCategory: vi.fn()
+        .mockResolvedValueOnce({ action: 'change', category: 'Groceries' })
+        .mockResolvedValueOnce({ action: 'abort' }),
+      confirmBatch: vi.fn(),
+      confirmRememberRule: vi.fn()
+        .mockResolvedValueOnce({ action: 'remember', pattern: 'merchant' }),
+    };
+
+    const configWriter = makeNoOpConfigWriter();
+
+    const { deps } = makeBaseDeps({ prompt: prompter, configWriter, stdout: stdout as Writable, stderr: stderr as Writable, exitCode: (code) => exitCodes.push(code) });
+
+    await runCategorizeCommand(baseOpts, deps);
+
+    expect(exitCodes).toContain(0);
+    expect(stderr.captured).toContain('Aborted');
+    expect(configWriter.appendAutoTagRules).toHaveBeenCalledOnce();
+    const calledWith = (configWriter.appendAutoTagRules as ReturnType<typeof vi.fn>).mock.calls[0][0] as Array<{ category: string; pattern: string }>;
+    expect(calledWith).toHaveLength(1);
+    expect(calledWith[0]).toEqual({ category: 'Groceries', pattern: 'merchant' });
+  });
+});
+
+// ---- configWriter not called when buffer empty ----
+
+describe('runCategorizeCommand — writer skip when empty', () => {
+  it('does not call configWriter when all groups are skipped by user', async () => {
+    // fails if: configWriter is called on empty buffer (wasteful write)
+    const configWriter = makeNoOpConfigWriter();
+    const { deps, exitCodes } = makeBaseDeps({
+      configWriter,
+      prompt: {
+        selectCategory: vi.fn().mockResolvedValue({ action: 'keep' }),
+        confirmBatch: vi.fn(),
+        confirmRememberRule: vi.fn(),
+      },
+    });
+
+    await runCategorizeCommand(baseOpts, deps);
+
+    expect(configWriter.appendAutoTagRules).not.toHaveBeenCalled();
+    expect(exitCodes).toContain(0);
+  });
+});
+
+// ---- pickSourceAccount failure ----
+
+describe('runCategorizeCommand — pickSourceAccount failure', () => {
+  it('exits 2 when pickSourceAccount fails', async () => {
+    // fails if: exit code is not 2 when no account matches the filename
+    const { deps, exitCodes, stderr } = makeBaseDeps({
+      pickSourceAccount: () => Result.fail('no account configured for this filename'),
+    });
+
+    await runCategorizeCommand(baseOpts, deps);
+
+    expect(exitCodes).toContain(2);
+    expect(stderr.captured).toContain('no account configured for this filename');
+  });
+});
+
+// ---- configWriter failure (exit 5) ----
+
+describe('runCategorizeCommand — configWriter failure', () => {
+  it('exits 5 when YAML write fails', async () => {
+    // fails if: exit code is not 5 when configWriter returns mtime-race error
+    const configWriter: ConfigWriter = {
+      appendAutoTagRules: vi.fn().mockResolvedValue(Result.fail({ kind: 'mtime-race' as const })),
+    };
+
+    const prompter: InteractivePrompter = {
+      selectCategory: vi.fn().mockResolvedValue({ action: 'change', category: 'Groceries' }),
+      confirmBatch: vi.fn(),
+      confirmRememberRule: vi.fn().mockResolvedValue({ action: 'remember', pattern: 'merchant' }),
+    };
+
+    const { deps, exitCodes, stderr } = makeBaseDeps({ configWriter, prompt: prompter });
+
+    await runCategorizeCommand(baseOpts, deps);
+
+    expect(exitCodes).toContain(5);
+    expect(stderr.captured).toMatch(/yaml|changed externally|categorize/i);
+  });
+});

--- a/tests/unit/core/ingest/categorize-scanner.test.ts
+++ b/tests/unit/core/ingest/categorize-scanner.test.ts
@@ -117,12 +117,12 @@ describe('scanForUnmatched — empty input', () => {
 describe('scanForUnmatched — property test', () => {
   // Scenario (property test, fast-check): scanner output is a permutation/subset of the input
   it('output groups are a subset of input descriptions, pairwise distinct, all count >= minCount, no rule-matched', () => {
-    const descriptionArb = fc.stringOf(fc.alphaNumericChar(), { minLength: 1, maxLength: 20 });
+    const descriptionArb = fc.stringMatching(/^[a-zA-Z0-9 ]{1,20}$/);
     const descriptionsArb = fc.array(descriptionArb, { minLength: 0, maxLength: 30 });
     const minCountArb = fc.integer({ min: 1, max: 5 });
 
     fc.assert(
-      fc.property(descriptionsArb, minCountArb, (descriptions, minCount) => {
+      fc.property(descriptionsArb, minCountArb, (descriptions: string[], minCount: number) => {
         const inputSet = new Set(descriptions);
         const result = scanForUnmatched(descriptions, [], { minCount });
 
@@ -157,7 +157,7 @@ describe('scanForUnmatched — property test', () => {
     const patternArb = fc.constantFrom('uber', 'altima', 'carrefour', 'amazon');
 
     fc.assert(
-      fc.property(descriptionsArb, fc.array(patternArb, { maxLength: 3 }), (descriptions, patterns) => {
+      fc.property(descriptionsArb, fc.array(patternArb, { maxLength: 3 }), (descriptions: string[], patterns: string[]) => {
         const rules: AutoTagRule[] = patterns.map((p) => makeRule(p));
         const result = scanForUnmatched(descriptions, rules, { minCount: 1 });
 

--- a/tests/unit/core/ingest/categorize-scanner.test.ts
+++ b/tests/unit/core/ingest/categorize-scanner.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { scanForUnmatched } from '../../../../src/core/ingest/categorize-scanner.js';
+import type { AutoTagRule } from '../../../../src/core/ingest/auto-tag-rules.js';
+
+// fails if: the scanner fabricates, dedups incorrectly, leaks already-matched strings,
+//   misorders by frequency, applies wrong min-count threshold, or ignores existing rules.
+
+const uberId = 'UBER FRANCE';
+const altimaId = 'ALTIMA COURTAGE 9876';
+const altimaId2 = 'ALTIMA COURTAGE 5432';
+const cardId = 'PAIEMENT CARTE X1234 AVRIL';
+
+function makeRule(pattern: string): AutoTagRule {
+  return { pattern: new RegExp(pattern, 'i'), category: 'TestCat' };
+}
+
+describe('scanForUnmatched — frequency sort', () => {
+  it('returns groups sorted by count descending', () => {
+    const descriptions = [
+      uberId, uberId, uberId, uberId,   // 4 occurrences
+      altimaId, altimaId, altimaId,     // 3 occurrences
+    ];
+    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    expect(result).toHaveLength(2);
+    expect(result[0].description).toBe(uberId);
+    expect(result[0].count).toBe(4);
+    expect(result[1].description).toBe(altimaId);
+    expect(result[1].count).toBe(3);
+  });
+});
+
+describe('scanForUnmatched — min-count filter', () => {
+  it('excludes groups with count < minCount', () => {
+    const descriptions = [
+      uberId, uberId, uberId,  // 3 occurrences — kept
+      'ONE-OFF SHOP',           // 1 occurrence — excluded by minCount=2
+    ];
+    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe(uberId);
+  });
+
+  it('returns empty when all groups are below minCount', () => {
+    const descriptions = ['A', 'B', 'C'];
+    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    expect(result).toHaveLength(0);
+  });
+
+  it('keeps groups with count == minCount', () => {
+    const descriptions = [uberId, uberId]; // exactly 2 occurrences
+    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+  });
+});
+
+describe('scanForUnmatched — existing-rule filter', () => {
+  it('excludes descriptions matched by an existing autotag rule', () => {
+    const descriptions = [
+      uberId, uberId, uberId,   // matched by 'uber' rule
+      altimaId, altimaId, altimaId,
+    ];
+    const rules: AutoTagRule[] = [makeRule('uber')];
+    const result = scanForUnmatched(descriptions, rules, { minCount: 2 });
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe(altimaId);
+  });
+
+  it('excludes card-settlement descriptions (PAIEMENT CARTE pattern)', () => {
+    const descriptions = [
+      cardId, cardId, cardId,   // card-settlement pattern
+      altimaId, altimaId,
+    ];
+    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe(altimaId);
+  });
+
+  it('returns empty when all descriptions are already matched', () => {
+    const descriptions = [uberId, uberId, uberId];
+    const rules: AutoTagRule[] = [makeRule('uber')];
+    const result = scanForUnmatched(descriptions, rules, { minCount: 2 });
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('scanForUnmatched — deduplication', () => {
+  it('groups identical descriptions together', () => {
+    const descriptions = [uberId, uberId, uberId];
+    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe(uberId);
+    expect(result[0].count).toBe(3);
+  });
+
+  it('treats distinct strings as distinct groups', () => {
+    const descriptions = [
+      altimaId, altimaId,
+      altimaId2, altimaId2,
+    ];
+    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    expect(result).toHaveLength(2);
+    const descs = result.map((g) => g.description);
+    expect(descs).toContain(altimaId);
+    expect(descs).toContain(altimaId2);
+  });
+});
+
+describe('scanForUnmatched — empty input', () => {
+  it('returns empty array for empty descriptions', () => {
+    const result = scanForUnmatched([], [], { minCount: 2 });
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('scanForUnmatched — property test', () => {
+  // Scenario (property test, fast-check): scanner output is a permutation/subset of the input
+  it('output groups are a subset of input descriptions, pairwise distinct, all count >= minCount, no rule-matched', () => {
+    const descriptionArb = fc.stringOf(fc.alphaNumericChar(), { minLength: 1, maxLength: 20 });
+    const descriptionsArb = fc.array(descriptionArb, { minLength: 0, maxLength: 30 });
+    const minCountArb = fc.integer({ min: 1, max: 5 });
+
+    fc.assert(
+      fc.property(descriptionsArb, minCountArb, (descriptions, minCount) => {
+        const inputSet = new Set(descriptions);
+        const result = scanForUnmatched(descriptions, [], { minCount });
+
+        // 1. Every group.description appears in the input
+        for (const group of result) {
+          expect(inputSet.has(group.description)).toBe(true);
+        }
+
+        // 2. Output groups are pairwise distinct by description
+        const outputDescs = result.map((g) => g.description);
+        const outputDescSet = new Set(outputDescs);
+        expect(outputDescSet.size).toBe(result.length);
+
+        // 3. Every output group has count >= minCount
+        for (const group of result) {
+          expect(group.count).toBeGreaterThanOrEqual(minCount);
+        }
+
+        // 4. Count value matches actual occurrences in input
+        for (const group of result) {
+          const actualCount = descriptions.filter((d) => d === group.description).length;
+          expect(group.count).toBe(actualCount);
+        }
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it('existing-rule filter: no output description is matched by any existingRules[i].pattern', () => {
+    const descriptionArb = fc.constantFrom('UBER FRANCE', 'ALTIMA COURTAGE', 'CARREFOUR MARKET', 'ONE-OFF SHOP', 'AMAZON EU');
+    const descriptionsArb = fc.array(descriptionArb, { minLength: 5, maxLength: 20 });
+    const patternArb = fc.constantFrom('uber', 'altima', 'carrefour', 'amazon');
+
+    fc.assert(
+      fc.property(descriptionsArb, fc.array(patternArb, { maxLength: 3 }), (descriptions, patterns) => {
+        const rules: AutoTagRule[] = patterns.map((p) => makeRule(p));
+        const result = scanForUnmatched(descriptions, rules, { minCount: 1 });
+
+        for (const group of result) {
+          for (const rule of rules) {
+            expect(rule.pattern.test(group.description)).toBe(false);
+          }
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/tests/unit/core/ingest/categorize-scanner.test.ts
+++ b/tests/unit/core/ingest/categorize-scanner.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fc from 'fast-check';
 import { scanForUnmatched } from '../../../../src/core/ingest/categorize-scanner.js';
 import type { AutoTagRule } from '../../../../src/core/ingest/auto-tag-rules.js';
+import type { AccountConfig } from '../../../../src/core/config/app-config.js';
 
 // fails if: the scanner fabricates, dedups incorrectly, leaks already-matched strings,
 //   misorders by frequency, applies wrong min-count threshold, or ignores existing rules.
@@ -21,7 +22,7 @@ describe('scanForUnmatched — frequency sort', () => {
       uberId, uberId, uberId, uberId,   // 4 occurrences
       altimaId, altimaId, altimaId,     // 3 occurrences
     ];
-    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    const result = scanForUnmatched(descriptions, [], [], { minCount: 2 });
     expect(result).toHaveLength(2);
     expect(result[0].description).toBe(uberId);
     expect(result[0].count).toBe(4);
@@ -36,20 +37,20 @@ describe('scanForUnmatched — min-count filter', () => {
       uberId, uberId, uberId,  // 3 occurrences — kept
       'ONE-OFF SHOP',           // 1 occurrence — excluded by minCount=2
     ];
-    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    const result = scanForUnmatched(descriptions, [], [], { minCount: 2 });
     expect(result).toHaveLength(1);
     expect(result[0].description).toBe(uberId);
   });
 
   it('returns empty when all groups are below minCount', () => {
     const descriptions = ['A', 'B', 'C'];
-    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    const result = scanForUnmatched(descriptions, [], [], { minCount: 2 });
     expect(result).toHaveLength(0);
   });
 
   it('keeps groups with count == minCount', () => {
     const descriptions = [uberId, uberId]; // exactly 2 occurrences
-    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    const result = scanForUnmatched(descriptions, [], [], { minCount: 2 });
     expect(result).toHaveLength(1);
     expect(result[0].count).toBe(2);
   });
@@ -62,25 +63,40 @@ describe('scanForUnmatched — existing-rule filter', () => {
       altimaId, altimaId, altimaId,
     ];
     const rules: AutoTagRule[] = [makeRule('uber')];
-    const result = scanForUnmatched(descriptions, rules, { minCount: 2 });
+    const result = scanForUnmatched(descriptions, rules, [], { minCount: 2 });
     expect(result).toHaveLength(1);
     expect(result[0].description).toBe(altimaId);
   });
 
-  it('excludes card-settlement descriptions (PAIEMENT CARTE pattern)', () => {
+  it('excludes card-settlement descriptions when the card account is configured', () => {
+    // fails if: scanner leaks card-settlement rows when a matching card account exists
+    // (the configured-card branch of the account-presence check)
+    const configuredCard: AccountConfig = { id: 'card-1234', type: 'card', filenamePrefix: 'CARD_', cardSuffix: '1234' };
     const descriptions = [
-      cardId, cardId, cardId,   // card-settlement pattern
+      cardId, cardId, cardId,   // PAIEMENT CARTE X1234 AVRIL — suffix 1234 is configured
       altimaId, altimaId,
     ];
-    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    const result = scanForUnmatched(descriptions, [], [configuredCard], { minCount: 2 });
     expect(result).toHaveLength(1);
     expect(result[0].description).toBe(altimaId);
+  });
+
+  it('surfaces card-settlement descriptions when the card account is NOT configured (unconfigured-suffix branch)', () => {
+    // fails if: scanner hides card-settlement rows whose suffix has no configured card account.
+    // Round-trip property: ingest's tryCardSettlement would return null for an unconfigured
+    // suffix (falling back to low-confidence tagDescription), so categorize MUST surface it.
+    const descriptions = [
+      cardId, cardId, cardId,   // PAIEMENT CARTE X1234 AVRIL — suffix 1234 is NOT configured
+    ];
+    const result = scanForUnmatched(descriptions, [], [], { minCount: 2 });
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe(cardId);
   });
 
   it('returns empty when all descriptions are already matched', () => {
     const descriptions = [uberId, uberId, uberId];
     const rules: AutoTagRule[] = [makeRule('uber')];
-    const result = scanForUnmatched(descriptions, rules, { minCount: 2 });
+    const result = scanForUnmatched(descriptions, rules, [], { minCount: 2 });
     expect(result).toHaveLength(0);
   });
 });
@@ -88,7 +104,7 @@ describe('scanForUnmatched — existing-rule filter', () => {
 describe('scanForUnmatched — deduplication', () => {
   it('groups identical descriptions together', () => {
     const descriptions = [uberId, uberId, uberId];
-    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    const result = scanForUnmatched(descriptions, [], [], { minCount: 2 });
     expect(result).toHaveLength(1);
     expect(result[0].description).toBe(uberId);
     expect(result[0].count).toBe(3);
@@ -99,7 +115,7 @@ describe('scanForUnmatched — deduplication', () => {
       altimaId, altimaId,
       altimaId2, altimaId2,
     ];
-    const result = scanForUnmatched(descriptions, [], { minCount: 2 });
+    const result = scanForUnmatched(descriptions, [], [], { minCount: 2 });
     expect(result).toHaveLength(2);
     const descs = result.map((g) => g.description);
     expect(descs).toContain(altimaId);
@@ -109,7 +125,7 @@ describe('scanForUnmatched — deduplication', () => {
 
 describe('scanForUnmatched — empty input', () => {
   it('returns empty array for empty descriptions', () => {
-    const result = scanForUnmatched([], [], { minCount: 2 });
+    const result = scanForUnmatched([], [], [], { minCount: 2 });
     expect(result).toHaveLength(0);
   });
 });
@@ -124,7 +140,7 @@ describe('scanForUnmatched — property test', () => {
     fc.assert(
       fc.property(descriptionsArb, minCountArb, (descriptions: string[], minCount: number) => {
         const inputSet = new Set(descriptions);
-        const result = scanForUnmatched(descriptions, [], { minCount });
+        const result = scanForUnmatched(descriptions, [], [], { minCount });
 
         // 1. Every group.description appears in the input
         for (const group of result) {
@@ -159,7 +175,7 @@ describe('scanForUnmatched — property test', () => {
     fc.assert(
       fc.property(descriptionsArb, fc.array(patternArb, { maxLength: 3 }), (descriptions: string[], patterns: string[]) => {
         const rules: AutoTagRule[] = patterns.map((p) => makeRule(p));
-        const result = scanForUnmatched(descriptions, rules, { minCount: 1 });
+        const result = scanForUnmatched(descriptions, rules, [], { minCount: 1 });
 
         for (const group of result) {
           for (const rule of rules) {


### PR DESCRIPTION
## 1. Story

Story D — out-of-epic workstream extending Epic 2 / Story 2.4 (FR6 auto-tagging).
Tracks closure of [issue #93](https://github.com/xavierbriand/accounting/issues/93). Plan: [docs/plans/story-D.md](docs/plans/story-D.md).

## 2. Intent

Issue #93 reports that autotag rules defined mid-`ingest` only take effect on the *next* invocation — `TransactionBuilder.rules` is frozen at construction and the interactive loop's remembered rules are written to YAML only after the loop completes. In the "first-time onboarding a year of statements" path the user is re-prompted for every recurrence of an already-defined merchant.

Story D adds a dedicated greenfield command, `accounting categorize -f <csv>`, that scans a CSV without touching the DB, walks the user through defining categories + regex for the most-frequent unmatched descriptions, and writes the warmed `accounting.yaml` in a single atomic append. The user then runs `ingest` against a config that already auto-tags most recurring merchants — closing the workflow gap without changing `ingest`'s rule-snapshot semantics.

## 3. Alternatives considered

- **Option B from #93 (re-apply rules mid-`ingest`)** — set aside as a separate issue ([#103](https://github.com/xavierbriand/accounting/issues/103)). Lighter fix but doesn't address the broader "teach categories before committing transactions" workflow the user actually needs.
- **Mutate `TransactionBuilder.rules` mid-loop** — set aside; breaks the constructor-DI / immutability boundary in `src/core/`.
- **Token-similarity grouping in v1** — set aside ([#106](https://github.com/xavierbriand/accounting/issues/106)); deferred to a v2 ranker. v1 ships a plain frequency-sorted function (no `RankingStrategy` interface — YAGNI; abstraction earned only when v2 lands).

## 4. Selected solution & rationale

A new top-level `categorize` subcommand that **separates the "teach the system my categories" phase from the "commit transactions" phase**. The separation matches how the user actually wants to work, doesn't perturb `ingest`'s existing rule-snapshot mechanic, and reuses the entire interactive prompter + YAML-writer surface from Story C — no port extension required for v1.

Architecture follows the existing three-layer rule:
- Pure scanner in `src/core/ingest/categorize-scanner.ts` (groups + frequency-sorts unmatched descriptions; no I/O).
- New shared predicate `src/core/ingest/auto-classify.ts` extracted from `TransactionBuilder` so the scanner uses **the same predicate** ingest uses to decide a row is `'high'` confidence — including the card-settlement path AND its account-presence sub-condition (P1-E fix from Phase-2 + Phase-4 reviews).
- Orchestrator in `src/cli/commands/categorize-command.ts` (Writable + exitCode injection, mirrors `runIngestCommand`).
- New subcommand wiring in `src/cli/program.ts` (R4 subprocess test required).

Beats Option B because the user's underlying need — onboarding a year of statements — is a workflow problem, not a per-row classification problem.

## 5. Gherkin scenarios

See full plan: [docs/plans/story-D.md § Gherkin scenarios](docs/plans/story-D.md). Six scenarios cover: scripted run appends rules · already-matched groups silently skipped · `--non-interactive` errors with no YAML write · `--json` multi-rule shape (mock-diversity per R8) · `--min-count` default of 2 · all-matched edge case (zero prompts, no YAML write — with explicit "prompter is never invoked" assertion). Plus a fast-check property test for the scanner.

## 6. Plan for Sonnet

Full details in [docs/plans/story-D.md](docs/plans/story-D.md). Key files:

**New (Core):** `src/core/ingest/auto-classify.ts` (extracted predicate), `src/core/ingest/categorize-scanner.ts`.
**New (CLI):** `src/cli/commands/categorize-command.ts`.
**New (tests):** unit + property tests for the scanner, orchestrator unit tests, `tests/features/categorize.feature` + steps, R4 subprocess wiring test.
**Edited:** `src/cli/program.ts` (subcommand registration), `src/core/ingest/transaction-builder.ts` (use the new shared predicate), `accounting.example.yaml` (one-line doc note).

**Slice plan landed:** 8 story slices + 5 Phase-4 fix-now commits = 13 implementation commits + 3 chore(docs)/chore(retro) commits.

**DoD for this story:** `lint && build && test` green on CI; 100% branch coverage on Core; fast-check property test for scanner invariants; R4 subprocess smoke asserts no `.db` file created; all 10 PR template sections filled at merge; suggestion log fully resolved (below); retrospective at [docs/retrospectives/story-D.md](docs/retrospectives/story-D.md).

## 7. Suggestion log

Plan-reviewer (Phase-2) returned 27 findings (P1: 7 · P2: 7 · P3: 13). Each is tagged below. DoR: every row resolved; every `deferred` links an issue.

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P1-A | Exit-code mapping inconsistent with `ingest-command.ts:55–80` (lumps `pickSourceAccount` into exit 1; ingest uses exit 2) | adopted | Plan § "Stable exit codes" rewritten to mirror ingest verbatim |
| P1-B | Partial-buffer-flush-on-abort path under-specified; no exit code defined | adopted | Plan § Behaviour step 6 + "Stable exit codes" now define abort = exit 0 with stderr advisory |
| P1-C | Empty / no-unmatched-rows edge case absent from Gherkin | adopted | New Scenario 6 covers all-matched → exit 0, prompter never invoked, YAML untouched |
| P1-D | All-malformed CSV path unspecified | adopted | Plan § Behaviour step 3 now spells out empty `parseOutcome.items` → exit 0 |
| P1-E | Card-settlement rows break the round-trip property — they survive the scanner but ingest auto-tags them as `'high'` confidence | adopted | New `src/core/ingest/auto-classify.ts` extracts the shared predicate (autotag rules + card-settlement RegExp + account-presence check) consumed by both `TransactionBuilder` and the scanner; new prep slice 1 |
| P1-F | Same exit-code inconsistency as P1-A on `pickSourceAccount` failure | adopted | Resolved with P1-A |
| P1-G | `ScriptedPrompter.Script` includes `confirmBatch` but categorize won't use it | rejected | Non-issue — categorize test scripts simply omit `confirmBatch` entries; no plan change required |
| P2-A | PII redaction posture in `--json` output | rejected | JSON output includes only user-typed regexes/category names (carve-out per security-checklist.md:31–32); raw descriptions never appear in JSON |
| P2-B | Two-stage parse/commit policy applicability | rejected | Categorize has no commit stage; YAML atomic-rename is the equivalent boundary; QA invariant satisfied in spirit |
| P2-C | Bootstrap-then-ingest UX promise broken for card-settlement rows | adopted | Resolved with P1-E (shared predicate) |
| P2-D | `rulesSkippedAsDuplicate` hardcoded to 0; writer doesn't return a count | deferred | [#104](https://github.com/xavierbriand/accounting/issues/104) — widen `appendAutoTagRules` success type |
| P2-E | Append-only ledger | rejected | No DB writes — invariant trivially satisfied |
| P2-F | Snapshot safety (FR17) | rejected | Not engaged — no DB writes |
| P2-G | Mock-diversity for `--json` (R8) — only single-rule fixture at acceptance tier | adopted | Scenario 4 rewritten to assert `rulesAdded > 1` + `rulesSkippedByUser > 0` |
| P3-A | Layer purity of `scanForUnmatched` | rejected | `RegExp.test` is ECMAScript-standard; no Node API leaks |
| P3-B | Constructor DI in orchestrator | rejected | Function-with-deps mirrors codebase pattern; correct constructor-DI equivalent |
| P3-C | Zod boundary placement | rejected | All external input validated in CLI/Infra; no Zod in Core (correct) |
| P3-D | `Result<T, E>` discipline in error paths | rejected | Plan describes `Result.fail` propagation for every failure; no `throw` inside Core |
| P3-E | `CategorizeCommandDeps` mirrors but doesn't share with `IngestCommandDeps` (KISS / DRY) | deferred | [#107](https://github.com/xavierbriand/accounting/issues/107) — extract shared base type as a maint refactor |
| P3-F | `RankingStrategy` interface with one impl is YAGNI | adopted | Interface dropped in v1; v2 ranker ([#106](https://github.com/xavierbriand/accounting/issues/106)) reintroduces it when two concrete impls exist |
| P3-G | No `any` types | rejected | Already enforced; plan introduces no `any` |
| P3-H | Path traversal on CSV `--file` argument | rejected | Same posture as ingest's existing `readBpceCsv` (read-only); no new risk |
| P3-I | `accounting.yaml` symlink check | rejected | Pre-existing deferral at [#88](https://github.com/xavierbriand/accounting/issues/88); no new exposure introduced |
| P3-J | Slice 5 bundles `test+feat` (no-test+feat-combined-commit rule) | adopted | Slice 5 split into slice 6 (test failing) + slice 7 (feat green); total slice count now 8 |
| P3-K | Slice 6 subject "note" is a noun (R12) | adopted | Renamed to `chore(docs): add accounting.example.yaml note + retro check` (now slice 8) |
| P3-L | `validateDbPath` may fail on first-run / non-existent DB | rejected | Verified `db-path-validator.ts:17–20` — ENOENT is explicitly accepted; no failure path on first run |
| P3-M | `runCategorizeCommand` likely > 50 LOC (engineering-standards.md guideline) | deferred | [#110](https://github.com/xavierbriand/accounting/issues/110) — extract `runPromptLoop` (Phase-4 partial: extracted `runCategorizeSummary`, landed 140 LOC vs 50 LOC target) |

Phase-4 code-reviewer returned 9 additional findings (2 P1, 0 P2, 7 P3). Resolution:

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P4-1 (R5) | Feature scenario 5 missing "the prompter is never invoked" assertion | fix-now | Commit `4a82255` adds explicit `--scripted-prompts '[]'` + new step `the prompter is never invoked` |
| P4-2 (P1-E partial) | `isAlreadyClassified` doesn't check account presence; card-settlement rows with unconfigured suffixes break round-trip | fix-now | Commits `6243284` + `a36bebe` widen `isAlreadyClassified(description, rules, accounts)` to mirror `tryCardSettlement`'s account-presence check |
| P4-3 (LOC) | `runCategorizeCommand` 161 LOC exceeds engineering-standards.md ~50 LOC target | fix-now (partial) | Commit `38406bb` extracts `runCategorizeSummary` (~22 LOC), landed at 140 LOC. Further `runPromptLoop` extraction deferred to [#110](https://github.com/xavierbriand/accounting/issues/110) |
| P4-4 (style) | Nine `// Step N` "what" comments | fix-now | Commit `38406bb` removes all nine |
| P4-5 (`--limit` untested) | Public CLI flag with zero coverage | fix-now | Commit `fe45b4b` adds `--limit 2 on 5 groups` unit test |
| P4-6 (R6) | `the script is fully consumed without errors` step asserts absence of error string but doesn't verify all entries consumed | acknowledge | Soft finding — current assertions detect the specific regression the `fails if` clause guards. Note in retro |
| P4-7 (R11 mismatch) | Slice 7 (`d7f8e38`) is empty `feat:` not `refactor:` | acknowledge | History rewrite not worth it; note in retro. New R20 candidate forwarded to next process-touching PR |
| P4-8 (ISP — `confirmBatch` in deps) | `CategorizeCommandDeps.prompt` includes `confirmBatch` which categorize never calls | acknowledge | Already deferred at [#107](https://github.com/xavierbriand/accounting/issues/107) |
| P4-9 (`IngestWorld` typing on shared steps) | Compile-time type annotation misleading for categorize scenarios | acknowledge | Pre-existing pattern; works structurally; revisit when third command lands |

**Phase-4 deferred items also opened a soft "double `isAlreadyClassified` call" follow-up** (Sonnet declined to land in Phase-4 due to 13-test-call-site touch budget): [#109](https://github.com/xavierbriand/accounting/issues/109).

## 8. Sonnet's learnings

### Phase 3 (initial implementation, 8 slices)

**What was built**

All 6 Gherkin scenarios for Story D pass: scripted categorize run appending two rules, existing-rule skip filter, `--non-interactive` CI bail, `--json` multi-rule shape (R8), all-already-matched short-circuit, and `--min-count` default filtering one-offs. Implementation adds `src/core/ingest/auto-classify.ts` (shared predicate for P1-E round-trip property), `src/core/ingest/categorize-scanner.ts` (pure frequency-sorted scanner), `src/cli/commands/categorize-command.ts` (orchestrator with abort flush, mtime-race handling, `--json` shape), and wires the `categorize` subcommand into `src/cli/program.ts`. The R4 subprocess test asserts no `.db` file is created in the temp dir.

**Deviations from plan**

- **Slice-5 over-implementation.** `runCategorizeCommand` was written in full in Slice 5, including the `--non-interactive` and `--json` paths the plan deferred to Slice 7. Slice 6 tests landed green-on-landing (R10 invoked); Slice 7 (`d7f8e38`) is therefore an effectively empty `feat:` commit (R11 invoked).
- **`fast-check` API**: used `fc.stringMatching(/^[a-zA-Z0-9 ]{1,20}$/)` instead of `fc.stringOf(fc.alphaNumericChar(), ...)` — the latter doesn't exist in fast-check v4.7.0.
- **`alreadyMatchedCount` initially computed incorrectly**, corrected within the same slice via the refactor-during-green allowance.
- **Quickpickle step-uniqueness shim**: removed duplicate `the process exits with code {int}` and `stderr contains {string}` step definitions from `categorize.steps.ts` — they collide with `ingest.steps.ts` and the BDD harness raises ambiguity.

### Phase 4 (refactor bundle, 5 commits)

**What was built**

Five fix-now items: `the prompter is never invoked` honesty step (`4a82255`); accounts-aware `isAlreadyClassified` widening (`6243284` + `a36bebe`); `runCategorizeSummary` extraction + Step-N comment removal (`38406bb`); `--limit` truncation unit test (`fe45b4b`).

**Deviations from refactor brief**

- **Double `isAlreadyClassified` call not collapsed.** Widening `scanForUnmatched`'s return type would cascade to 13 scanner-test call sites — exceeds the implicit Phase-4 touch budget. Filed as [#109](https://github.com/xavierbriand/accounting/issues/109).
- **`runCategorizeCommand` landed at 140 LOC**, not the ~80 LOC target. Further extraction (the prompt loop, with five shared-state variables) is structural; filed as [#110](https://github.com/xavierbriand/accounting/issues/110).

## 9. Retrospective

- **Keep:** Auto-mode end-to-end run (phases 2 → 4 in one continuous arc, three sub-agent hand-offs, no phase skips). Plan-reviewer's load-bearing P1-E save (constructed the precise card-settlement counter-example by reading two files). Filing follow-up issues at Phase-1 exit prevented suggestion-log debate.
- **Change:** Slice 5 over-implementation collapsed slice 7 to an empty `feat:` commit (R11 covers `refactor:` not `feat:`). Phase-4 caught a real bug (P1-E partial) that Sonnet's slice-3 unit tests missed — the scanner tested every input pattern but not every branch of the original predicate.
- **Try:** Codify three new sub-rules in next process-touching PR — explicit Phase-4 "touch budget", "predicate-extraction stories require per-branch unit test", and R20 ("empty `feat:` slices retitle to `chore(workflow): empty slice`").

Full retrospective: [docs/retrospectives/story-D.md](docs/retrospectives/story-D.md).

## 10. Merge checklist

- [x] \`lint\` / \`build\` / \`test\` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at \`docs/retrospectives/story-D.md\`
- [x] All suggestion-log items resolved (no blank \`Resolution\` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)