### PR TITLE
story-h2: promote drift-scan table-only findings to hard (exit 1)

### DIFF
--- a/docs/plans/story-h2.md
+++ b/docs/plans/story-h2.md
@@ -199,3 +199,16 @@ Phase 2 (P1 / P2 / P3) by `plan-reviewer` sub-agent on 2026-05-11 — 11 finding
 | — | R1, R2, R3, R7, R8, R11 — factual confirmations. | (no action) | Reviewer-confirmed compliant. |
 
 **Tally:** 7 adopted/clarified · 2 acknowledged · 0 rejected · 0 deferred. **DoR gate met.**
+
+## Phase 4 retro-check
+
+Phase 4 (P1 / P2 / P3 retro-check) by `code-reviewer` sub-agent on 2026-05-11 — 3 findings (0 P1, 0 P2, 3 P3 soft).
+
+| Phase | Finding | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+| P3 (soft) | R98 retro-only test's `fails if` comment uses the deleted identifier `hardFindings` as a label (`main() ignores a non-empty hard-findings list`). | fix-now | Renamed to `non-empty findings list` (Phase-4 refactor `2cecd75`). |
+| P3 (soft) | New `table-only` test missing `(Gherkin scenario N: …)` label for parity with the five pre-existing tests. | fix-now | Added `(Gherkin scenario h2-1: orphan § 8 row exits 1)`; tightened `fails if` phrasing to name the exit-code gate directly (Phase-4 refactor `2cecd75`). |
+| P3 (soft) | Clean-repo test description retains `(slice 10)` — a story-h1 internal slice reference. | acknowledged | Historically accurate — slice 10 of story-h1 is when R21 was codified. Renaming it would lose that pin. |
+| — | R1, R2, R3, R5, R6, R7, R8, R10, R12, R13, R21 — factual confirmations. | (no action) | Reviewer-confirmed compliant. |
+
+**Tally:** 2 fix-now · 1 acknowledged · 0 defer-issue · 0 rejected. **DoD gates 8 + 9 ready** pending retro authoring.

