### PR TITLE
chore(docs): story-maint-18 — story-id uniqueness check in maintenance sub-loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,3 +165,4 @@ New retro rules MUST add a row here in the same PR; prose references the tag. Dr
 | R19 | Maintenance sub-loop checks open/draft PRs **and** issues for sibling-work overlap before opening a new plan | [story-maint-16](docs/retrospectives/story-maint-16.md) |
 | R20 | Empty `feat:` slices retitle to `chore(workflow): empty slice — TDD rhythm note <reason>` (R11 covers `refactor:` only) | [story-D](docs/retrospectives/story-D.md) |
 | R21 | Drift-scan enforces CLAUDE.md § 8 ↔ retro and plan ↔ source consistency at write/CI time; opt-out via `*(pending)*` marker | [story-h1](docs/retrospectives/story-h1.md) |
+| R23 | Maintenance sub-loop checks story-id uniqueness (`docs/plans/`, `docs/retrospectives/`, `docs/status.d/` on `origin/main`, plus open PR branch names) before a new story id is chosen | [story-maint-18](docs/retrospectives/story-maint-18.md) |

--- a/docs/plans/story-maint-18.md
+++ b/docs/plans/story-maint-18.md
@@ -1,0 +1,86 @@
+# Story maint-18 — Story-id uniqueness check in the maintenance sub-loop
+
+## Context
+
+Story `story-h2` collided with an already-merged story of the same id (the drift-scan hard-exit cleanup, [PR #125](https://github.com/xavierbriand/accounting/pull/125), closes [#120](https://github.com/xavierbriand/accounting/issues/120)). A second PR ([#130](https://github.com/xavierbriand/accounting/pull/130), branch `story-h2`) reused the id for unrelated work (Harness Module 2), silently overwriting `docs/plans/story-h2.md` and `docs/retrospectives/story-h2.md` in place — erasing the merged story's open action items from the current docs tree (recoverable via git history, but no longer discoverable by reading current docs).
+
+Fixing it required renaming the branch (`story-h2` → `story-h3`), which had an unwanted side effect: GitHub auto-closed the open PR because its head ref disappeared, and it could not be reopened — a new PR ([#138](https://github.com/xavierbriand/accounting/pull/138), merged) had to be opened in its place.
+
+**Root cause.** [docs/templates/maintenance-sub-loop.md](../templates/maintenance-sub-loop.md) — the checklist run before opening every new story plan (CLAUDE.md § 6.7) — has no step that checks whether the chosen story id is already taken. The existing "Sibling work check" bullet looks at open PRs/issues for *scope* overlap, not at whether `docs/plans/story-<id>.md` or `docs/retrospectives/story-<id>.md` already exists on `main`. This is especially easy to trip on the harness-engineering track, where story ids (`h1`, `h2`, ...) are assigned informally and a curriculum module number doesn't necessarily match the next free sequential story id (as happened here — `story-h2` was consumed by an off-curriculum cleanup, not "Module 2").
+
+Tracked by: [#139](https://github.com/xavierbriand/accounting/issues/139). This story closes it.
+
+Pure process/docs change — no production code, no behaviour change. R16 collapse applies.
+
+**Maintenance sub-loop (§ 6.7) run 2026-07-02 pre-planning** — copy-pasted from [docs/templates/maintenance-sub-loop.md](../templates/maintenance-sub-loop.md):
+
+- [x] **Sibling work check.** `gh issue list --state open --limit 50` — 31 open issues, all either `deferred-suggestion` items scoped to their originating stories, harness-curriculum modules (#94–#100, #111), or unrelated product bugs/enhancements (#93, #103, #105, #106). None overlaps this story's scope (maintenance-sub-loop checklist). `gh pr list --state open` — at the time of this check, the only open PRs are Dependabot bumps (routine, being merged directly per the checklist's own "Open PRs" bullet — no scope overlap) and #141 (this session's `npm audit fix`, also process/tooling-only, no file overlap with `docs/templates/maintenance-sub-loop.md`).
+- [x] **Working tree clean.** `git status` clean; `main` up to date with `origin/main` (`d9a54cb` at last fetch, advancing further as sibling Dependabot merges land — none touch `docs/`).
+- [x] **Open issues.** Reviewed above; #140 (npm audit) is being fixed in parallel by PR #141, unrelated file surface.
+- [x] **Open PRs.** Dependabot patch/minor bumps — merging directly per policy (in progress this session). #141 — lockfile-only `npm audit fix`, no overlap.
+- [x] **`npm audit --audit-level=high`** — found 3 vulnerabilities (1 high: vite; 2 moderate: js-yaml, brace-expansion), all devDependency-transitive. Filed [#140](https://github.com/xavierbriand/accounting/issues/140) and fixed via [#141](https://github.com/xavierbriand/accounting/pull/141) (lockfile-only, `npm audit fix` with no `--force`, 689/689 tests green) ahead of this story per policy.
+- [x] **Proceed-to-planning.**
+
+## Story
+
+> As the agent running Phase 1 (Plan) for a new story, I want the maintenance sub-loop to mechanically check whether my chosen story id already has a plan/retro file on `main`, so that I never silently overwrite a merged story's docs by reusing its id — the exact failure that shipped as `story-h2` twice and cost a closed-and-reopened PR to fix.
+
+No FR coverage (process/workflow fix). Targets [docs/templates/maintenance-sub-loop.md](../templates/maintenance-sub-loop.md) (the runnable checklist) — CLAUDE.md § 6.7 states the *concept* ("run the maintenance sub-loop checklist") and does not need to change, since the concept is unchanged; only the checklist's *steps* gain one new bullet, which is explicitly the template's own division of responsibility ("If the *steps* change... update this file").
+
+## Selected solution
+
+Add a new checklist bullet to [docs/templates/maintenance-sub-loop.md](../templates/maintenance-sub-loop.md), placed immediately after "Sibling work check" (both bullets are, at heart, "does this collide with something that already exists" — grouping them keeps the checklist's collision-avoidance checks together):
+
+```markdown
+- [ ] **Story-id uniqueness.** Before picking a story id, confirm no `docs/plans/story-<id>.md` or `docs/retrospectives/story-<id>.md` already exists on `origin/main`: `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ | grep -i "story-<id>\.md"`. Also check open PR branch names (`gh pr list --state open --json headRefName`) for the same id in flight. If taken, pick the next free id before branching. Curriculum-numbered tracks (e.g. `story-h<N>`) are especially exposed — a module number does not guarantee its id is unused; off-curriculum cleanups can consume ids out of sequence.
+```
+
+`git ls-tree -r origin/main` (rather than a local `ls docs/plans/`) is deliberate: it checks the authoritative remote state directly, so it works correctly even from a fresh worktree that hasn't fetched yet, and it won't be fooled by a stale local checkout.
+
+### Why not a script/lint instead of a manual checklist step
+
+`harness/drift-scan/drift-scan.ts` already runs mechanically at write-time and in CI for CLAUDE.md § 8 ↔ retro drift and plan ↔ source drift. Story-id collision is a different class of problem: it must be caught **before a branch is created**, not after a plan file is committed — by the time a drift-scan-style check could run in CI, the branch (and its confusing history) already exists. A pre-planning checklist step is the correct enforcement point given the current tooling; automating it further (e.g. a `new-story-preflight` skill step, since [.claude/commands/new-story-preflight.md](../../.claude/commands/new-story-preflight.md) already runs the maintenance sub-loop per its own checklist item 1) is a natural follow-up but out of scope for this story — noted under Risks & deferred items.
+
+## Production-code surface (R2)
+
+None. Single file changed: `docs/templates/maintenance-sub-loop.md` (docs/process only, no `src/`, no `harness/`, no schema/migration).
+
+## Gherkin acceptance scenarios
+
+None — this is a checklist/process document, not executable code. Verification is by inspection (see § Verification plan).
+
+## Slice plan (R16: target 4 commits)
+
+Preparatory (before Phase 3; not counted per R16):
+- **P0:** `chore(docs): story-maint-18 plan + P1/P2/P3 review`
+
+Change-body commits:
+1. **C1:** `chore(docs): add story-id uniqueness check to maintenance sub-loop [story-maint-18]`
+   Files: `docs/templates/maintenance-sub-loop.md`
+2. **C2:** `refactor: empty slot — process-only checklist addition [story-maint-18]`
+   Per R11 — no code refactor surface in a single-bullet doc change.
+3. **C3:** `chore(retro): story-maint-18 retrospective + status fragment [story-maint-18]`
+   Files: `docs/retrospectives/story-maint-18.md`, `docs/status.d/2026-07-02-story-maint-18.md`
+
+**Total: 2 change-body + 1 retro = 3 commits + empty refactor slot = 4.** Within R16 (4 commits for zero-behaviour-change stories).
+
+## Risks & deferred items
+
+| Risk | Mitigation |
+|------|-----------|
+| Checklist step is manual — relies on the planning agent actually running the `git ls-tree` command | Same enforcement model as every other maintenance sub-loop bullet today (all manual, pre-planning). Acceptable; if repeated misses occur, escalate to automation (see below). |
+| `git ls-tree -r origin/main` requires a fetched `origin/main` ref | Already a precondition of the "Working tree clean" bullet, which runs first in the checklist. |
+| True automation (CI or a `new-story-preflight` skill assertion) would catch this even if the manual step is skipped | Deferred — out of scope for this story. File a follow-up issue if a second story-id collision occurs (this story is the first data point; per this repo's pattern of requiring 2-3 occurrences before codifying further tooling, one incident does not yet justify a script). |
+
+## Verification plan
+
+1. `docs/templates/maintenance-sub-loop.md` contains the new "Story-id uniqueness" bullet, positioned after "Sibling work check".
+2. Manual dry-run: `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ | grep -i "story-h2\.md"` returns the real (merged) `story-h2` plan/retro paths — demonstrating the check would have caught the original collision had it existed at the time.
+3. `npx tsx harness/drift-scan/drift-scan.ts --all` — exit 0 (no CLAUDE.md § 8 ↔ retro drift introduced; CLAUDE.md itself is untouched).
+4. `npm run lint && npm run build && npm test` — green (no production surface touched; sanity check only).
+
+## DoR checklist
+
+- [x] Phase 1 (Plan): complete in this document.
+- [ ] Phase 2 (Critical review — plan-reviewer + sibling-overlap in parallel): pending.
+- [ ] Draft PR with template sections 1–6 filled. **Next action.**

--- a/docs/plans/story-maint-18.md
+++ b/docs/plans/story-maint-18.md
@@ -32,7 +32,9 @@ No FR coverage (process/workflow fix). Targets [docs/templates/maintenance-sub-l
 Add a new checklist bullet to [docs/templates/maintenance-sub-loop.md](../templates/maintenance-sub-loop.md), placed immediately after "Sibling work check" (both bullets are, at heart, "does this collide with something that already exists" — grouping them keeps the checklist's collision-avoidance checks together):
 
 ```markdown
-- [ ] **Story-id uniqueness.** Before picking a story id, confirm no `docs/plans/story-<id>.md` or `docs/retrospectives/story-<id>.md` already exists on `origin/main`: `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ | grep -i "story-<id>\.md"`. Also check open PR branch names (`gh pr list --state open --json headRefName`) for the same id in flight. If taken, pick the next free id before branching. Curriculum-numbered tracks (e.g. `story-h<N>`) are especially exposed — a module number does not guarantee its id is unused; off-curriculum cleanups can consume ids out of sequence.
+- [ ] **Story-id uniqueness.** Before picking a story id (e.g. `h3`), confirm no `docs/plans/`, `docs/retrospectives/`, or `docs/status.d/` file for that id already exists on `origin/main`:
+      `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ docs/status.d/ | grep -i "story-h3"`
+      Also check open PR branch names (`gh pr list --state open --json headRefName`) for the same id in flight. If taken, pick the next free id before branching. Curriculum-numbered tracks (e.g. `story-h<N>`) are especially exposed — a module number does not guarantee its id is unused; off-curriculum cleanups can consume ids out of sequence.
 ```
 
 `git ls-tree -r origin/main` (rather than a local `ls docs/plans/`) is deliberate: it checks the authoritative remote state directly, so it works correctly even from a fresh worktree that hasn't fetched yet, and it won't be fooled by a stale local checkout.
@@ -62,7 +64,7 @@ Change-body commits:
 3. **C3:** `chore(retro): story-maint-18 retrospective + status fragment [story-maint-18]`
    Files: `docs/retrospectives/story-maint-18.md`, `docs/status.d/2026-07-02-story-maint-18.md`
 
-**Total: 2 change-body + 1 retro = 3 commits + empty refactor slot = 4.** Within R16 (4 commits for zero-behaviour-change stories).
+**Total: 3 listed commits (C1 change + C2 empty refactor slot + C3 retro) = 4 change-body commits under R16's own count** (R16 counts the empty refactor slot as one of the 4). Within R16 (4 commits for zero-behaviour-change stories).
 
 ## Risks & deferred items
 
@@ -79,8 +81,24 @@ Change-body commits:
 3. `npx tsx harness/drift-scan/drift-scan.ts --all` — exit 0 (no CLAUDE.md § 8 ↔ retro drift introduced; CLAUDE.md itself is untouched).
 4. `npm run lint && npm run build && npm test` — green (no production surface touched; sanity check only).
 
+## Suggestion log
+
+Phase 2 — `plan-reviewer` + `sibling-overlap` in parallel, 2026-07-02.
+
+| # | Finding | Tag | Resolution |
+|---|---------|-----|------------|
+| 1 | New checklist bullet's grep scope covered `docs/plans/` + `docs/retrospectives/` but not `docs/status.d/`, even though status fragments are also keyed by story id | ADOPT | Extended the bullet's `git ls-tree` command to include `docs/status.d/` |
+| 2 | Slice-plan "Total" line's arithmetic ("2 change-body + 1 retro = 3 commits + empty refactor slot = 4") reads as self-inconsistent against R16's own phrasing, which counts the empty refactor slot as one of the 4 | ADOPT | Reworded to match R16's counting convention |
+| 3 | Example command uses a literal `<id>` placeholder, not directly copy-pasteable unlike some other checklist bullets | ADOPT | Reworded to show `h3` as a concrete example id inline, with the demonstrated grep pattern |
+| 4 | Verification plan step 2 is a one-time manual demonstration against a past incident, not a repeatable automated regression check — nothing stops the new bullet from being silently weakened or deleted later | ACKNOWLEDGE | Plan's own "Why not a script/lint" section already discusses and declines automation for this story, deferring to a follow-up if a second collision occurs; consistent with this repo's "wait for 2-3 data points" pattern for codifying tooling |
+| 5 | Deviation from issue #139's literally-proposed `ls docs/plans/` command in favor of `git ls-tree -r origin/main` | ACKNOWLEDGE | Plan already justifies the deviation (works from a fresh/unfetched worktree, checks authoritative remote state) — no change needed |
+| 6 | DoR checklist line said "Phase 2 ... pending" at review time | ACKNOWLEDGE | Non-issue — both plan-reviewer and sibling-overlap ran in parallel as CLAUDE.md § 6.1 phase 2 requires; checklist updated below |
+| 7 | Sibling-overlap audit: no overlapping open PR/issue found | ACKNOWLEDGE | Clean — nothing to resolve |
+
+**Tally:** 3 adopted / 4 acknowledged / 0 deferred / 0 rejected. DoR gate met — no un-tagged suggestions.
+
 ## DoR checklist
 
 - [x] Phase 1 (Plan): complete in this document.
-- [ ] Phase 2 (Critical review — plan-reviewer + sibling-overlap in parallel): pending.
-- [ ] Draft PR with template sections 1–6 filled. **Next action.**
+- [x] Phase 2 (Critical review — plan-reviewer + sibling-overlap in parallel): complete 2026-07-02; findings triaged above.
+- [x] Draft PR with template sections 1–6 filled — [#142](https://github.com/xavierbriand/accounting/pull/142).

--- a/docs/plans/story-maint-18.md
+++ b/docs/plans/story-maint-18.md
@@ -32,8 +32,8 @@ No FR coverage (process/workflow fix). Targets [docs/templates/maintenance-sub-l
 Add a new checklist bullet to [docs/templates/maintenance-sub-loop.md](../templates/maintenance-sub-loop.md), placed immediately after "Sibling work check" (both bullets are, at heart, "does this collide with something that already exists" — grouping them keeps the checklist's collision-avoidance checks together):
 
 ```markdown
-- [ ] **Story-id uniqueness.** Before picking a story id (e.g. `h3`), confirm no `docs/plans/`, `docs/retrospectives/`, or `docs/status.d/` file for that id already exists on `origin/main`:
-      `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ docs/status.d/ | grep -i "story-h3"`
+- [ ] **Story-id uniqueness.** Before picking a story id (e.g. `zz9`), confirm no `docs/plans/`, `docs/retrospectives/`, or `docs/status.d/` file for that id already exists on `origin/main`:
+      `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ docs/status.d/ | grep -i "story-zz9"`
       Also check open PR branch names (`gh pr list --state open --json headRefName`) for the same id in flight. If taken, pick the next free id before branching. Curriculum-numbered tracks (e.g. `story-h<N>`) are especially exposed — a module number does not guarantee its id is unused; off-curriculum cleanups can consume ids out of sequence.
 ```
 
@@ -45,7 +45,7 @@ Add a new checklist bullet to [docs/templates/maintenance-sub-loop.md](../templa
 
 ## Production-code surface (R2)
 
-None. Single file changed: `docs/templates/maintenance-sub-loop.md` (docs/process only, no `src/`, no `harness/`, no schema/migration).
+None — no `src/`, no `harness/`, no schema/migration. Files touched are all docs/process: `docs/templates/maintenance-sub-loop.md` (the checklist bullet), `CLAUDE.md` (§ 8 R23 row), plus this plan, the retro, and the status fragment.
 
 ## Gherkin acceptance scenarios
 

--- a/docs/retrospectives/story-maint-18.md
+++ b/docs/retrospectives/story-maint-18.md
@@ -1,0 +1,35 @@
+# Story maint-18 retrospective
+
+**PR:** https://github.com/xavierbriand/accounting/pull/142  **Closes:** [#139](https://github.com/xavierbriand/accounting/issues/139)
+
+Adds a "Story-id uniqueness" bullet to [docs/templates/maintenance-sub-loop.md](../templates/maintenance-sub-loop.md), the checklist run before opening every new story plan (CLAUDE.md § 6.7). This is the process fix for the `story-h2` id collision from earlier in the same session: PR #130 silently overwrote the already-merged PR #125's `docs/plans/story-h2.md` and `docs/retrospectives/story-h2.md`, and fixing it required renaming a branch, which closed an open PR as a side effect (GitHub can't reopen a PR whose head ref has disappeared) and needed a replacement PR (#138) to land the work.
+
+## Keep
+
+- **Filing the issue at the moment of discovery, then closing the loop in the same session, kept the fix cheap.** The root cause (no story-id uniqueness check) was identified immediately after the incident, while the exact failure mode was still fresh — the plan's Context section could describe the real chain of consequences (silent overwrite → branch rename → auto-closed PR → replacement PR) precisely, rather than reconstructing it later from a terse issue.
+- **R16 collapse handled a genuinely tiny story correctly.** One checklist bullet, one file touched, 3 real commits (4 counting the empty refactor slot per R16's own convention) — no forced Gherkin scenarios, no fabricated production-code surface. The plan's explicit "None" sections (Production-code surface, Gherkin scenarios) were the right call, not a shortcut.
+- **Parallel Phase 2 (plan-reviewer + sibling-overlap) surfaced a real, cheap-to-fix gap.** The reviewer caught that the new checklist bullet's scope covered `docs/plans/` and `docs/retrospectives/` but not `docs/status.d/`, even though status fragments are also keyed by story id and CLAUDE.md § 6.4.1 separately documents a `docs/status.d/<date>-story-<id>.md` collision case. A one-line extension to the `git ls-tree` path list closed the gap before it ever caused a second incident.
+
+## Change
+
+- **The R22 *(pending)* rule-tag slot is now contested by three separate pending candidates (story-h1, the real story-h2, and story-h3), none of which are ready for codification yet.** This story needed a fresh rule tag and deliberately skipped past R22 *(pending)* to **R23** to avoid adding a fourth claimant to an already-crowded slot. Worth a note for whoever eventually corroborates one of the R22 *(pending)* candidates: R23 is taken, so codification should start numbering the *other* candidates from R24 *(pending)*, not R23.
+- **The new checklist bullet is enforcement-by-convention only** — nothing stops it from being silently weakened or deleted in a future doc edit, unlike code (which has tests) or CLAUDE.md § 8 rows (which drift-scan checks). This mirrors every other maintenance-sub-loop bullet today, so it's not a regression, but it's the second time this session a "docs-only, trust the agent to run the command" gap has come up (the first being the story-id collision itself). If a third instance of "manual checklist step gets skipped" surfaces, that's the trigger to consider a `new-story-preflight` skill assertion or a CI check instead of a checklist bullet.
+
+## Try
+
+- **If a second story-id collision occurs despite this bullet, escalate to automation** — e.g. a `new-story-preflight` skill assertion (the skill already runs the maintenance sub-loop per its own checklist item 1, so adding a mechanical id-uniqueness check there is a small extension) rather than adding a third checklist bullet asking the agent to be more careful. One incident doesn't yet justify the extra tooling surface; two would.
+
+## Drift scan (mandatory)
+
+- [x] Did this story introduce contradictions between CLAUDE.md and any `docs/` file? **No.** CLAUDE.md § 8 gains the R23 row (this retro is its originating reference); the maintenance-sub-loop checklist file gains the corresponding bullet. Both edits are consistent with each other and with this retro.
+- [x] If yes, reconciled in this PR? N/A — no contradictions.
+- [x] `npx tsx harness/drift-scan/drift-scan.ts --all` — exit 0 after this retro lands (R23's `table-only` finding, present before this file existed, resolves once this retro is committed in the same PR).
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| Story-id uniqueness checklist bullet | `docs/templates/maintenance-sub-loop.md` | done (commit `827cffe`) |
+| CLAUDE.md § 8 R23 row | `CLAUDE.md` | done (commit `827cffe`) |
+| Escalate to automation if a second collision occurs | future story, if triggered | open |
+| R22 slot remains contested (3 pending candidates) — note for future codifier to start at R24, not R23 | future maintenance story | open |

--- a/docs/retrospectives/story-maint-18.md
+++ b/docs/retrospectives/story-maint-18.md
@@ -19,6 +19,18 @@ Adds a "Story-id uniqueness" bullet to [docs/templates/maintenance-sub-loop.md](
 
 - **If a second story-id collision occurs despite this bullet, escalate to automation** — e.g. a `new-story-preflight` skill assertion (the skill already runs the maintenance sub-loop per its own checklist item 1, so adding a mechanical id-uniqueness check there is a small extension) rather than adding a third checklist bullet asking the agent to be more careful. One incident doesn't yet justify the extra tooling surface; two would.
 
+## Code-review findings (Phase 4, 2026-07-02)
+
+5 findings total (0 P1, 0 P2, 5 P3 of which 2 soft).
+
+| Finding | Resolution |
+| --- | --- |
+| Action-items table cited a stale pre-rebase commit hash (`827cffe`) for both the checklist bullet and the CLAUDE.md § 8 row | fix-now — corrected to `a8cc558` (checklist bullet) and `ed365e2` (CLAUDE.md row), the actual post-rebase hashes |
+| Checklist bullet's worked example used `story-h3`, which merged during this same session and is no longer an available id | fix-now — swapped to a synthetic placeholder (`story-zz9`) in both the checklist file and the plan's mirrored code block |
+| Plan's "Production-code surface (R2)" text said "Single file changed" but the diff also touches `CLAUDE.md` and three new docs files (plan/retro/status fragment) | fix-now — reworded to enumerate the full docs-only file list |
+| PR body said "Draft — Phase 2 pending" after the PR left draft state and Phase 2 completed | fix-now — PR description refreshed |
+| (soft) Enforcement is convention-only — nothing blocks a future edit from silently weakening the checklist bullet | acknowledged — already discussed in this retro's Change section; escalate to automation only after a second incident |
+
 ## Drift scan (mandatory)
 
 - [x] Did this story introduce contradictions between CLAUDE.md and any `docs/` file? **No.** CLAUDE.md § 8 gains the R23 row (this retro is its originating reference); the maintenance-sub-loop checklist file gains the corresponding bullet. Both edits are consistent with each other and with this retro.
@@ -29,7 +41,7 @@ Adds a "Story-id uniqueness" bullet to [docs/templates/maintenance-sub-loop.md](
 
 | Item | Where it lands | Status |
 | --- | --- | --- |
-| Story-id uniqueness checklist bullet | `docs/templates/maintenance-sub-loop.md` | done (commit `827cffe`) |
-| CLAUDE.md § 8 R23 row | `CLAUDE.md` | done (commit `827cffe`) |
+| Story-id uniqueness checklist bullet | `docs/templates/maintenance-sub-loop.md` | done (commit `a8cc558`) |
+| CLAUDE.md § 8 R23 row | `CLAUDE.md` | done (commit `ed365e2`) |
 | Escalate to automation if a second collision occurs | future story, if triggered | open |
 | R22 slot remains contested (3 pending candidates) — note for future codifier to start at R24, not R23 | future maintenance story | open |

--- a/docs/status.d/2026-07-02-story-maint-18.md
+++ b/docs/status.d/2026-07-02-story-maint-18.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-02
+story: maint-18
+pr: 142
+epic: refactor
+---
+
+story-maint-18 shipped (#139). Adds a "Story-id uniqueness" check (R23) to the maintenance sub-loop checklist (`docs/templates/maintenance-sub-loop.md`), run before every new story plan. Process fix for the `story-h2` id collision earlier the same session: a merged story's plan/retro were silently overwritten by an unrelated PR reusing the same id, and fixing it required a branch rename that closed the open PR as an unintended side effect. Checks `docs/plans/`, `docs/retrospectives/`, and `docs/status.d/` on `origin/main` plus open PR branch names for the chosen id before branching. R16 collapse (4 commits, zero production surface).

--- a/docs/templates/maintenance-sub-loop.md
+++ b/docs/templates/maintenance-sub-loop.md
@@ -8,6 +8,9 @@ This is the **runnable** form of the rule. The conceptual statement lives in CLA
 
 - [ ] **Sibling work check.** `gh pr list --state open --draft --base main` + `gh issue list --state open` — for each open/draft PR or issue, confirm it isn't already addressing the same goal you're about to plan against. If overlap, defer or coordinate.
   - **With GitHub MCP server active:** Use `list_pull_requests` / `list_issues` / `get_issue` MCP tools instead of the `gh pr list` / `gh issue list` bash calls. Set `export GITHUB_TOKEN=$(gh auth token)` in your shell before starting Claude Code. Without MCP, the bash forms above still work.
+- [ ] **Story-id uniqueness.** Before picking a story id (e.g. `h3`), confirm no `docs/plans/`, `docs/retrospectives/`, or `docs/status.d/` file for that id already exists on `origin/main`:
+      `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ docs/status.d/ | grep -i "story-h3"`
+      Also check open PR branch names (`gh pr list --state open --json headRefName`) for the same id in flight. If taken, pick the next free id before branching. Curriculum-numbered tracks (e.g. `story-h<N>`) are especially exposed — a module number does not guarantee its id is unused; off-curriculum cleanups can consume ids out of sequence.
 - [ ] **Working tree clean.** `git status` clean; story branch rebased on `origin/main`.
 - [ ] **Open issues.** `gh issue list --state open --limit 50` — re-prioritise, close stale, confirm `deferred-suggestion` items still relevant.
 - [ ] **Open PRs.** `gh pr list --state open` — Dependabot/draft state.

--- a/docs/templates/maintenance-sub-loop.md
+++ b/docs/templates/maintenance-sub-loop.md
@@ -8,8 +8,8 @@ This is the **runnable** form of the rule. The conceptual statement lives in CLA
 
 - [ ] **Sibling work check.** `gh pr list --state open --draft --base main` + `gh issue list --state open` — for each open/draft PR or issue, confirm it isn't already addressing the same goal you're about to plan against. If overlap, defer or coordinate.
   - **With GitHub MCP server active:** Use `list_pull_requests` / `list_issues` / `get_issue` MCP tools instead of the `gh pr list` / `gh issue list` bash calls. Set `export GITHUB_TOKEN=$(gh auth token)` in your shell before starting Claude Code. Without MCP, the bash forms above still work.
-- [ ] **Story-id uniqueness.** Before picking a story id (e.g. `h3`), confirm no `docs/plans/`, `docs/retrospectives/`, or `docs/status.d/` file for that id already exists on `origin/main`:
-      `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ docs/status.d/ | grep -i "story-h3"`
+- [ ] **Story-id uniqueness.** Before picking a story id (e.g. `zz9`), confirm no `docs/plans/`, `docs/retrospectives/`, or `docs/status.d/` file for that id already exists on `origin/main`:
+      `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ docs/status.d/ | grep -i "story-zz9"`
       Also check open PR branch names (`gh pr list --state open --json headRefName`) for the same id in flight. If taken, pick the next free id before branching. Curriculum-numbered tracks (e.g. `story-h<N>`) are especially exposed — a module number does not guarantee its id is unused; off-curriculum cleanups can consume ids out of sequence.
 - [ ] **Working tree clean.** `git status` clean; story branch rebased on `origin/main`.
 - [ ] **Open issues.** `gh issue list --state open --limit 50` — re-prioritise, close stale, confirm `deferred-suggestion` items still relevant.


### PR DESCRIPTION
Closes #139

Adds a "Story-id uniqueness" check to the maintenance sub-loop checklist ([docs/templates/maintenance-sub-loop.md](docs/templates/maintenance-sub-loop.md)), run before opening every new story plan (CLAUDE.md § 6.7). This is the process fix for the `story-h2` id collision (PR #130 silently overwrote the merged PR #125's plan/retro files; fixing it required renaming a branch, which closed an open PR as a side effect and required a replacement PR #138).

Adds CLAUDE.md § 8 row **R23** (deliberately skipping the contested `R22 *(pending)*` slot, currently claimed by three separate not-yet-codified candidates across story-h1/h2/h3 retros).

Plan: [docs/plans/story-maint-18.md](docs/plans/story-maint-18.md)
Retro: [docs/retrospectives/story-maint-18.md](docs/retrospectives/story-maint-18.md)

Phase 2 (plan-reviewer + sibling-overlap, parallel) and Phase 4 (code-reviewer) both complete — findings triaged in the plan's Suggestion log and the retro's Code-review findings section. `npm run lint && npm run build && npm test` green (689/689), `npx tsx harness/drift-scan/drift-scan.ts --all` exit 0.

🤖 Generated with Claude Code