### PR TITLE
docs(learning): application-layer comparison vs harness, #94 curriculum

### DIFF
--- a/docs/learning/application-layer-comparison.md
+++ b/docs/learning/application-layer-comparison.md
@@ -1,0 +1,105 @@
+# Application-layer (Ubl) vs. this repo's harness — operator notes
+
+> **Audience.** Operator already fluent in this repo's harness. One-page brief; no harness primer.
+>
+> **Companion to** [spdd-comparison.md](spdd-comparison.md): a second external frame benchmarked against the same loop. Where SPDD asks *how do specs and code stay in sync at team scale?*, the application-layer frame asks *what survives when code generation gets cheap and the moat moves up?*
+>
+> See also: [harness-engineering.md](harness-engineering.md) (the parent curriculum doc).
+
+## § 1. What the talk claims
+
+**Source.** Malte Ubl, CTO Vercel, *"The New Application Layer"* — AI Engineer Europe 2026, ~18 min. [YouTube `XKup1pj-34M`](https://www.youtube.com/watch?v=XKup1pj-34M).
+
+**Source-fidelity caveat.** The talk transcript is not directly accessible via WebFetch (only the title was returned). The body below is reconstructed from a third-party structured summary; the chapter outline is reliably drawn from chapter timestamps in that summary, but quoted lines should be read as *indicative paraphrase*, not verbatim transcript. Anything attributed to Ubl below traces to a chapter (1–4) or is explicitly framed as *"the talk's frame says"*.
+
+Five claims, one per chapter / theme:
+
+1. **Engineering shifts from typing to piloting.** Humans steer probabilistic systems toward deterministic outcomes. The engineer's role moves from generation to curation. *(chap. 1)*
+2. **Code is cheap; verification is expensive.** Generating 10,000 lines costs nothing; ensuring they don't break the system is where the work moves. *(chap. 1, follow-up)*
+3. **Models commoditize; the moat moves up.** Loyalty to a model vendor decreases; the application layer — harness + verification + proprietary logic — is where competitive value accrues. *(chap. 4)*
+4. **Software must be agent-legible.** APIs, schemas, and logs become the primary product, not pixels. Other agents drive the software, so machine-readable surfaces are first-class. *(chap. 3)*
+5. **Workloads need durable execution.** Agent runs span hours-to-days, not 200ms lambdas; pause-and-resume across external events is a runtime requirement. Vercel Workflow as imperative TypeScript, not YAML, is the talk's example. *(chap. 3)*
+
+Indicative quote (paraphrased via the summary): *"Modern infrastructure must no longer merely host code; it must understand the intent of the agent executing it."*
+
+## § 2. One problem the harness has shipped a partial answer to
+
+**Verification, at human-throughput scale.**
+
+The harness has automated the bulk of single-PR verification:
+
+- Phase 2 plan-reviewer + Phase 4 code-reviewer sub-agents ([CLAUDE.md § 6.1](../../CLAUDE.md))
+- R1–R19 retro rules ([CLAUDE.md § 8](../../CLAUDE.md)) — each crystallized from a real failure mode
+- 100% branch coverage on `src/core/`; property tests via `fast-check` for financial invariants
+- DoR/DoD gates with a 10-item merge checklist ([CLAUDE.md § 7](../../CLAUDE.md))
+- Failure-signature taxonomy ([Part B of harness-engineering.md](harness-engineering.md#failure-signatures-to-learn-to-spot)) — vocabulary for naming what goes wrong
+
+This is real progress against claim 2 of the talk's frame.
+
+**The partial.** It scales to *one PR at a time, one human gating merge*. The talk's claim is about how verification scales when *code volume rises*. If Sonnet starts producing several PRs per day in parallel, the bottleneck is the human reviewer, not the harness. The current loop has a verification *quality* story (catches subtle bugs); it does not have a verification *throughput* story (sustains correctness when N parallel agents push N PRs/day). [spdd-comparison.md](spdd-comparison.md) inherits the same blind spot.
+
+## § 3. Two problems the harness is silent on
+
+### 3.1. Durable execution
+
+Markdown-as-state (plan file, suggestion log, retrospective) works because the human re-spawns sessions and the harness re-reads files on the next turn. There is no replay primitive. When a Phase 3 task crashes mid-session, we re-prompt and hope. The cost shows up the moment we want anything genuinely async — long evals, multi-day workflows, pausing on external events (a webhook, a human approval, a third-party API rate limit).
+
+[Module 7 / issue #111](harness-engineering.md) is the only nod toward this and it is currently `blocked-on-tripwire` ([§ 7 of spdd-comparison.md](spdd-comparison.md#7-curriculum-delta)). The silence is structural, not absent-by-oversight: *the human is the runtime*, and the harness was designed around that fact. The talk's claim 5 names a primitive that is simply not present.
+
+### 3.2. Agent-legibility of the *product surface*
+
+The talk's frame: the *software you ship* should be machine-readable so other agents can drive it. Our product is a human-CLI accounting tool — `commander`-driven, formatted for terminal eyes.
+
+The harness *is* agent-legible (XML-structured agent specs, structured sub-agent reports, `Result<T, E>` returns at every layer boundary, machine-grep-able R-tags). The product surface is not (no MCP server over the ledger, no structured-API export, no JSON-first query interface).
+
+Caveat against over-claiming: *domain types* like `Result<T,E>` and the append-only ledger are agent-legible *to our own harness, which already knows the type system*. They would not help a third-party agent driving the ledger cold. The talk's claim 4 is about the latter.
+
+## § 4. How the curriculum encodes those silences
+
+Module-by-module, against the talk's frame:
+
+| Module | Read against claims 1–5 |
+| --- | --- |
+| 1 — drift-scan | Verification quality scope. Direct fit on claim 2 at single-PR granularity. Doesn't address throughput. |
+| 2 — primitives by niche | Toolkit fluency. Tangential to application-layer concepts. |
+| 3 — right-sizing the gate | Tension worth naming. The trivial-story lane assumes ceremony cost dominates verification value for ≤20 LOC. The talk's frame says verification value scales with code in the *system*, not just the *change* — a small diff against a large AI-generated codebase has a different verification calculus. Module 3 right-sizes by *risk*, which is defensible, but the calculus isn't currently stated in those terms. |
+| 4 — eval-driven agent engineering | Centerpiece, strongest fit on claim 2. Currently scoped to *quality* fixtures. An additional *throughput* fixture (concurrency vs. review quality) would close the § 2 partial. |
+| 5 — cost & telemetry | Light fit. The talk barely addresses telemetry except as input to "compressed search" agents — a future 5b could borrow that angle. |
+| 6 — talk + colleague-ships | Aligned at fluency. Success metric is *"colleague forks and ships **one** story"* — synchronous, hand-paired, no scale axis. Reasonable for v1; worth naming as the v1 ceiling. |
+
+The curriculum is coherent at *"how to run this loop fluently"*. It is silent on *"how this loop scales as code becomes cheap"* — which is the talk's frame in one sentence.
+
+## § 5. What changes if we take the talk seriously
+
+Five concrete moves. The first three are candidate sub-issue edits against [issue #94](https://github.com/xavierbriand/accounting/issues/94); the fourth is a position; the fifth is follow-on tooling. **None are filed in this PR.**
+
+1. **Module 4 — add a throughput fixture.** Beyond *"does the reviewer catch the bug"*, ask *"at what concurrency does reviewer quality degrade?"* That is where the harness will break first as Sonnet output scales. Add as a sub-bullet to acceptance.
+2. **Module 6 — add a scale axis to the success metric.** *"Colleague ships **N** stories before the author rejoins"* with N=2 or N=3 is a meaningfully different test than N=1. It also exercises rule evolution (the colleague will hit a retro that needs to advance R-tags), not just fluency.
+3. **#111 / Module 7 — commit-or-rename.** Either elevate it from `blocked-on-tripwire` footnote to a real module on durable plans / drift-resilient state, or accept that the curriculum's scope is *synchronous-paired-with-AI* and rename accordingly. The current half-filed status is the awkward middle.
+4. **Position on agent-legible product surface (curriculum-level question only).** If we accept the talk's frame, an MCP server over the ledger — making invariants queryable by *any* agent, not just our harness — is what *"the moat is the harness"* looks like when applied to the product, not just the dev-loop. Whether to *build* it is a product-roadmap decision out of scope here. The curriculum-level call is whether to *teach the lens*. **Recommendation:** name the question explicitly in [Module 6's](harness-engineering.md#module-6--teach-back-evaluated-by-colleague-ships-without-you) talk as the *open frontier*. Don't fold it into the curriculum body — it isn't skill, it's strategy.
+5. **R-tag staleness scan.** Extend `scripts/drift-scan.ts` (Module 1) to flag rules that have had zero retro touches in N stories. The R-table currently crystallizes past failures; this would surface rules that may have outlived their failure mode (Principle 7 of [harness-engineering.md Part B](harness-engineering.md#principles-memorize-the-rest-follows)). Small, cheap, sympathetic to the talk's *"verification is the work"* framing.
+
+## § 6. What this loop has that the talk doesn't address
+
+The talk is a vision pitch, not a methodology. Honest credit, with the same caveat the SPDD comparison applies: these are *load-bearing now*; whether they survive scale is a separate question.
+
+- **Rule-from-retro provenance** ([R1–R19 with originating retros](../../CLAUDE.md)) — a reproducible mechanism for *evolving the gate*. The talk says "verification is expensive" but doesn't say how the verification rules themselves should evolve. We have an answer.
+- **Bidirectional plan-code accountability** (R2 production-code-surface section) — the plan must enumerate type/signature/format changes; Phase 4 audits the diff against it. Catches a class of drift the talk doesn't name.
+- **Failure-signature taxonomy** ([Part B](harness-engineering.md#failure-signatures-to-learn-to-spot): lying-summary, helpful-but-wrong, coincidence-pass, safeguard-removal, shim-creep, over-eager-generalization, plan-execution-drift, cargo-cult-guard) — vocabulary for naming what goes wrong in agent output. Not present in the talk.
+
+These are real wins worth claiming in [Module 6's](harness-engineering.md#module-6--teach-back-evaluated-by-colleague-ships-without-you) talk. They don't close the § 3 silences, but they're a deeper methodology than an 18-minute keynote can offer.
+
+## § 7. Verdict — three slide bullets
+
+Each ≤ 80 chars. Slide bullets for talk Section 5 alongside the SPDD bullets ([§ 8 of spdd-comparison.md](spdd-comparison.md#8-verdict--three-slide-bullets)).
+
+- **Models commoditize; the harness is the moat — Ubl validates the curriculum's thesis.** *Slide-1 hook for the [Module 6](harness-engineering.md#module-6--teach-back-evaluated-by-colleague-ships-without-you) talk.*
+- **The loop solves verification quality — not yet verification throughput.** *Single-PR review is a partial answer when N parallel agents push N PRs/day.*
+- **Durable execution + agent-legible product are the curriculum's open frontiers.** *Name them in the talk; treat as strategy, not skill.*
+
+## § 8. References
+
+- Malte Ubl, *"The New Application Layer"*, AI Engineer Europe 2026 — [YouTube `XKup1pj-34M`](https://www.youtube.com/watch?v=XKup1pj-34M).
+- Sibling comparison: [spdd-comparison.md](spdd-comparison.md) — same loop benchmarked against Structured Prompt-Driven Development.
+- Parent curriculum: [harness-engineering.md](harness-engineering.md) — modules, principles, failure-signature taxonomy.
+- This repo: [CLAUDE.md](../../CLAUDE.md) — workflow + R-tag rule provenance · [.claude/agents/](../../.claude/agents/) — sub-agent specs.

--- a/docs/learning/harness-engineering.md
+++ b/docs/learning/harness-engineering.md
@@ -241,6 +241,7 @@ Live-demo: edit `plan-reviewer.md` to introduce a deliberate regression (drop th
 - **Eval design:** Inspect Evals docs (Anthropic-affiliated). Skim only — borrow vocabulary, don't adopt the framework yet at this scale.
 - **Lightweight eval tooling for solo scale:** promptfoo README, just enough to know what isn't being used.
 - **Prompt engineering for Anthropic models:** Anthropic docs → Prompt engineering guide. The XML-tag and example-shaped-output sections are the load-bearing parts.
+- **Vision / strategic context:** Malte Ubl, *"The New Application Layer"* (AI Engineer Europe 2026, [YouTube `XKup1pj-34M`](https://www.youtube.com/watch?v=XKup1pj-34M)). Read the comparison [application-layer-comparison.md](application-layer-comparison.md) — names where this curriculum aligns, where it's silent (durable execution, agent-legible product), and what changes if we take the talk seriously.
 
 Skip until later: agent-framework / LangChain / LangGraph / CrewAI. Out of scope by design, and the abstractions hurt before they help at this scale.
 

--- a/docs/learning/spdd-comparison.md
+++ b/docs/learning/spdd-comparison.md
@@ -5,7 +5,7 @@
 > 1. **Talk-feeder for Module 6** — the speaker preparing the 45-min agentic-engineering talk needs three slide-ready bullets, named methodology references, and the *places we exceed and trail SPDD* mapped to talk sections.
 > 2. **Onboarding for the starter template** — a forking colleague reading this alongside `STARTER.md` to understand *why* the workflow looks the way it does, with both sides steel-manned so they can defend the loop's choices to their own team.
 >
-> See also: [harness-engineering.md](harness-engineering.md) (the parent curriculum doc).
+> See also: [harness-engineering.md](harness-engineering.md) (the parent curriculum doc) · [application-layer-comparison.md](application-layer-comparison.md) (sibling — same loop benchmarked against Malte Ubl's "The New Application Layer").
 
 ## § 1. Preamble
 


### PR DESCRIPTION
## Summary

- New [docs/learning/application-layer-comparison.md](docs/learning/application-layer-comparison.md) — sibling to `spdd-comparison.md`, benchmarks this loop against Malte Ubl's *"The New Application Layer"* (AI Engineer Europe 2026, [YouTube `XKup1pj-34M`](https://www.youtube.com/watch?v=XKup1pj-34M)).
- Cross-links wired both ways: `harness-engineering.md` Part D reading list now points to the new doc; `spdd-comparison.md` header see-also extended.
- Honest framing: names *one* problem the harness has shipped a partial answer to (verification at human-throughput scale), *two* the harness is silent on (durable execution; agent-legibility of the product surface), *five* concrete moves that would change if we take the talk seriously, and *three* genuine wins over the talk (R-tag provenance, R2 plan-code accountability, failure-signature taxonomy). No sub-issues filed against #94 in this PR.

## Notes for review

- **Source-fidelity caveat** is explicit at top of § 1: WebFetch only returned the title, so the body is reconstructed from a third-party structured summary. Claims attributed to Ubl trace to chapter outlines (1–4); quoted lines are framed as *indicative paraphrase*, not verbatim transcript.
- **Position taken on agent-legible product surface (§ 5.4)** is explicitly scoped as a *curriculum-level* question (whether to teach the lens), not a product-roadmap proposal (whether to build an MCP server over the ledger).
- **Plan went through one round of self-critique** before writing — first draft over-claimed alignment; rewrite restructured around three open questions (verification throughput, durable execution, agent-legibility) and added the § 6 "what we have they don't" section.

## Test plan

- [x] `npm run build` green (docs-only change; sanity per harness Part D pattern)
- [x] Cross-links resolve: `grep -r "application-layer-comparison" docs/learning/` returns two hits
- [x] New doc length within budget (~150-line target; landed at 105)
- [x] Source-fidelity check: every § 1 claim traces to a chapter or is marked paraphrase; § 2–§ 6 use *"the talk's frame says"* framing, not *"Ubl said"*
- [x] Critique smoke test: § 2 / § 3 anchor sentences (*"human-throughput scale"*, *"the human is the runtime"*) survive in final doc — tone hasn't drifted polite
- [x] Reviewer: open the new doc rendered (markdown preview) and confirm the § 1–§ 8 TOC collapses cleanly to one page

🤖 Generated with [Claude Code](https://claude.com/claude-code)