--- a/docs/plans/story-h2.md
+++ b/docs/plans/story-h2.md
@@ -1,0 +1,201 @@
+# Story h2 — Promote `table-only` drift to hard finding
+
+## Context
+
+**Why this change.** Story-h1 ([PR #115](https://github.com/xavierbriand/accounting/pull/115)) shipped `harness/drift-scan/` with a documented compromise: `table-only` findings (a § 8 row with no retro reference) exit 0 instead of 1. The reason was a chicken-and-egg — R21 was codified in § 8 by story-h1's slice 10, but the retro that mentions R21 was only authored at slice 12; promoting `table-only` to hard then would have made slice 10's verification step ("`tsx harness/drift-scan/drift-scan.ts` exits 0 on the live repo") unachievable. See [story-h1.md § Change](../retrospectives/story-h1.md) and the Phase-4 R2 finding.
+
+Story-h1 has now merged ([12a6c13](https://github.com/xavierbriand/accounting/commit/12a6c13)). Its retro is on main and references R21. Every R-tag in § 8 (R1..R21) now has an originating retro reference, so the precondition holds: promoting `table-only` to hard restores Check A's bidirectional invariant **without** breaking the live-repo run.
+
+Tracked at [#120](https://github.com/xavierbriand/accounting/issues/120). This story closes it.
+
+**Why now.** The compromise weakens the very invariant story-h1 shipped. Every additional retro authored under the soft regime is a place where a § 8 row could land without an originating retro and go unflagged. The fix is 1 LOC + a test + a README cleanup; the cost of leaving it is open-ended.
+
+**Maintenance sub-loop (§ 6.7) run 2026-05-11 pre-planning.** Following [docs/templates/maintenance-sub-loop.md](../templates/maintenance-sub-loop.md):
+
+- [x] **Working tree clean.** On worktree branch `claude/pedantic-kirch-ea8971`, rebased on `origin/main` at `12a6c13`.
+- [x] **Open PRs check (R19).** 4 open PRs: #118 (`docs(learning)` — application-layer comparison, unrelated tree), #122/#123/#124 (dependabot — no overlap with `harness/`). None touch drift-scan, CLAUDE.md § 8, or retrospectives.
+- [x] **Open issues / sibling work (R19).** #119 (drift-scan default-scope diff filter tests) and #120 (this story) are the only drift-scan-touching open issues. #119 is independent — separate test infrastructure. No conflict.
+- [x] **`origin/main` fetched.** `git fetch origin` returned the dependabot-branch listing only.
+- [x] **`npm audit --audit-level=high`** — to be run during sonnet-implementer's verification.
+- [x] **Proceed-to-planning.**
+
+## Story
+
+> As the maintainer of the drift-scan tooling, I want `table-only` findings (a § 8 row whose R-tag has no retro reference) to exit 1, so that Check A's bidirectional invariant is restored now that R21 has an originating retro on main.
+
+**FR coverage:** none (harness/process tooling, not product behaviour). **R2 production-code surface:** small but non-zero — one filter literal in `drift-scan.ts`, one paragraph in `harness/drift-scan/README.md`, one new subprocess test.
+
+**Epic coverage:** none — harness-engineering follow-up under [#94](https://github.com/xavierbriand/accounting/issues/94) umbrella. Out of scope of [docs/epics.md](../epics.md).
+
+## Selected solution
+
+### 1. `harness/drift-scan/drift-scan.ts` — promote `table-only` to hard
+
+Today:
+
+```ts
+const hardFindings = findings.filter(
+  (f) => f.kind === 'retro-only' || f.kind === 'missing-path',
+);
+process.exit(hardFindings.length > 0 ? 1 : 0);
+```
+
+Change to:
+
+```ts
+process.exit(findings.length > 0 ? 1 : 0);
+```
+
+Deleting the filter (not extending the kinds list) — once `table-only` is hard, every finding kind is hard, and the variable name `hardFindings` no longer carries information. The simpler form makes the invariant ("any finding fails the scan") legible at the call site. Verified with `grep -n hardFindings harness/drift-scan/drift-scan.ts` before editing — sole occurrence is at the filter site.
+
+### 2. `harness/drift-scan/README.md` — remove the soft/hard distinction
+
+Current § Exit codes:
+
+```
+- `0` — no **hard** findings.
+- `1` — one or more hard findings.
+
+A finding is **hard** (contributes to exit 1) when it represents drift between artefacts that should already be in sync: `retro-only` … and `missing-path` … A finding is **soft** (informational, does not affect exit code) for `table-only` … but do not gate CI.
+```
+
+Replace with:
+
+```
+- `0` — no findings.
+- `1` — one or more findings (any kind: `retro-only`, `table-only`, `missing-path`).
+```
+
+The "exit 1 on any drift" wording matches the original story-h1 plan § 1.3 output contract before the chicken-and-egg compromise.
+
+### 3. New subprocess test — `tests/drift-scan.integration.test.ts`
+
+Add a single test (**appended at the END of the existing `describe` block** so it runs after the existing tests — keeps `R97` injection in the `--json` test order-independent from the new R96 injection) that introduces a § 8 row whose R-tag has no retro reference and asserts the scanner exits 1 with that tag named on stderr.
+
+**Mechanism — temporary CLAUDE.md mutation with snapshot/restore.** The cleanest pattern given the existing test infrastructure (no `--claude-md=<path>` flag plumbed; adding one would expand scope). The test:
+
+1. Reads the current `CLAUDE.md` and stashes its content in a module-level variable `CLAUDE_MD_SNAPSHOT: string | null`.
+2. Appends one row `| R96 | drift-scan test orphan | [none](docs/retrospectives/none.md) |` to the end of the file (the section is the last in the file, so appending to EOF places the row inside the region per `extractSectionEightTags`'s "EOF terminates region" branch).
+3. Runs the scanner; asserts `status === 1` and stderr contains `R96` and the substring `table-only:`.
+4. Restores `CLAUDE.md` to the stashed original via a **second `afterEach`** (added alongside the existing `TEMP_RETRO_FILES` hook, not folded into it — keeps the new cleanup scoped to its own slice and avoids touching the existing hook's code).
+
+**Exact comment block for the new test:**
+
+```ts
+// fails if the hardFindings filter (or its successor) in drift-scan.ts
+// excludes table-only from the exit-1 gate. Mutates CLAUDE.md in place
+// and restores it via afterEach — if a hard crash leaks the mutation,
+// run `git checkout CLAUDE.md` to recover (the appended R96 row is
+// the only diff).
+```
+
+Cleanup is **mandatory and exception-safe** — if the test process crashes between mutate and restore, CLAUDE.md would be left in a corrupt state on disk and would leak into the next run / next commit. The `CLAUDE_MD_SNAPSHOT` variable is set **before** the mutating write, so the snapshot is always captured by the time `afterEach` runs. The `afterEach` resets the variable to `null` after restore so subsequent tests don't double-write. `fs.writeFileSync` in the hook is not wrapped in try/catch — per `docs/engineering-standards.md`, bare catches that swallow errors are forbidden; an unhandled throw in `afterEach` surfaces as a vitest hook error and is the correct failure mode (user recovers via `git checkout CLAUDE.md`).
+
+**Test-mechanism honesty (R7):** subprocess-tier, real fs, real `CLAUDE.md` (mutated and restored). Asserts the full pipeline: parser → composer → exit-code logic. No mocks.
+
+**Mock diversity (R8):** the existing `--json` integration test already asserts the discriminated-union shape for `table-only` entries. This new test asserts the exit-code path. Together they pin both the data shape and the gating behaviour.
+
+### 3a. Stale comment cleanup in the existing clean-repo test
+
+The clean-repo test at `harness/drift-scan/tests/drift-scan.integration.test.ts:57-67` carries two now-stale references that this story makes inaccurate:
+
+1. The block comment says `false positive in composeDrift's hard-findings filter` — `hardFindings` is the eliminated variable, not a name inside `composeDrift`. Rewrite the comment to name the actual current path: the exit-code gate in `drift-scan.ts` and `composeDrift` in `drift-parser.ts`.
+2. The comment says `Stderr is allowed to carry table-only informational findings (R21 today)` — this becomes false post-promotion. Rewrite to: clean repo means **no** drift of any kind on stderr (retro-only, missing-path, table-only).
+3. The assertions cover only `retro-only:` and `missing-path:`. Strengthen by adding `expect(result.stderr).not.toContain('table-only:')` — closes a regression gap where a future stray § 8 row would silently pass this test if the only assertion gap is on `table-only:`.
+
+Folded into **slice 3** (same slice as the production-code change) because the test whose semantics are inverted by the promotion belongs in the same diff. Without this cleanup the comment block becomes a misleading historical artefact and the new behaviour is under-asserted on the clean-repo path.
+
+### 4. CLAUDE.md update — no rule change
+
+This story does **not** add a new R-tag. R21's rule statement ("drift-scan enforces CLAUDE.md § 8 ↔ retro and plan ↔ source consistency at write/CI time; opt-out via `*(pending)*` marker") already covers bidirectional enforcement; promoting `table-only` is a behaviour-tightening within R21's scope, not a new rule. CLAUDE.md is untouched (except by Phase 4 if a finding lands there).
+
+## Production-code surface (R2)
+
+| Path | New/Modified | Layer | Purpose |
+| --- | --- | --- | --- |
+| `harness/drift-scan/drift-scan.ts` | modified | harness | Delete the `hardFindings` filter; gate exit code on `findings.length`. |
+| `harness/drift-scan/README.md` | modified | harness | Drop the soft/hard distinction paragraph; restore "exit 1 on any drift" wording. |
+| `harness/drift-scan/tests/drift-scan.integration.test.ts` | modified | harness | New subprocess test: orphan § 8 row exits 1. `afterEach` snapshot/restore for CLAUDE.md. |
+| `docs/plans/story-h2.md` | new | docs | This file. |
+| `docs/retrospectives/story-h2.md` | new | docs | Authored at the retro slice. |
+| `docs/status.d/2026-05-11-story-h2.md` | new | docs | Per R17, dropped at the retro slice. |
+
+**Type/signature/format changes outside this story:** none.
+
+**No new dependencies (R3 audit).** `harness/drift-scan/tests/drift-scan.integration.test.ts` already imports `vitest`, `node:child_process`, `node:fs`, `node:path`. No new imports needed for the snapshot/restore pattern (string in a closure + the existing `fs.writeFileSync`/`fs.readFileSync`).
+
+## Acceptance scenarios
+
+```gherkin
+Feature: table-only drift fails the scan
+
+  Scenario: § 8 row with no retro reference exits 1
+    Given CLAUDE.md § 8 contains an R96 row
+    And no retro file references R96
+    When I run `tsx harness/drift-scan/drift-scan.ts`
+    Then it exits 1
+    And the report names R96 and the table-only kind
+    fails if the `hardFindings` filter in `drift-scan.ts` excludes `table-only`, or the exit gate ignores a `table-only`-only findings list.
+
+  Scenario: clean repo still passes
+    Given every § 8 row has an originating retro reference
+    And no retro references an R-tag missing from § 8
+    When I run `tsx harness/drift-scan/drift-scan.ts`
+    Then it exits 0
+    fails if the new filter promotes false positives (e.g. counts a finding when the array is empty), or if Check A's bidirectional logic in `composeDrift` regresses.
+```
+
+The first scenario maps onto the new subprocess test in slice 2. The second scenario maps onto the existing clean-repo test in `drift-scan.integration.test.ts` (no change needed — it already asserts `status === 0` and stderr cleanliness; the change is that `table-only:` lines on the **live repo** would now also fail it, which on main today they do not).
+
+## Slice plan
+
+R13 envelope: 6–10 commits. This story sits at the **lower bound** with **4 body slices** + the preparatory plan commit + the retro commit. Justification: a single-behaviour change (one filter literal) with a single new test. The R9 trivial-inline carve-out (≤5 LOC, single file, pre-specified) almost applies but the change spans `drift-scan.ts` + README + a new test, so the formal phases run. Below R13's lower bound by 2 slices, accepted because the unit of behaviour change is genuinely small — conflating slices would either fold the test into the green commit (breaking the red→green pairing) or merge the README cleanup with the code change (mixing docs and behaviour).
+
+1. **`chore(docs): plan + P1/P2/P3 review (story-h2)`** — preparatory. Commits this plan file with the suggestion log filled after Phase 2. **Not counted in R13's body.**
+2. **`test(drift-scan): table-only finding contributes to exit 1 — failing`** *(red)*. Adds the new subprocess test with the `afterEach` snapshot/restore for CLAUDE.md. Fails today because `table-only` exits 0.
+3. **`feat(drift-scan): gate exit code on all findings — minimal green`**. Deletes the `hardFindings` filter; replaces `hardFindings.length > 0` with `findings.length > 0` at the `process.exit` call. Updates the stale clean-repo test block comment (§ 3a above) and adds the `not.toContain('table-only:')` assertion. The slice-2 test goes green; the existing clean-repo test stays green because every § 8 row on main has an originating retro reference.
+4. **`docs(harness): drop soft/hard distinction in drift-scan README`**. Rewrites § Exit codes to the simpler form. No behaviour change.
+5. **`chore(retro): write retrospective + status fragment (story-h2)`**. `docs/retrospectives/story-h2.md` + `docs/status.d/2026-05-11-story-h2.md`. Closes [#120](https://github.com/xavierbriand/accounting/issues/120) in the PR body so merge auto-closes it.
+
+**R11 empty-refactor slot.** Folded into slice 3 — deleting the filter *is* the structural simplification; no separate empty `refactor:` commit unless Phase 4 surfaces a real refactor. If Phase 4 is empty, the body stays at 4 commits (R13 lower-bound).
+
+## Risks & deferred items
+
+- **CLAUDE.md mutation leak.** If slice-2's test crashes between the file mutation and the `afterEach` restore, CLAUDE.md is left corrupt on disk. Mitigations: the `afterEach` uses the stashed string and a try/finally-equivalent vitest hook contract; the test asserts within a tight scope (3 lines between write and assertions); a fallback git-stash recovery is documented in the test comment. The same risk applies to the existing tempfile-based tests, but those create *new* files rather than mutating tracked files — the new test is the first to mutate CLAUDE.md in-place. **Considered alternative:** plumb a `--claude-md=<path>` flag through `drift-scan.ts` and write a temp CLAUDE.md to a scratch dir. Rejected: expands the production-code surface (new CLI flag, new arg-parsing path, doc updates) for a test affordance. Snapshot/restore is the smaller change.
+- **R-tag collision.** Using `R96` for the test row; if a future retro introduces R96, the test's invariant would conflict. R-tags advance monotonically (next is R22); R96 is outside the foreseeable allocation horizon. Same reasoning as the existing tests that use R97/R98/R99 for orphan injection.
+- **Test order interaction.** vitest runs tests in source order by default; the new test mutates CLAUDE.md *after* the existing tests have read it. The `afterEach` restore makes order-independence explicit. Verified by mental walk of vitest 3.x's hook semantics.
+
+## Verification plan
+
+1. `npm run lint && npm run build && npm test` — green. Product test count unchanged.
+2. `npm run test:harness` — green. New test count: +1 (5 → 6 integration tests; unit tests untouched).
+3. `npm run typecheck:harness` — green.
+4. `npx tsx harness/drift-scan/drift-scan.ts` on the live repo — exits 0. (Pre-condition: story-h1's retro mentioning R21 is on main — verified at planning time, [12a6c13](https://github.com/xavierbriand/accounting/commit/12a6c13).)
+5. **Negative-case rehearsal.** Manually run the integration test in isolation (`npm run test:harness -- -t 'table-only finding contributes'`); confirm it fails before slice 3 and passes after. Confirm CLAUDE.md is restored after each run via `git diff CLAUDE.md` returning empty.
+6. **CI gate confirmation.** Push the feature branch; observe the Run Harness Tests step picks up the new test and the Drift scan step exits 0.
+
+## DoR checklist
+
+- [x] Phase 1 (Plan): this document.
+- [x] Phase 2 (Critical review): 11 findings (6 P1, 1 P2, 4 P3). 7 adopted, 2 acknowledged, 0 deferred.
+- [ ] Draft PR with template sections 1–6 filled — pending (slice 1 commit + push + `gh pr create`).
+
+## Suggestion log
+
+Phase 2 (P1 / P2 / P3) by `plan-reviewer` sub-agent on 2026-05-11 — 11 findings (6 P1, 1 P2, 4 P3).
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+| P1 | Slice 3 commit subject (`include table-only in hardFindings`) contradicts the change (which deletes `hardFindings` entirely); misleads `git log` readers. | adopted | Renamed slice 3 to `feat(drift-scan): gate exit code on all findings — minimal green`. Accurate per R12. |
+| P1 | Existing clean-repo test's `fails if` comment references `composeDrift's hard-findings filter` — a construct eliminated by this story; will become stale. | adopted | Added § 3a; slice 3 rewrites the comment to name the actual current path (exit-code gate in `drift-scan.ts` + `composeDrift` in `drift-parser.ts`). |
+| P1 | Plan ambiguous on whether the CLAUDE.md restore is in the existing `afterEach` or a new second hook. | adopted (clarified) | § 3 now specifies a **second `afterEach`** hook, added alongside the existing `TEMP_RETRO_FILES` hook (not folded into it). Keeps cleanup scoped to the new slice. |
+| P1 | Comment text for git-stash recovery instruction not specified — Sonnet would invent it. | adopted (clarified) | § 3 now contains the exact comment block to write into the test, including the `git checkout CLAUDE.md` recovery hint. |
+| P1 | Test insertion position unspecified; if inserted before the `--json` test, R96 mutation could pollute the R97 test's run. | adopted (clarified) | § 3 now specifies: append at the **END** of the existing `describe` block. |
+| P1 / P2 | Existing clean-repo test's body comment `Stderr is allowed to carry table-only informational findings (R21 today)` is invalidated by this story's behaviour change; misleads future readers about the QA expectation. | adopted | § 3a; slice 3 rewrites the body comment AND adds `expect(result.stderr).not.toContain('table-only:')` to strengthen the assertion against the new behaviour. |
+| P3 | Slice 3 commit subject mismatch (R12). | adopted | Same as P1 finding 1 above. |
+| P3 | `fs.writeFileSync` in `afterEach` could throw; plan silent on try/catch. | acknowledged | Per `docs/engineering-standards.md`, bare catches swallowing errors are forbidden. Vitest's hook-error reporting is the correct failure mode; user recovers via `git checkout CLAUDE.md`. § 3 now explicitly states this design choice. |
+| P3 | Surface table doc-paths (`docs/retrospectives/story-h2.md`, `docs/status.d/2026-05-11-story-h2.md`) aren't matched by Check B (only `src/`, `tests/`, `harness/` prefixes). | acknowledged | Intentional scanner scope rule; no action. Documented here so a future reviewer doesn't wonder why doc paths are unlinted. |
+| P3 (soft) | `afterEach` structural ambiguity (single hook modified vs second hook added). | adopted | Same as P1 finding 3 above — second hook, added alongside the existing. |
+| — | R1, R2, R3, R7, R8, R11 — factual confirmations. | (no action) | Reviewer-confirmed compliant. |
+
+**Tally:** 7 adopted/clarified · 2 acknowledged · 0 rejected · 0 deferred. **DoR gate met.**

--- a/docs/retrospectives/story-h2.md
+++ b/docs/retrospectives/story-h2.md
@@ -1,0 +1,56 @@
+# Story h2 retrospective
+
+**PR:** https://github.com/xavierbriand/accounting/pull/125  **Closed:** 2026-05-11  **Closes:** [#120](https://github.com/xavierbriand/accounting/issues/120)
+
+Follow-up to [story-h1](./story-h1.md). Closes the documented chicken-and-egg compromise: `harness/drift-scan/drift-scan.ts` `table-only` findings (a CLAUDE.md § 8 row with no originating retro reference) are now hard — they contribute to exit 1, restoring Check A's bidirectional invariant. The compromise was unblocked the moment story-h1's retro (mentioning R21) merged to main; every R-tag R1..R21 now has an originating retro.
+
+## Keep
+
+- **Tracking #120 from story-h1's retro paid off.** Filing the cleanup ticket at the moment the compromise was made (rather than reopening the conversation later) meant the precondition was checkable from a single source: the issue's acceptance criteria. The maintenance sub-loop step "is there an existing issue that already plans this work?" returned a clean yes/no.
+- **R13 lower-bound (4 body slices) was the right call.** No fake refactor slot, no padding. The story is a 1-LOC behaviour change with a test and a README cleanup; conflating slices would have broken the failing→green pairing. Plan § Slice plan justified the bound explicitly so the Phase-2 reviewer didn't have to re-derive it.
+- **Plan-reviewer's "test insertion position" finding caught a real ordering hazard.** The new test mutates `CLAUDE.md`; the existing `--json` test mutates a retro file *and* asserts on the same scanner run's stderr. If the new test had been inserted before the `--json` test, the new orphan-row injection would have polluted the `--json` test's assertions. Phase 2 spotted this from the plan alone, before Sonnet wrote a single line. The kind of finding that's cheap to catch on paper and expensive once it ships.
+- **Second `afterEach` keeps cleanup hooks per-slice.** Folding the CLAUDE.md restore into the existing `TEMP_RETRO_FILES` hook would have touched code outside slice 2's intended diff. Two hooks is cleaner — vitest runs them all, the responsibilities don't overlap, and `git blame` keeps each story's cleanup attributable.
+- **Snapshot-then-mutate pattern stayed exception-safe without try/catch noise.** The `CLAUDE_MD_SNAPSHOT` variable is set on the line *before* the mutating write. If the write throws, the snapshot is captured; if the assertion throws, the afterEach still restores. No `try`/`finally` boilerplate, and the "no bare catches" rule in `engineering-standards.md` is honoured.
+
+## Change (what to do differently next time)
+
+- **R21 self-test arrived as an after-thought rather than a deliberate piece of the original story-h1 plan.** The bidirectional invariant of Check A was conceptually the spec from day one; story-h1 shipped only one direction (retro→table). Better future pattern: when a tool implements a "check X *and* Y" specification, sketch the test for both directions at planning time, even if one of them has a chicken-and-egg dependency. The plan would then surface the chicken-and-egg explicitly as a *deferred test*, not a *deferred behaviour*. Cost would have been one Gherkin scenario and a `// TODO: enable in cleanup PR` in story-h1; benefit would have been story-h2 reducing from a 5-commit PR to a 2-commit PR (uncomment + delete filter).
+- **The retro-only test's `// fails if` comment carried a stale identifier (`hardFindings`) post-merge of c3d83b0.** Phase 4 caught it; the same comment was *not* identified in plan § 3a (which scoped the cleanup to the clean-repo test only). **Lesson:** when a story deletes a named construct, plan § 3a-style cleanup audits should `grep -rn '<construct>'` across the test tree at planning time, not just inspect comments adjacent to assertions being modified. One grep, no follow-up Phase-4 nit. Worth considering as a soft hardening of R6 — "when deleting a production identifier, audit *all* `// fails if` comments that mention it."
+- **The "(Gherkin scenario N)" labeling convention isn't documented anywhere.** Five of six pre-existing tests carry it; the new test arrived without one because the plan didn't ask for one. Phase 4 caught the inconsistency. **Lesson:** if a convention is followed consistently enough that an inconsistency reads as a bug, write it down. Either: codify in `.claude/agents/sonnet-implementer.md` § Process under TDD rhythm, or accept it as soft taste and let Phase 4 catch the misses. The drift-scan tool itself doesn't enforce test-comment shape, so codification is the cheaper option.
+- **"slice 10" reference in the clean-repo test description aged.** It was historically accurate when written; it's still accurate today, but a reader unfamiliar with story-h1's slice numbering has to dig into git history to decode it. Test descriptions that reference internal story slice numbers are durable for the author and brittle for everyone else. **Lesson:** prefer descriptive test names ("clean repo passes once R20 and R21 are codified") over slice-numbered ones; let the commit log carry the "when" pin. Not a rule, but a soft taste worth keeping in mind on the next story that adds an integration test.
+
+## Code-review findings (Phase 4)
+
+`code-reviewer` sub-agent on 2026-05-11 — 3 findings (0 P1, 0 P2, 3 P3 soft). Tally: 2 fix-now · 1 acknowledged · 0 defer-issue · 0 rejected.
+
+| Phase | Finding | Resolution | Where |
+| --- | --- | --- | --- |
+| P3 (soft) | Retro-only test's `fails if` comment names deleted identifier `hardFindings`. | fix-now | Phase-4 refactor (`2cecd75`) — renamed to `non-empty findings list`. |
+| P3 (soft) | New `table-only` test missing `(Gherkin scenario N: …)` label for parity. | fix-now | Phase-4 refactor (`2cecd75`) — added the new scenario label; tightened `fails if` phrasing. |
+| P3 (soft) | Clean-repo test description retains `(slice 10)` — story-h1 internal slice reference. | acknowledged | Historically accurate; renaming would lose the pin. |
+
+## Try
+
+- **New rule candidate:** when a story deletes a named production identifier (function, variable, type), the implementation slice should include a `grep -rn <name>` of the test tree and update any `// fails if` comment that references the deleted name. Mark as `R22 *(pending)*` until a second story has data on whether it generalises. Pairs with story-h1's "R22 *(pending)*" candidate on the over-import trap — both are R6/R12-adjacent rule-of-thumb refinements that need 2-3 stories of corroboration before codification.
+- **New maintenance-sub-loop step candidate:** "If this story closes a `*(pending)*` or chicken-and-egg compromise from a prior retro, has the precondition been verified on `origin/main`?" Story-h2 implicitly did this (the plan's maintenance-sub-loop ran `git fetch origin` and the plan's § Context narrated the precondition), but the checklist didn't ask for it. Worth a single line in `docs/templates/maintenance-sub-loop.md` after the next 1-2 cleanup-PR follow-ups happen — too early to codify on this story's data alone.
+- **Curriculum delta candidate.** This PR exists *because* drift-scan exists — without it, the R21 chicken-and-egg compromise would have shipped silently and the soft regime would have persisted indefinitely. Worth a sentence in [docs/learning/harness-engineering.md § Module 1](../learning/harness-engineering.md) under "what Module 1 buys you": tooling that flags a compromise the moment it ships also makes the cleanup cheap *and* legible. Not in scope for this PR; flag for the next Module-1 documentation pass (likely when Module 2 starts).
+
+## Drift scan (mandatory)
+
+- [x] Did this story introduce contradictions between CLAUDE.md and any `docs/` file? **No.** CLAUDE.md is untouched. R21's rule statement still accurately describes drift-scan's behaviour ("enforces … consistency at write/CI time"); the *implementation* of that rule is what tightened, not the rule itself. `tsx harness/drift-scan/drift-scan.ts` exits 0 on `origin/main + this PR` (verified locally on the branch tip).
+- [x] If yes, reconciled in this PR? N/A — no contradictions.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| Delete `hardFindings` filter in `drift-scan.ts` | `harness/drift-scan/drift-scan.ts` | done (slice 3, commit `c3d83b0`) |
+| New subprocess test: orphan § 8 row exits 1 | `harness/drift-scan/tests/drift-scan.integration.test.ts` | done (slice 2, commit `829f837`) |
+| Clean-repo test: rewrite block comment + add `not.toContain('table-only:')` | `harness/drift-scan/tests/drift-scan.integration.test.ts` | done (slice 3, commit `c3d83b0`) |
+| Drop soft/hard distinction from drift-scan README | `harness/drift-scan/README.md` | done (slice 4, commit `4511fd1`) |
+| Phase-4 fix-now (retro-only test comment + Gherkin label on new test) | `harness/drift-scan/tests/drift-scan.integration.test.ts` | done (Phase-4 refactor, commit `2cecd75`) |
+| Close [#120](https://github.com/xavierbriand/accounting/issues/120) | PR body `Closes #120` | done (auto-close on merge) |
+| Status fragment | `docs/status.d/2026-05-11-story-h2.md` | done (slice 5, this commit) |
+| Rule-of-thumb: `grep -rn <name>` audit when deleting a production identifier | next process-touching PR — mark `R22 *(pending)*` until data | open |
+| Maintenance-sub-loop step: verify precondition on `origin/main` for cleanup PRs | future retro observation | open |
+| Curriculum delta: Module 1 narrative on "tool that flags its own compromises" | next Module-1 doc pass | open |

--- a/docs/status.d/2026-05-11-story-h2.md
+++ b/docs/status.d/2026-05-11-story-h2.md
@@ -1,0 +1,8 @@
+---
+date: 2026-05-11
+story: h2
+pr: 125
+epic: harness-engineering
+---
+
+story-h2 merged (#125). Cleanup PR for story-h1's documented `table-only`-as-soft compromise: `harness/drift-scan/drift-scan.ts` now exits 1 on any drift (retro-only, table-only, or missing-path), restoring Check A's bidirectional invariant. The chicken-and-egg dissolved the moment story-h1's retro merged to main and references R21 — every § 8 row R1..R21 now has an originating retro. One-LOC production change (delete the `hardFindings` filter; gate `process.exit` on `findings.length`) + a new subprocess test that injects an orphan § 8 row and asserts exit 1, with second `afterEach` snapshot/restore for CLAUDE.md. README § Exit codes simplified to drop the soft/hard paragraph. Closes [#120](https://github.com/xavierbriand/accounting/issues/120).

--- a/harness/drift-scan/README.md
+++ b/harness/drift-scan/README.md
@@ -21,10 +21,8 @@ npx tsx harness/drift-scan/drift-scan.ts --json
 
 ## Exit codes
 
-- `0` — no **hard** findings.
-- `1` — one or more hard findings.
-
-A finding is **hard** (contributes to exit 1) when it represents drift between artefacts that should already be in sync: `retro-only` (a retro mentions an R-tag with no § 8 row) and `missing-path` (a plan names a file that no longer exists). A finding is **soft** (informational, does not affect exit code) for `table-only` (a § 8 row with no retro reference yet — common during the slice between codifying a new rule and authoring its retro). Soft findings are reported on stderr in human mode and included in the `--json` array, but do not gate CI.
+- `0` — no findings.
+- `1` — one or more findings (any kind: `retro-only`, `table-only`, `missing-path`).
 
 ## Output
 

--- a/harness/drift-scan/drift-scan.ts
+++ b/harness/drift-scan/drift-scan.ts
@@ -129,10 +129,7 @@ function main(): void {
     process.stderr.write(formatHumanReport(findings) + '\n');
   }
 
-  const hardFindings = findings.filter(
-    (f) => f.kind === 'retro-only' || f.kind === 'missing-path',
-  );
-  process.exit(hardFindings.length > 0 ? 1 : 0);
+  process.exit(findings.length > 0 ? 1 : 0);
 }
 
 main();

--- a/harness/drift-scan/tests/drift-scan.integration.test.ts
+++ b/harness/drift-scan/tests/drift-scan.integration.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 
 describe('drift-scan integration', () => {
   // fails if extractRetroTags skips the unbacked tag, or composeDrift fails to
-  // surface a retro-only set member, or main() ignores a non-empty hard-findings
+  // surface a retro-only set member, or main() ignores a non-empty findings
   // list (Gherkin scenario 2: retro references an undocumented rule).
   it('exits 1 and names R98 when a retro references R98 without a marker', () => {
     const retroFile = tempRetroPath('story-test-r98.md');
@@ -138,11 +138,11 @@ describe('drift-scan integration', () => {
     expect(r97Finding?.['kind']).toBe('retro-only');
   });
 
-  // fails if the hardFindings filter (or its successor) in drift-scan.ts
-  // excludes table-only from the exit-1 gate. Mutates CLAUDE.md in place
-  // and restores it via afterEach — if a hard crash leaks the mutation,
-  // run `git checkout CLAUDE.md` to recover (the appended R96 row is
-  // the only diff).
+  // fails if the exit-code gate in drift-scan.ts excludes table-only from
+  // the exit-1 condition. Mutates CLAUDE.md in place and restores it via
+  // afterEach — if a hard crash leaks the mutation, run
+  // `git checkout CLAUDE.md` to recover (the appended R96 row is the only
+  // diff). (Gherkin scenario h2-1: orphan § 8 row exits 1.)
   it('table-only finding contributes to exit 1', () => {
     const claudeMdPath = path.join(REPO_ROOT, 'CLAUDE.md');
     CLAUDE_MD_SNAPSHOT = fs.readFileSync(claudeMdPath, 'utf8');

--- a/harness/drift-scan/tests/drift-scan.integration.test.ts
+++ b/harness/drift-scan/tests/drift-scan.integration.test.ts
@@ -18,12 +18,20 @@ function tempRetroPath(name: string): string {
 }
 
 const TEMP_RETRO_FILES: string[] = [];
+let CLAUDE_MD_SNAPSHOT: string | null = null;
 
 afterEach(() => {
   for (const f of TEMP_RETRO_FILES.splice(0)) {
     if (fs.existsSync(f)) {
       fs.unlinkSync(f);
     }
+  }
+});
+
+afterEach(() => {
+  if (CLAUDE_MD_SNAPSHOT !== null) {
+    fs.writeFileSync(path.join(REPO_ROOT, 'CLAUDE.md'), CLAUDE_MD_SNAPSHOT, 'utf8');
+    CLAUDE_MD_SNAPSHOT = null;
   }
 });
 
@@ -126,5 +134,25 @@ describe('drift-scan integration', () => {
     );
     expect(r97Finding).toBeDefined();
     expect(r97Finding?.['kind']).toBe('retro-only');
+  });
+
+  // fails if the hardFindings filter (or its successor) in drift-scan.ts
+  // excludes table-only from the exit-1 gate. Mutates CLAUDE.md in place
+  // and restores it via afterEach — if a hard crash leaks the mutation,
+  // run `git checkout CLAUDE.md` to recover (the appended R96 row is
+  // the only diff).
+  it('table-only finding contributes to exit 1', () => {
+    const claudeMdPath = path.join(REPO_ROOT, 'CLAUDE.md');
+    CLAUDE_MD_SNAPSHOT = fs.readFileSync(claudeMdPath, 'utf8');
+    fs.writeFileSync(
+      claudeMdPath,
+      CLAUDE_MD_SNAPSHOT + '\n| R96 | drift-scan test orphan | [none](docs/retrospectives/none.md) |\n',
+      'utf8',
+    );
+
+    const result = runScanner();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('R96');
+    expect(result.stderr).toContain('table-only:');
   });
 });

--- a/harness/drift-scan/tests/drift-scan.integration.test.ts
+++ b/harness/drift-scan/tests/drift-scan.integration.test.ts
@@ -63,15 +63,17 @@ describe('drift-scan integration', () => {
   });
 
   // fails if Check A or Check B mistakenly classify a clean state as drift
-  // (false positive in composeDrift's hard-findings filter or scanPlanPaths's
-  // fs probe). Stderr is allowed to carry table-only informational findings
-  // (R21 today) but must not contain retro-only/missing-path lines.
+  // (false positive in the exit-code gate in drift-scan.ts or composeDrift
+  // in drift-parser.ts). A clean repo has no drift of any kind on stderr
+  // (retro-only, missing-path, or table-only — every § 8 row has an
+  // originating retro reference on main).
   // (Gherkin scenario 1: clean repo passes.)
   it('clean repo exits 0 — passes after R20 and R21 are codified (slice 10)', () => {
     const result = runScanner();
     expect(result.status).toBe(0);
     expect(result.stderr).not.toContain('retro-only:');
     expect(result.stderr).not.toContain('missing-path:');
+    expect(result.stderr).not.toContain('table-only:');
   });
 
   // fails if --all flag handling in main() does not bypass the diff-scope


### PR DESCRIPTION
## 1. Story

[Story h2](docs/plans/story-h2.md) — closes [#120](https://github.com/xavierbriand/accounting/issues/120). Promote `harness/drift-scan/drift-scan.ts` `table-only` findings (a § 8 row with no retro reference) from soft (exit 0) to hard (exit 1). Follow-up to [story-h1 (#115)](https://github.com/xavierbriand/accounting/pull/115).

## 2. Intent

Story-h1 shipped drift-scan with a documented compromise: `table-only` findings exit 0 because R21 (the rule that drift-scan codifies) was added to § 8 *before* the retro that originates it. Once story-h1's retro merged to main, the chicken-and-egg dissolved — every § 8 row R1..R21 now has an originating retro reference. This story restores Check A's bidirectional invariant by promoting `table-only` to a hard finding.

## 3. Alternatives considered

- **Extend the `hardFindings` kinds list to include `'table-only'`.** Set aside: once table-only is hard, every kind is hard; the `hardFindings` variable no longer carries information. Deleting the filter is cleaner.
- **Plumb a `--claude-md=<path>` flag through `drift-scan.ts` so the new test can write a scratch CLAUDE.md.** Set aside: expands the production-code surface (new CLI flag, new arg-parsing path, doc updates) just to avoid a snapshot/restore pattern that already works elsewhere in the test suite.
- **Defer the README cleanup to a separate doc-only PR.** Set aside: splitting docs from the behaviour change that invalidates them creates a window where the README contradicts the code.

## 4. Selected solution & rationale

Three changes:
1. `harness/drift-scan/drift-scan.ts` — delete the `hardFindings` filter; gate `process.exit` on `findings.length > 0`. Net 3-line deletion + 1-line update.
2. `harness/drift-scan/README.md` § Exit codes — drop the soft/hard distinction paragraph; restore "exit 1 on any drift" wording.
3. `harness/drift-scan/tests/drift-scan.integration.test.ts` — new subprocess test that mutates `CLAUDE.md` to inject an orphan R96 row and asserts exit 1 + stderr names R96; second `afterEach` restores CLAUDE.md. Existing clean-repo test gains a `not.toContain('table-only:')` assertion and an updated comment block.

Rationale: smallest possible diff that restores the invariant. R9 (≤5 LOC, single file, pre-specified) almost applies but the change touches 3 files so the formal phases run.

## 5. Gherkin scenarios

See [docs/plans/story-h2.md § Acceptance scenarios](docs/plans/story-h2.md).

```gherkin
Feature: table-only drift fails the scan

  Scenario: § 8 row with no retro reference exits 1
    Given CLAUDE.md § 8 contains an R96 row
    And no retro file references R96
    When I run `tsx harness/drift-scan/drift-scan.ts`
    Then it exits 1
    And the report names R96 and the table-only kind

  Scenario: clean repo still passes
    Given every § 8 row has an originating retro reference
    And no retro references an R-tag missing from § 8
    When I run `tsx harness/drift-scan/drift-scan.ts`
    Then it exits 0
```

## 6. Plan for Sonnet

Full plan: [docs/plans/story-h2.md](docs/plans/story-h2.md).

Slice plan (R13 lower-bound, 4 body slices + preparatory plan commit + retro):

1. `chore(docs): plan + P1/P2/P3 review (story-h2)` — preparatory.
2. `test(drift-scan): table-only finding contributes to exit 1 — failing` — adds the new subprocess test with second `afterEach` for CLAUDE.md snapshot/restore.
3. `feat(drift-scan): gate exit code on all findings — minimal green` — deletes `hardFindings` filter; updates stale clean-repo test comment; adds `not.toContain('table-only:')` assertion.
4. `docs(harness): drop soft/hard distinction in drift-scan README` — README § Exit codes cleanup.
5. `chore(retro): write retrospective + status fragment (story-h2)` — retro + status.d fragment.

Phase-4 refactor (commit `2cecd75`) — folded R6 nits identified by code-reviewer (stale `hardFindings` in retro-only test's `fails if` comment; missing `(Gherkin scenario h2-1: …)` label on the new test).

## 7. Suggestion log

Phase 2 by `plan-reviewer` on 2026-05-11 — 11 findings (6 P1, 1 P2, 4 P3). Tally: 7 adopted/clarified · 2 acknowledged · 0 rejected · 0 deferred.

Phase 4 by `code-reviewer` on 2026-05-11 — 3 findings (0 P1, 0 P2, 3 P3 soft). Tally: 2 fix-now · 1 acknowledged · 0 defer-issue · 0 rejected.

Full tables in [docs/plans/story-h2.md § Suggestion log](docs/plans/story-h2.md) and [docs/plans/story-h2.md § Phase 4 retro-check](docs/plans/story-h2.md).

## 8. Sonnet's learnings

### What was built

The two Gherkin scenarios from plan § acceptance now pass. The new subprocess test (`table-only finding contributes to exit 1`) mutates CLAUDE.md in place with an orphan R96 row, runs the scanner via `spawnSync`, and asserts `status === 1` with `R96` and `table-only:` on stderr. A module-level `CLAUDE_MD_SNAPSHOT` variable and a second `afterEach` hook snapshot/restore CLAUDE.md safely. The production change is a 1-LOC deletion in `harness/drift-scan/drift-scan.ts`: the `hardFindings` filter block is removed and `process.exit` now gates on `findings.length > 0`. The existing clean-repo test's stale comment was rewritten to name the actual code paths and a `not.toContain('table-only:')` assertion was added. The README `## Exit codes` section was simplified to drop the soft/hard paragraph.

### Red → green sequence

- `table-only finding contributes to exit 1` · `829f837` · proved `process.exit` gates on `hardFindings` (exits 0 for table-only), causing the status assertion to fail as expected.
- `feat(drift-scan): gate exit code on all findings` (delete `hardFindings` filter) · `c3d83b0` · turned the new test green; clean-repo and all existing tests remained green.

### Deviations from plan

None.

### Unknowns encountered

None. The plan was complete and unambiguous.

### Proposed follow-ups

- Issue [#119](https://github.com/xavierbriand/accounting/issues/119) (drift-scan default-scope diff filter tests) is still open and independent — separate test infrastructure, not touched here.

### Files touched

- `harness/drift-scan/drift-scan.ts` — deleted `hardFindings` filter block; changed `process.exit` to gate on `findings.length > 0`.
- `harness/drift-scan/tests/drift-scan.integration.test.ts` — added `CLAUDE_MD_SNAPSHOT` variable, second `afterEach` restore hook, new `table-only finding contributes to exit 1` test at end of `describe` block; rewrote stale clean-repo block comment; added `not.toContain('table-only:')` assertion.
- `harness/drift-scan/README.md` — replaced the `## Exit codes` section with the 2-bullet simpler form dropping the soft/hard distinction paragraph.

## 9. Retrospective

- **Keep:** R13 lower-bound (4 body slices) was the right call — no fake refactor slot, no padding; conflating slices would have broken the failing→green pairing. Plan-reviewer's "test insertion position" finding caught a real ordering hazard from the plan alone, before Sonnet wrote a line.
- **Change:** the bidirectional invariant of Check A was conceptually the spec on day one of story-h1; surfacing the chicken-and-egg as a *deferred test* rather than a *deferred behaviour* would have reduced story-h2 from a 5-commit PR to a 2-commit PR. Also: when deleting a named production identifier, run `grep -rn <name>` across the test tree at planning time, not just inspect comments adjacent to assertions being modified.
- **Try:** soft hardening of R6 — "when a story deletes a production identifier, audit *all* `// fails if` comments that mention it." Marked as `R22 *(pending)*` candidate alongside story-h1's "over-import trap" candidate; needs 2-3 stories of corroboration.

Full retrospective: [docs/retrospectives/story-h2.md](docs/retrospectives/story-h2.md).

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-h2.md`
- [x] All suggestion-log items resolved (no blank `Resolution` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)