### PR TITLE
fix(tests): guard fc.date() against RangeError in status-command property test

### DIFF
--- a/tests/unit/cli/commands/status-command.test.ts
+++ b/tests/unit/cli/commands/status-command.test.ts
@@ -592,6 +592,7 @@ describe('Property #7: --from > --to exits with code 2', () => {
 
   it('fast-check: whenever from > to, always exits 2', async () => {
     const isoDateArb = fc.date({ min: new Date('2020-01-01'), max: new Date('2030-12-31') })
+      .filter(d => !isNaN(d.getTime()))
       .map(d => d.toISOString().slice(0, 10));
 
     await fc.assert(


### PR DESCRIPTION
## Summary

- `fc.date({ min, max })` in fast-check 4.x, when wrapped by `AlwaysShrinkableArbitrary`, can generate `Date` objects whose timestamp falls outside JavaScript's valid range (±8,640,000,000,000,000 ms from epoch)
- `toISOString()` throws `RangeError: Invalid time value` for those dates, causing the property test to crash instead of producing a verdict
- Fix: add `.filter(d => !isNaN(d.getTime()))` between `fc.date()` and `.map()` so fast-check discards out-of-range dates before converting them to ISO strings

Fixes CI failure on main: [run 25133753328](https://github.com/xavierbriand/accounting/actions/runs/25133753328)

## Test plan

- [x] `npm test -- tests/unit/cli/commands/status-command.test.ts` — all 28 tests green (was 27 pass / 1 fail)
- [x] `npm run lint && npm run build && npm test` — lint + build clean; suite green in full environment (worktree lacks tsx for symlink integration tests — pre-existing environment gap, not a regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)