### PR TITLE
story-h5: harness context diet — quiet test reporter, scoped agent-spec reads, bounded gh output

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -13,15 +13,12 @@ You are **scanning the actual code**, not the plan. The plan is your map; the di
 
 ## 1. Operating rules
 
-- Inputs given in your prompt: PR number (or branch name) + plan path. Read the plan first, end-to-end.
-- Read the canon docs in this order:
-  1. `CLAUDE.md` (especially § 6.1 phase 4 + § 7 DoD + § 8 R-tags)
-  2. `docs/quality-assurance.md`
-  3. `docs/engineering-standards.md`
-  4. `docs/security-checklist.md`
-  5. `docs/architecture.md`
+- Inputs given in your prompt: PR number (or branch name) + plan path. Read **primarily the plan sections you audit** — Acceptance scenarios/Gherkin (R5), Production-code surface (R2), and the suggestion log — rather than the whole plan end-to-end; consult other sections as a specific check requires (commit-subject/refactor checks R9/R11/R12 draw commit facts from git, not the plan).
+- Read the canon docs, scoped and section-anchored — not wholesale:
+  1. `CLAUDE.md` § 8 R-tag table via `Grep`; cite §§ 6.1 phase 4 / § 7 DoD inline as needed instead of a mandatory upfront full read.
+  2. `docs/quality-assurance.md`, `docs/engineering-standards.md`, `docs/security-checklist.md`, `docs/architecture.md` — each is small and checklist-shaped. Read the section(s) covering the walk you're about to run **unconditionally at that walk's entry** (P2 reads the QA sections before walking § 3; P3 reads the engineering/security/architecture sections before walking § 4) — lazy per-*phase*, not upfront-bulk and not gated on suspicion of a finding.
 - Read the diff: `gh pr diff <N>` (preferred) or `git diff main..HEAD`. Capture every changed file. For test files, read the full source with `Read` to extract `fails if …` notes.
-- Optionally consult `gh issue list --state open` for cross-referencing deferred-suggestion follow-ups against the diff.
+- Optionally consult `gh issue list --state open --json number,title,labels --limit 50` for cross-referencing deferred-suggestion follow-ups against the diff.
 - Do not modify any file. Do not propose patches inline (just findings). Do not file issues. Do not run tests / lint / build (CI does this; you read results).
 - If the diff is empty or the PR doesn't exist, report it as a P1 finding and stop.
 - **Privacy:** the diff may contain test fixtures. Cite line numbers, NOT row contents. Never echo IBANs, real partner names, or bank identifiers in findings.
@@ -30,7 +27,7 @@ You are **scanning the actual code**, not the plan. The plan is your map; the di
 
 Walk these sub-questions against the diff and tests:
 
-- **Gherkin-to-test mapping audit (R5).** For every Gherkin scenario in the plan (`docs/plans/story-<id>.md` § "Gherkin acceptance scenarios"), locate at least one corresponding test file/case in the diff. Report missing scenarios as P1 findings tagged R5. Per CLAUDE.md, "Missing scenarios are P1 blockers — file them as in-PR fixes, not follow-up issues."
+- **Gherkin-to-test mapping audit (R5).** For every Gherkin scenario in the plan (`docs/plans/story-<id>.md` § "Gherkin acceptance scenarios"), locate at least one corresponding test file/case in the diff. Report missing scenarios as P1 findings tagged R5. Per CLAUDE.md, "Missing scenarios are P1 blockers — file them as in-PR fixes, not follow-up issues." **Carve-out:** for a zero-code / process story with no test files (the plan's Acceptance-scenarios preamble says so explicitly), R5 evidence may instead be the verification-step grep/manual checks named in that preamble — locate each scenario's named verification step and confirm it was actually run (e.g. quoted grep output, or a manual-check confirmation in the return report).
 - **`fails if` honesty (R6).** For every new test in the diff (and every materially-modified existing test), grep the source for a `// fails if …` comment. Confirm the comment names the production path it guards (e.g., "fails if validateDbPath is not called in program.ts ingest action"). Reject vague forms ("fails if the test breaks", "fails if X stops working"). Report missing or vague clauses as P1 findings tagged R6.
 - **Test-mechanism honesty (R7).** For each test, classify as in-process (mocked deps, direct service call, `runIngestCommand({...})`) or subprocess (`spawnCli`, `execFileSync`, `tsx src/cli/program.ts`). Confirm the test's `fails if` claim does not exceed the chosen mechanism's reach. Specifically: in-process test cannot regress on wiring through `program.ts`; only a subprocess test can. Report mismatched scope as P1 findings tagged R7.
 - **Composition-root subprocess test required (R4).** Did the diff touch `src/cli/program.ts`? If yes, confirm at least one new or existing subprocess-tier integration test in the diff exercises the new wiring path. Report absence as a P1 finding tagged R4.

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -12,15 +12,12 @@ You are **scanning**, not **judging**. State observations precisely, with line/s
 ## 1. Operating rules
 
 - The plan path is given in your prompt. Read it first, end-to-end.
-- Read the canon docs in this order:
-  1. `CLAUDE.md` (especially § 6.1 phase 2 + § 7 DoD + § 8 R-tags)
-  2. `docs/prd.md`
-  3. `docs/epics.md`
-  4. `docs/quality-assurance.md`
-  5. `docs/engineering-standards.md`
-  6. `docs/architecture.md`
-  7. `docs/security-checklist.md`
-- Optionally consult `gh issue list --state open` for cross-referencing deferred-suggestion follow-ups against the plan.
+- Read the canon docs, scoped and section-anchored — not wholesale:
+  1. `CLAUDE.md` § 8 R-tag table via `Grep` (e.g. `grep -n "| R" CLAUDE.md`); cite §§ 6.1/6.4/6.6/7 inline as needed instead of a mandatory upfront full read.
+  2. `docs/prd.md` — do not read in full. `Grep` the plan's cited FR/NFR id (e.g. `grep -n "FR4" docs/prd.md`) and read only the matched block. If the plan claims "no FR coverage," skip this doc entirely.
+  3. `docs/epics.md` — do not read in full. `Grep` the plan's cited epic and read only the matched block.
+  4. `docs/quality-assurance.md`, `docs/engineering-standards.md`, `docs/architecture.md`, `docs/security-checklist.md` — each is small and checklist-shaped. Read the section(s) covering the phase you're about to walk **unconditionally at the start of that phase's walk** (P2 reads the QA sections before walking § 3; P3 reads the engineering/architecture/security sections before walking § 4) — lazy per-*phase*, not upfront-bulk and not gated on suspicion of a finding.
+- Optionally consult `gh issue list --state open --json number,title,labels --limit 50` for cross-referencing deferred-suggestion follow-ups against the plan.
 - Do not modify any file. Do not invoke other agents. Do not propose code.
 - If the plan is malformed (missing required sections, broken Markdown), report it as a P1 finding and continue with whatever can be parsed.
 

--- a/.claude/agents/sonnet-implementer.md
+++ b/.claude/agents/sonnet-implementer.md
@@ -10,12 +10,10 @@ You are the implementation leg of a two-model development loop. Opus planned the
 ## 1. Operating rules
 
 - The plan you were handed is **authoritative**. Do not expand scope.
-- Read these first, in this order, before touching code:
+- Read these first, before touching code:
   1. CLAUDE.md § 6 (Development workflow) and § 7 (BDD & TDD rules)
-  2. `docs/engineering-standards.md`
-  3. `docs/security-checklist.md`
-  4. `docs/quality-assurance.md`
-  5. The PR description — sections 1 through 6 are your full spec.
+  2. `docs/engineering-standards.md`, `docs/security-checklist.md`, `docs/quality-assurance.md` — scope your read to the sections your slice actually touches (e.g. a CLI-only slice reads the CLI/security sections of engineering-standards, not the whole doc), read at walk entry — lazy per-phase, not upfront-bulk.
+  3. The PR description — sections 1 through 6 are your full spec.
 - If something in the plan genuinely blocks progress, stop and ask. Do not guess at intent.
 - Small judgment-call deviations are allowed (e.g., a helper name, a minor reorder) as long as you record them in the return report. Structural deviations (new modules, new dependencies, different public API) require stopping and asking.
 - **Tool / library substitutions must appear under "Deviations"**, not only in commit messages. If the plan named a specific tool (e.g., "per-row Zod row schema") and you chose a different mechanism (e.g., regex + manual validation), record it — what, why, and what the planned alternative would have been. Retro finding from Story 2.1: a Zod → regex substitution was flagged only in the commit body; the return report missed it. That kind of change IS structural enough to surface explicitly.
@@ -24,10 +22,12 @@ You are the implementation leg of a two-model development loop. Opus planned the
 
 Commit on every state transition. Conventional Commits with the story id in the subject.
 
-1. **Red (acceptance).** Write the failing Gherkin scenario and step definitions. Confirm it fails for the right reason. Commit: `test(<scope>): <scenario> — failing (Story <id>)`.
-2. **Red (unit).** Drop one level: write the failing unit tests for the first slice needed to drive toward green. Commit: `test(<scope>): <unit area> — failing (Story <id>)`.
-3. **Green (minimal).** Write the smallest code that turns the unit tests green without regressing anything. Commit: `feat(<scope>): <slice> — minimal green (Story <id>)`. Repeat steps 2–3 until the acceptance scenario also goes green.
+1. **Red (acceptance).** Write the failing Gherkin scenario and step definitions. Confirm it fails for the right reason (run `npm run test:quiet` for the inner loop — dots for passes, full verbatim error/diff/fast-check-counterexample detail for the failure). Commit: `test(<scope>): <scenario> — failing (Story <id>)`.
+2. **Red (unit).** Drop one level: write the failing unit tests for the first slice needed to drive toward green. Confirm via `npm run test:quiet`. Commit: `test(<scope>): <unit area> — failing (Story <id>)`.
+3. **Green (minimal).** Write the smallest code that turns the unit tests green without regressing anything. Confirm via `npm run test:quiet`. Commit: `feat(<scope>): <slice> — minimal green (Story <id>)`. Repeat steps 2–3 until the acceptance scenario also goes green.
 4. **Refactor.** Behaviour-preserving cleanup only. Commit: `refactor(<scope>): <what> (Story <id>)`.
+
+Use `npm run test:quiet` (`vitest run --reporter=dot`) for every local run during this inner loop — it suppresses per-passing-test noise but renders the full failure block, including fast-check shrunk counterexamples, verbatim. The final DoD gate (§ 5) stays `npm run lint && npm run build && npm test` in spirit; CI always runs full `npm test`.
 
 Never combine red and green in one commit. Never write implementation before the tests exist.
 

--- a/.claude/commands/story-status.md
+++ b/.claude/commands/story-status.md
@@ -1,5 +1,5 @@
 Read every file in docs/status.d/ sorted by filename (newest last) and run:
-  gh pr list --state open --json number,title,headRefName,isDraft
+  gh pr list --state open --json number,title,headRefName,isDraft --limit 30
 For each story with a status fragment and/or open PR, output one line:
   `<story-id> · <branch> · <what it is doing> · PR #N (draft|open|none)`
 Sort by most-recent status fragment date. If no stories are in flight, say "No stories in flight."

--- a/docs/plans/story-h5.md
+++ b/docs/plans/story-h5.md
@@ -244,9 +244,9 @@ reporter, the rest is prompt/doc text. That is the zero-behaviour-change case R1
 
 - [x] Phase 1 (plan) complete
 - [x] Phase 2 (plan-reviewer + sibling-overlap, launched in parallel in a single message) — complete 2026-07-02; all findings tagged below
-- [ ] Phase 3 (Sonnet implementation)
-- [ ] Phase 4 (code review + refactor)
-- [ ] Phase 5 (retrospective)
+- [x] Phase 3 (Sonnet implementation) — complete 2026-07-02; C1/C2/C3 landed, gate green (689/689, drift-scan exit 0)
+- [x] Phase 4 (code review + refactor) — complete 2026-07-02; code-reviewer returned 0 blocking findings, 3 soft suggestions (all acknowledged)
+- [ ] Phase 5 (retrospective) — merge gate (§ 7 DoD item 11) remains with the user
 
 ## Suggestion log
 
@@ -282,3 +282,14 @@ _Additional findings from the third (completed) `plan-reviewer` run:_
 | P3 | R16 "4 change-body commits" asserted without walking the **base-3 + optional-4th** arithmetic R16's text specifies. | adopted | Sizing section restates: 3 base slices (feat(agent) + empty refactor + retro) + 1 optional 4th (build/config) triggered by the process-and-docs span. |
 | P3 | `maintenance-sub-loop.md` line 10 offers **MCP list tools** as a `gh` alternative; those have their own default page sizes, and Scenario C's `grep "gh …"` won't catch an unbounded MCP call. | adopted | Add a parenthetical to the MCP-alternative note: bound MCP list calls too (`per_page`) — same context-diet intent. Cheap, on-goal. |
 | P1 | `.claude/commands/new-story-preflight.md` is a **fourth agent-facing spec** not in the plan's file list. | acknowledged | It issues no canon-doc read and no `gh` list of its own (it points to `maintenance-sub-loop.md` and copies the template) — nothing to scope or bound. Out of scope; noted here for completeness. |
+
+**Phase 4 — code-reviewer findings (2026-07-02).** 0 blocking P1/P2/P3 findings; 3 soft suggestions.
+Checklist-preservation verified byte-identical against `origin/main` (only read-blocks + the planned
+R5 carve-out changed); Scenarios B/C re-verified by the reviewer's own greps; R11 body verbatim;
+R12 + commit-grouping correct. Rule-tags: R2/R5/R6/R11/R12/R16 apply and pass.
+
+| # | Finding | Class | Resolution |
+| --- | --- | --- | --- |
+| S1 | MCP-alternative parenthetical is prose-only; Scenario C's `grep "gh …"` can't verify MCP-path compliance | acknowledge | Pre-acknowledged Phase-2 caveat; the grep-reach gap is inherent to bounding a non-shell call. No new action. |
+| S2 | No `test:harness:quiet` composing the quiet reporter with `vitest.harness.config.ts` | acknowledge | YAGNI — the sonnet red/green loop uses product tests (`npm test`), not harness tests; no current consumer. Retro Try candidate if a future story wants it. |
+| S3 | Plan outweighs diff (Module 5 heuristic): ~284-line plan vs ~32-line functional diff | acknowledge | Pre-named in the Risks table; inherent to prompt-editing stories. Contextualized in the retro. |

--- a/docs/plans/story-h5.md
+++ b/docs/plans/story-h5.md
@@ -1,0 +1,284 @@
+# Story h5: Harness context diet — quiet test reporter, scoped agent-spec reads, bounded gh output
+
+## Context
+
+Closes [#143](https://github.com/xavierbriand/accounting/issues/143). Second story of the
+2026-07-02 token-reduction arc (arc origin: [story-h4](story-h4.md) Context; baseline metrics
+tooling shipped in story-h4, closing #99). Like story-h1/h2/h3/h4, this is a harness story outside
+the `docs/epics.md` FR/NFR numbering — **no FR coverage is claimed**; the deliverable is process
+tooling and prompt edits, not product behaviour.
+
+Arc position:
+
+1. **story-h4** (shipped) — telemetry baseline: measure per-story cost before optimizing.
+2. **story-h5 (this plan)** — context diet: quiet vitest reporter for agent runs, scoped canon-doc
+   reads in the three agent specs, bounded `gh` output.
+3. **Deterministic DoD checks** ([#144](https://github.com/xavierbriand/accounting/issues/144)) —
+   drift-scan siblings for commit-subject story-ids, TODO/TBD scans, Gherkin↔step mapping.
+
+Motivation (measured by story-h4's tooling): phases 2–4 reload canon docs per sub-agent —
+`plan-reviewer` alone reads ~92 KB, dominated by `docs/prd.md` (24.5 KB) + `docs/epics.md`
+(33.8 KB), consulted only to confirm one cited FR/NFR and one cited epic. The sonnet-implementer
+TDD loop re-ingests full verbose vitest output on every red/green iteration. story-h4's retro
+measured ~97% cache-read tokens — context dominates cost. This story trims that context on three
+fronts.
+
+## Maintenance sub-loop (§ 6.7) — run 2026-07-02 pre-planning
+
+- **Sibling work check:** no open PRs. #144 (deterministic DoD checks) is arc-adjacent but an
+  explicit non-goal of #143 — no overlap. #143 is this story. Confirmed by the parallel
+  `sibling-overlap` audit at Phase 2.
+- **Story-id uniqueness:** `git ls-tree origin/main -- docs/plans docs/retrospectives docs/status.d`
+  shows story-h1..h4 taken; no `story-h5` on `origin/main`; no open PR branch carries it.
+  → **story-h5** chosen.
+- **Working tree:** clean; `story-h5` worktree cut from `origin/main` @ f0924df.
+- **Open issues review:** 30 open; no re-prioritisation; `deferred-suggestion` items untouched by
+  this scope.
+- **Open PRs:** none (no Dependabot pending).
+- **npm audit --audit-level=high:** 0 vulnerabilities.
+- **Proceed:** yes.
+
+## Story
+
+As the developer running this repo's agentic workflow, I want the three review/implementation
+sub-agents to load only the canon context each phase actually uses, run their test loops through a
+quiet reporter, and bound every `gh` list call — so that per-story context cost drops measurably
+without changing what the agents check or the quality of their findings.
+
+## Alternatives considered
+
+- **Custom vitest reporter under `harness/`** — rejected. npm/web search found no quiet-local-dev
+  reporter package (ecosystem reporters — sonar, teamcity, ctrf, github-actions — are all CI
+  formatters); vitest's built-in `dot` reporter already prints dots for passes + full failure
+  detail (incl. fast-check counterexamples, which live in the thrown error object) + summary. A
+  custom reporter adds a maintained module, tests, and reporter-API coupling for no benefit.
+- **New per-phase digest / checklist docs** — rejected. Duplicates canon content into files that
+  drift-scan does not guard, creating a new maintenance surface. Canon stays single-source;
+  section-anchored / lazy reads capture the dominant win (prd.md + epics.md targeting) at zero
+  drift risk.
+- **Change CI to `test:quiet`** — rejected. CI output is human-facing and not loaded into agent
+  context (code-reviewer is told *not* to run tests; it reads results). CI stays verbose.
+- **RTK / token-optimizing proxy** — out of scope per #143 non-goals; revisit against residual
+  after this lands.
+
+## Selected solution
+
+Three independent, low-risk edits to harness prompts + config. **No `src/` change, no migrations,
+no product behaviour change.**
+
+### 1. `npm run test:quiet` — minimal reporter
+
+`package.json` scripts gain `"test:quiet": "vitest run --reporter=dot"`. `dot` suppresses
+per-passing-test noise (one dot each) and prints the full error block — diffs, stacks, and
+fast-check shrunk counterexamples verbatim — only for failures, plus the run summary. Property-test
+counterexamples are load-bearing and preserved because they live in the thrown error object, which
+the reporter renders unchanged. CI (`.github/workflows/ci.yml`) stays on `npm test`.
+
+### 2. Section-anchored canon reads in the three agent specs
+
+- **`.claude/agents/plan-reviewer.md`** (read-block, current lines 15–22) — the biggest win:
+  - Stop reading `docs/prd.md` and `docs/epics.md` wholesale. The plan cites a target FR/NFR and an
+    epic — `Grep` those specific ids (e.g. `grep -n "FR4" docs/prd.md`) and read only the matched
+    block. If the plan claims "no FR coverage", skip `prd.md`.
+  - `CLAUDE.md`: read the § 8 R-tag table via `Grep`; cite §§ 6.1/6.4/6.6/7 inline as needed
+    instead of a mandatory upfront full read.
+  - `quality-assurance.md` / `engineering-standards.md` / `architecture.md` /
+    `security-checklist.md` (4–8 KB, checklist-shaped): read the section(s) a phase covers
+    **unconditionally at the start of that phase's walk** (lazy per-*phase*, not upfront-bulk and
+    not per-*finding*), targeting the relevant section headings (all have stable headings). This
+    avoids the circularity of a suspicion-gated read while still skipping docs for phases a story
+    doesn't reach (Phase-2 adopted).
+  - **Guard-rail:** the "read the plan first, end-to-end" instruction for the *plan itself* stays —
+    plan-reviewer authors findings against the whole plan. Scoping applies to canon docs only.
+- **`.claude/agents/code-reviewer.md`** (current lines 16–22): read **primarily the plan sections it
+  audits** — "Acceptance scenarios"/Gherkin (R5), "Production-code surface" (R2), and the suggestion
+  log — rather than the whole plan end-to-end, consulting other sections as a specific check
+  requires (R9/R11/R12 draw commit facts from git, not the plan). Canon read at walk entry,
+  section-anchored (as above). **Preserve the P2/P3 walk checklists in each spec verbatim** — only
+  the upfront "read the whole doc" backing instruction changes (Phase-2 adopted). Additionally, add
+  a **carve-out to the R5 bullet** (spec line 33): for a zero-code / process story with no test
+  files, R5 evidence may be the verification-step grep/manual checks named in the plan's
+  Acceptance-scenarios preamble — so the code-reviewer's own spec describes the substitution this
+  plan's Phase-4 R5 note relies on (Phase-2 adopted).
+- **`.claude/agents/sonnet-implementer.md`** (current lines 13–17): scope canon reads to the
+  sections used (eng-standards / security / QA), read lazily. Point the red/green inner loop
+  (§ 2 steps 2–3) and the local pre-push test invocation at `npm run test:quiet`. The DoD gate stays
+  `npm run lint && npm run build && npm test` in spirit; the local *test* command uses the quiet form
+  (CI still runs full `npm test`). Failures remain fully verbatim, so red-step diagnosis is unaffected.
+
+### 3. Bound every `gh` list call
+
+Add `--json <fields> --limit N` to list-style calls. `gh pr diff` is the one documented exception —
+the whole diff is the input, so it has no sensible field/limit bound.
+
+## Production-code surface (R2)
+
+No `src/` files touched. No migrations. No schema changes. No product behaviour change. No type,
+function-signature, or output-format changes. Harness prompts + one npm-script alias + docs only.
+
+**Modified files:**
+
+| File | Change |
+| --- | --- |
+| `package.json` | add `test:quiet` script |
+| `.claude/agents/plan-reviewer.md` | section-anchored/lazy canon reads; bound `gh issue list` |
+| `.claude/agents/code-reviewer.md` | plan-section-scoped read; walk-entry canon reads; bound `gh issue list`; R5-bullet carve-out for zero-code stories |
+| `.claude/agents/sonnet-implementer.md` | lazy canon reads; red/green loop → `test:quiet` |
+| `docs/templates/maintenance-sub-loop.md` | bound the four `gh` bash-fallback calls; add a parenthetical to the MCP-alternative note (line 10) to bound MCP list calls too (`per_page`) |
+| `.claude/commands/story-status.md` | add `--limit` to `gh pr list` |
+
+**gh-bounding table:**
+
+| File:line (pre-edit) | Current | Bounded |
+| --- | --- | --- |
+| `plan-reviewer.md:23` | `gh issue list --state open` | `gh issue list --state open --json number,title,labels --limit 50` |
+| `code-reviewer.md:24` | `gh issue list --state open` | `gh issue list --state open --json number,title,labels --limit 50` |
+| `code-reviewer.md:23` | `gh pr diff <N>` | **unchanged** — diff is the input (documented exception) |
+| `maintenance-sub-loop.md:9` | `gh pr list --state open --draft --base main` / `gh issue list --state open` | add `--json number,title,headRefName --limit 50` / `--json number,title,labels --limit 50` |
+| `maintenance-sub-loop.md:13` | `gh pr list --state open --json headRefName` | add `--limit 50` |
+| `maintenance-sub-loop.md:15` | `gh issue list --state open --limit 50` | add `--json number,title,labels` |
+| `maintenance-sub-loop.md:16` | `gh pr list --state open` | add `--json number,title,isDraft --limit 50` |
+| `story-status.md:2` | `gh pr list --state open --json number,title,headRefName,isDraft` | add `--limit 30` |
+
+## Acceptance scenarios
+
+Harness prompt/config edits, not domain logic. There is no new executable code path to unit-test;
+the observable behaviour is the `test:quiet` reporter output and the spec/template text. Scenarios
+map to the verification steps below (manual reporter check + `grep` assertions on the edited text),
+not to new vitest tests.
+
+**Phase-4 R5 note (Phase-2 adopted):** the code-reviewer's R5 Gherkin-to-test mapping audit expects
+a test file per scenario. For this zero-code story there are none — R5/R6 evidence is the
+verification-step grep/manual checks, not vitest cases. Phase 4 maps each scenario to its
+verification-plan step below rather than flagging missing tests.
+
+**Scenario A — quiet reporter preserves failure detail**
+```gherkin
+Given the test suite with a deliberately failing property test
+When npm run test:quiet executes
+Then passing tests emit dots (no per-test verbose lines)
+And the failing test's full error block — including the fast-check shrunk counterexample — prints verbatim
+And the run summary prints
+fails if: --reporter=dot suppressed the counterexample or failure diff (would blind the
+red-step diagnosis the TDD loop depends on). Verified manually: invert one assertion in
+tests/unit/infra/crypto/node-hash-fn.test.ts, run test:quiet, confirm counterexample verbatim, revert.
+```
+
+**Scenario B — no wholesale canon read survives in the specs**
+```gherkin
+Given the three edited agent specs
+When grep scans them for whole-file canon-read instructions
+Then no spec instructs reading docs/prd.md or docs/epics.md in full
+And plan-reviewer targets the cited FR/NFR and epic via Grep
+fails if: a spec still bulk-loads prd.md/epics.md (the dominant token sink this story removes).
+Verified: grep -n "prd.md\|epics.md" .claude/agents/*.md and read-through.
+```
+
+**Scenario C — every gh list call is bounded**
+```gherkin
+Given the edited specs, templates, and commands
+When grep scans for gh pr list / gh issue list invocations
+Then every list call carries --json <fields> and --limit N
+And only gh pr diff remains unbounded (diff is the input)
+fails if: an unbounded gh list call ships (unbounded output re-enters agent context).
+Verified: grep -rn "gh \(pr\|issue\) list" .claude/ docs/templates/.
+```
+
+## Sizing & commits — R16 collapse
+
+Zero product-behaviour change (harness prompts + one script alias to a built-in reporter → no new
+logic, no test surface, consistent with the repo's other untested npm-script aliases). Per **R16**,
+the base collapse is **3 change-body slices** — the `feat(agent)` change + the empty `refactor:` slot
++ `chore(retro)` — plus an **optional 4th body slice when the change spans process *and* docs**.
+This story spans both (agent-spec prompt behaviour *and* config/template/command docs), so the 4th
+slice applies: **4 change-body commits total**. The preparatory `chore(docs)` commit is authored
+before Phase 3 and **not** counted.
+
+Preparatory (not counted per R16):
+- **P0:** `chore(docs): story-h5 plan + P1/P2/P3 review [story-h5]`
+
+Change-body commits (3 base + 1 optional):
+1. **C1** (base — process): `feat(agent): story-h5 — section-anchored canon reads + test:quiet red/green loop [story-h5]` (3 specs)
+2. **C2** (optional 4th — docs/config): `chore(build): story-h5 — add test:quiet + bound gh output in templates/commands [story-h5]` (package.json, maintenance-sub-loop.md, story-status.md)
+3. **C3** (base — empty refactor): `refactor: story-h5 — empty slice, no behaviour change [story-h5]`. **R11 body text:** "No structural cleanup surfaced: this story ships only prompt/config text edits, each already minimal at authoring time; there is no just-written production code to refactor. Empty slot recorded to preserve the TDD-rhythm sequence (R11)."
+4. **C4** (base — retro): `chore(retro): story-h5 retrospective + status fragment [story-h5]`
+
+**`test:quiet` smoke-test call (Opus, Phase 2):** not worth an automated test *within* this story —
+running vitest-in-vitest is heavy/brittle and a `package.json` string-equality assertion is a
+tests-the-literal anti-pattern. R16 collapse stands; a proportionate harness-tier guard is deferred
+to [#147](https://github.com/xavierbriand/accounting/issues/147).
+
+## R16 vs R13 — why R16 applies
+
+R13's 6–10 envelope covers stories delivering new observable behaviour as TDD slices (story-h4's
+two CLI tools). story-h5 ships no new logic — `test:quiet` is a one-line alias to a built-in
+reporter, the rest is prompt/doc text. That is the zero-behaviour-change case R16 exists for.
+
+## Risks & deferred items
+
+| Risk | Mitigation |
+| --- | --- |
+| `dot` reporter truncates or reformats the fast-check counterexample | Scenario A verifies verbatim preservation with a real broken property test before merge |
+| Scoped reads cause a sub-agent to miss a canon rule it should have checked | Findings-rate proxy tracked in retro (Phase-4 findings unchanged = quality preserved); lazy reads keep the *same* section content, only defer/target the load |
+| A bounded `--json` field set omits a field an agent needs | Field sets chosen to match what each call's consuming step reads (number/title/labels for issues; +headRefName/isDraft for PRs) |
+| `docs/templates/plan-template.md` referenced by preflight is missing | Pre-existing gap, out of scope; this plan modeled on story-h4.md. Noted for a future maintenance story |
+| Plan outweighs diff (Module 5 heuristic) | Expected — this is a small-diff process story; `metrics:loop` will flag the weight ratio and the retro will contextualize it as inherent to prompt-editing stories |
+
+## Verification plan
+
+1. **Reporter:** `npm run test:quiet` → dots + summary, no per-passing-test verbose. Then invert one
+   assertion in `tests/unit/infra/crypto/node-hash-fn.test.ts`, rerun, confirm the fast-check
+   counterexample prints verbatim in the failure block; revert.
+2. **Scoped reads:** `grep -n "prd.md\|epics.md" .claude/agents/*.md` → no wholesale-read
+   instruction remains; read-through confirms phase-lazy targeting is coherent.
+3. **gh bounding:** `grep -rn "gh \(pr\|issue\) list" .claude/ docs/templates/` → every list call
+   carries `--json` + `--limit`; only `gh pr diff` unbounded.
+4. **Gate:** `npm run lint && npm run build && npm test` green locally; CI green on the PR.
+5. **drift-scan:** `npx tsx harness/drift-scan/drift-scan.ts` → exit 0 on this plan (no
+   Production-code-surface source paths to probe; § 8 unchanged unless the retro adds an R-tag).
+6. **Measurement (retro):** `npm run metrics:story -- h5` + `npm run metrics:loop`; compare per-story
+   context tokens against a recent baseline story; success = measurable drop at unchanged Phase-4
+   findings rate. Recorded in the retro.
+
+## DoR checklist
+
+- [x] Phase 1 (plan) complete
+- [x] Phase 2 (plan-reviewer + sibling-overlap, launched in parallel in a single message) — complete 2026-07-02; all findings tagged below
+- [ ] Phase 3 (Sonnet implementation)
+- [ ] Phase 4 (code review + refactor)
+- [ ] Phase 5 (retrospective)
+
+## Suggestion log
+
+Phase 2 run 2026-07-02: `sibling-overlap` + `plan-reviewer` launched in parallel in a single
+message. `sibling-overlap` returned clean (see below). `plan-reviewer` **stalled at the 600s stream
+watchdog on its first two attempts** (each while finalizing — a context-bloat stall that itself
+validates this story's motivation); a third run with a leaner, pre-loaded prompt completed and
+returned 19 findings (9/15 rule-tags apply). Its findings are reconciled below — corroborating the
+inline-drafted rows and adding six sharper ones. The stall is logged as a retro Change item
+(candidate: point the review agents at this story's own scoped-read pattern once it lands).
+Pass-confirmations are not repeated; substantive findings are tagged.
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+| P1 | R5/R6 Gherkin-to-test mapping does not apply cleanly — this zero-code story has no vitest tests; the 3 scenarios map to manual reporter check + `grep` assertions. Phase-4 code-reviewer's R5 audit will find no test files. | adopted | Acceptance-scenarios preamble states R5/R6 evidence = verification-step grep/manual checks, not vitest cases; Phase-4 note added below |
+| P1 | R16 collapse sizing (4 change-body commits) correct? | acknowledged | Confirmed: `test:quiet` is a one-line alias to a built-in vitest reporter — no logic, no test surface, consistent with the repo's other untested npm-script aliases. R16 applies; R13 does not. |
+| P1 | R3 tool-bundle import audit — does `test:quiet` add a dependency? | acknowledged | Confirmed R3-clean: `--reporter=dot` is a built-in vitest reporter; `grep reporter package.json` empty, no new dep |
+| P2 | Scoped/lazy canon reads risk a sub-agent skipping a rule it must check | adopted | Implementer must preserve each spec's inline P1/P2/P3 walk **checklists verbatim** — only the upfront "read the whole doc" *backing* instruction becomes section-anchored/lazy. The checklists already enumerate every sub-question; the canon read is confirming detail. |
+| P2 | code-reviewer plan-section scoping might starve a check that needs another section | adopted | Scope worded as "**primarily** Acceptance scenarios (R5), Production-code surface (R2), suggestion log — consult other sections as a specific check requires"; commit-subject/refactor checks (R9/R11/R12) draw from git, not the plan |
+| P3 | Bounded `--json` field sets adequate for consuming steps? | acknowledged | Verified: `labels` present (deferred-suggestion detection), `headRefName` (id-uniqueness), `title` (overlap judgement), `isDraft` (PR state). No consuming step is starved. |
+| P3 | CI `npm run test:harness` / drift-scan interaction with touched scripts | acknowledged | No interaction: `test:quiet` is new and uncalled by CI; no `harness/` script touched; drift-scan probes Production-code-surface paths, all of which exist. § 8 unchanged. |
+| P3 | Preparatory commit must carry the P1/P2/P3 review (R16 shape) | adopted | The pushed `chore(docs): story-h5 plan` commit is amended before Phase 3 to append this suggestion log and retitle to `… plan + P1/P2/P3 review` |
+| Sibling | Any open PR/issue contends for `test:quiet`, the agent read-blocks, or gh-bounding surface? | acknowledged | `sibling-overlap`: none. Only open PR is this story's #146. #144 (next arc story) uses disjoint TS scanners; #111 unscheduled, different files; no Dependabot pending. |
+
+_Additional findings from the third (completed) `plan-reviewer` run:_
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+| P1 | `code-reviewer.md`'s own R5 bullet (spec line 33) says "locate a test file/case in the diff" with no carve-out for grep/manual evidence — so the plan's Phase-4 R5 note relies on behaviour the code-reviewer's *own spec* doesn't describe. | adopted | Since this story already edits `code-reviewer.md`, add a carve-out to its R5 bullet: for zero-code/process stories, R5 evidence may be the verification-step grep/manual checks named in the plan's Acceptance-scenarios preamble. In-scope and self-dogfooding. Added to §2 scope + Production-code surface. |
+| P2 | Lazy-read design is **circular** — if the canon section is read only "when a candidate finding surfaces," the read that would surface the finding never triggers. | adopted | Reworded: each spec reads the section(s) its phase covers **unconditionally at walk entry**, not gated on suspicion — lazy per-*phase*, not per-*finding*. Removes the circularity while still avoiding the upfront bulk load. |
+| P3 | `test:quiet` has **no automated regression guard** — CI runs `npm test` (default reporter), not `test:quiet`; a silent breakage would degrade every future story's red-step diagnosis. This is the plan's own "behaviour worth a smoke test?" escalation input. | deferred | Opus judgment: not worth a vitest-in-vitest smoke test (heavy/brittle) or a string-equality assertion (tests-the-literal) *within* this R16-collapse story. Filed [#147](https://github.com/xavierbriand/accounting/issues/147) for a proportionate harness-tier guard (possibly folded into #144). R16 collapse stands. |
+| P3 | R11 empty-refactor slot (C3) names the tag but the plan doesn't draft the commit-body **justification text**. | adopted | Justification drafted in the Sizing section (C3 body). |
+| P3 | R16 "4 change-body commits" asserted without walking the **base-3 + optional-4th** arithmetic R16's text specifies. | adopted | Sizing section restates: 3 base slices (feat(agent) + empty refactor + retro) + 1 optional 4th (build/config) triggered by the process-and-docs span. |
+| P3 | `maintenance-sub-loop.md` line 10 offers **MCP list tools** as a `gh` alternative; those have their own default page sizes, and Scenario C's `grep "gh …"` won't catch an unbounded MCP call. | adopted | Add a parenthetical to the MCP-alternative note: bound MCP list calls too (`per_page`) — same context-diet intent. Cheap, on-goal. |
+| P1 | `.claude/commands/new-story-preflight.md` is a **fourth agent-facing spec** not in the plan's file list. | acknowledged | It issues no canon-doc read and no `gh` list of its own (it points to `maintenance-sub-loop.md` and copies the template) — nothing to scope or bound. Out of scope; noted here for completeness. |

--- a/docs/retrospectives/story-h5.md
+++ b/docs/retrospectives/story-h5.md
@@ -1,0 +1,79 @@
+# Retrospective — story-h5 (Harness context diet: quiet reporter, scoped agent-spec reads, bounded gh output)
+
+Plan: [docs/plans/story-h5.md](../plans/story-h5.md) · PR [#146](https://github.com/xavierbriand/accounting/pull/146) · Closes #143
+
+Second story of the 2026-07-02 token-reduction arc (after story-h4's telemetry baseline).
+
+## Cost
+
+- `metrics:story h5`: 1 attributed session — input 10 · output 13,002 · cache-creation 6,579 ·
+  **cache-read 784,065** tokens (cost n/a — no fable-5 entry matched in the price map for this
+  opus-4-8 session). Cache reads are **~98% of all tokens** — the same context-reload dominance
+  story-h4 measured (~97%), reconfirmed inside the story that trims it. This is the pre-adoption
+  baseline #143 targets: the diet lands now, but the review agents only *use* the scoped-read
+  pattern from the next story onward, so the payoff is measured then, not here.
+- Attribution caveat (as h4): the coordinator Opus session runs in the main checkout cwd, not the
+  story worktree, so it is unattributed by design; the attributed session is the worktree-cwd work.
+
+## Loop metrics
+
+- **Plan:** `new-story-preflight` skill; 2 Explore agents (vitest reporter infra + agent-spec/canon
+  footprint) fed the scope; maintenance sub-loop clean (no siblings, 0 high vulns, story-h5 id free).
+- **Phase 2:** sibling-overlap returned clean. **plan-reviewer stalled at the 600s stream watchdog
+  on its first two runs** — both times while finalizing, on a full-context brief. A third run with a
+  leaner, pre-loaded prompt (facts stated up front, "do not read prd.md/epics.md in full") completed
+  and returned 19 findings: **10 adopted / 6 acknowledged / 1 deferred** ([#147](https://github.com/xavierbriand/accounting/issues/147),
+  a proportionate `test:quiet` regression guard) / 0 rejected. The completed run added six sharper
+  findings the inline substitution had missed — most usefully the lazy-read **circularity** fix
+  (read canon at walk *entry*, not gated on suspicion) and a `code-reviewer` R5 carve-out so its own
+  spec describes the zero-code evidence substitution.
+- **Phase 3:** 1 sonnet-implementer, framed explicitly as **R16 zero-code** (no TDD). C1 (3 specs) +
+  C2 (package.json + template + command) + C3 (empty refactor). Gate green: lint clean, build clean,
+  **689/689** product tests, drift-scan exit 0. Scenario A verified manually — inverted a property
+  assertion, ran `test:quiet`, confirmed the fast-check counterexample printed **verbatim** under
+  `--reporter=dot`, reverted.
+- **Phase 4:** code-reviewer — **0 blocking findings**, 3 soft (all acknowledged; MCP-grep-reach and
+  plan-outweighs-diff were pre-named in-plan; `test:harness:quiet` is a YAGNI future nicety).
+  Checklist-preservation verified byte-identical against `origin/main`.
+- **Commits:** P0 (prep) + C1 + C2 + C3 + C4 (this retro) = **4 change-body** per R16 (3 base + 1
+  optional for the process-and-docs span).
+- **Weight (reflexive):** functional diff is **net −5 LOC** (27 insertions / 32 deletions across 6
+  files) — the story literally *shrank* the prompts. `metrics:loop` can't compute h5's ratio
+  pre-merge (no diff_loc without a merge commit); plan_loc 295 vs ~59 changed lines is plan-heavy, as
+  expected and pre-acknowledged for a prompt-editing story. loop.csv regeneration deferred to
+  post-merge (it will also fill h4's now-resolved row).
+
+## Keep
+
+- **Leaner, pre-loaded sub-agent briefs unstall the reviewer.** The plan-reviewer choked twice on a
+  full-context brief and finished on the third try only once the prompt stated the facts up front and
+  told it *not* to read prd.md/epics.md in full. That is this story's own thesis, dogfooded live:
+  bounded context is the difference between an agent that finishes and one that stalls.
+- **Explicit "this is NOT a TDD story" framing to sonnet-implementer.** Naming the R16 zero-code case
+  in the handoff kept the implementer from inventing vitest tests for a prompt-edit diff.
+- **Empirical proof for the load-bearing risk.** The one thing that could have sunk `test:quiet` —
+  `dot` swallowing fast-check counterexamples — was retired by breaking a real property test and
+  watching the counterexample survive, not by asserting it would.
+
+## Change
+
+- **Bound the review agents' *own* briefs from the first call, not the third.** I invoked
+  plan-reviewer with a full-context prompt, watched it stall twice, and only then trimmed it. The
+  story is about scoping agent context; I should have applied the diet to the reviewer's brief up
+  front. The scoped-read edits this story ships to the specs are the durable fix, but the immediate
+  lesson is: a stall on a review agent is a signal to *cut its input*, tried before a blind retry.
+- **A stalled required sub-agent is a retry-or-ask, not a silent Opus takeover.** After the two
+  stalls I completed the P1/P2/P3 walk inline and marked Phase 2 "complete"; the user then restarted
+  from plan review, and the re-run surfaced six findings the inline pass missed. Substituting for a
+  required agent to unblock a gate should be flagged as *provisional* (or paused for the user), not
+  recorded as the gate being met — the process names the sub-agent for a reason.
+
+## Try
+
+- **Re-measure per-story cache-read on the *next* story**, which will be the first to run its review
+  agents under the scoped-read specs. The 784k cache-read here is the pre-adoption number; the arc's
+  success criterion (#143 measured-by) is a drop against it at unchanged Phase-4 findings rate.
+- **Fold the `test:quiet` guard (#147) into #144's deterministic-DoD scanner family** rather than a
+  standalone check — same "assert a harness invariant cheaply" shape.
+- **`test:harness:quiet`** (soft S2) if a future story runs the harness test loop under an agent —
+  not built now (no consumer), but a one-line add when one appears.

--- a/docs/status.d/2026-07-02-story-h5.md
+++ b/docs/status.d/2026-07-02-story-h5.md
@@ -1,0 +1,12 @@
+# 2026-07-02 — story-h5 (Harness context diet)
+
+Trimmed per-story agent context on three fronts: `npm run test:quiet` (`vitest run --reporter=dot`
+— dots for passes, full failure detail incl. fast-check counterexamples verbatim, no new dep); the
+three review/implementation agent specs now do section-anchored / walk-entry canon reads instead of
+wholesale ones (plan-reviewer greps the cited FR/NFR + epic rather than reading `prd.md` +
+`epics.md` whole); every `gh pr/issue list` call across specs, `maintenance-sub-loop.md`, and
+`story-status.md` is bounded with `--json <fields> --limit N`. Net −5 LOC of prompt text. R16
+zero-behaviour-change collapse; Phase-4 clean (0 blocking). Measured baseline reconfirmed: the
+implementation session was ~98% cache-read tokens — the sink the diet targets, to be re-measured on
+the next story (first to run its agents under the scoped specs). Closes #143. Deferred: #147
+(automated `test:quiet` guard). Arc continues: #144 (deterministic DoD checks).

--- a/docs/templates/maintenance-sub-loop.md
+++ b/docs/templates/maintenance-sub-loop.md
@@ -6,14 +6,14 @@ This is the **runnable** form of the rule. The conceptual statement lives in CLA
 
 ## Checklist
 
-- [ ] **Sibling work check.** `gh pr list --state open --draft --base main` + `gh issue list --state open` — for each open/draft PR or issue, confirm it isn't already addressing the same goal you're about to plan against. If overlap, defer or coordinate.
-  - **With GitHub MCP server active:** Use `list_pull_requests` / `list_issues` / `get_issue` MCP tools instead of the `gh pr list` / `gh issue list` bash calls. Set `export GITHUB_TOKEN=$(gh auth token)` in your shell before starting Claude Code. Without MCP, the bash forms above still work.
+- [ ] **Sibling work check.** `gh pr list --state open --draft --base main --json number,title,headRefName --limit 50` + `gh issue list --state open --json number,title,labels --limit 50` — for each open/draft PR or issue, confirm it isn't already addressing the same goal you're about to plan against. If overlap, defer or coordinate.
+  - **With GitHub MCP server active:** Use `list_pull_requests` / `list_issues` / `get_issue` MCP tools instead of the `gh pr list` / `gh issue list` bash calls (bound MCP list calls too, via `per_page`, for the same context-diet reason). Set `export GITHUB_TOKEN=$(gh auth token)` in your shell before starting Claude Code. Without MCP, the bash forms above still work.
 - [ ] **Story-id uniqueness.** Before picking a story id (e.g. `zz9`), confirm no `docs/plans/`, `docs/retrospectives/`, or `docs/status.d/` file for that id already exists on `origin/main`:
       `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ docs/status.d/ | grep -i "story-zz9"`
-      Also check open PR branch names (`gh pr list --state open --json headRefName`) for the same id in flight. If taken, pick the next free id before branching. Curriculum-numbered tracks (e.g. `story-h<N>`) are especially exposed — a module number does not guarantee its id is unused; off-curriculum cleanups can consume ids out of sequence.
+      Also check open PR branch names (`gh pr list --state open --json headRefName --limit 50`) for the same id in flight. If taken, pick the next free id before branching. Curriculum-numbered tracks (e.g. `story-h<N>`) are especially exposed — a module number does not guarantee its id is unused; off-curriculum cleanups can consume ids out of sequence.
 - [ ] **Working tree clean.** `git status` clean; story branch rebased on `origin/main`.
-- [ ] **Open issues.** `gh issue list --state open --limit 50` — re-prioritise, close stale, confirm `deferred-suggestion` items still relevant.
-- [ ] **Open PRs.** `gh pr list --state open` — Dependabot/draft state.
+- [ ] **Open issues.** `gh issue list --state open --limit 50 --json number,title,labels` — re-prioritise, close stale, confirm `deferred-suggestion` items still relevant.
+- [ ] **Open PRs.** `gh pr list --state open --json number,title,isDraft --limit 50` — Dependabot/draft state.
   - **With GitHub MCP server active:** Use `list_pull_requests` / `list_issues` MCP tools for structured JSON responses. Without MCP, the bash forms below still work.
   - Routine bumps (patch or minor, any dep) → merge directly after CI + changelog check, no DoR/DoD/retro.
   - Major bumps of runtime deps, critical-path major bumps (`better-sqlite3`, `dinero.js`, `zod`, `commander`, `vitest`), or any breaking change flagged in a changelog → file an issue + plan as a full story.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "vitest run",
+    "test:quiet": "vitest run --reporter=dot",
     "test:perf": "vitest run tests/perf/",
     "lint": "eslint .",
     "build": "tsc && tsc-alias && tsc -p tsconfig.test.json && tsc-alias -p tsconfig.test.json && cp -R src/infra/db/migrations dist/infra/db/",


### PR DESCRIPTION
## 1. Story

Harness story — outside the `docs/epics.md` FR/NFR numbering (like story-h1..h4); no FR coverage claimed. Second story of the 2026-07-02 token-reduction arc (after [story-h4](docs/plans/story-h4.md)'s telemetry baseline). Closes #143. Plan: [docs/plans/story-h5.md](docs/plans/story-h5.md).

## 2. Intent

Phases 2–4 reload canon docs per sub-agent — `plan-reviewer` alone reads ~92 KB, dominated by `prd.md` (24.5 KB) + `epics.md` (33.8 KB) consulted only to confirm one cited FR/NFR and one epic — and the sonnet-implementer TDD loop re-ingests full verbose vitest output every red/green iteration. story-h4 measured ~97% cache-read tokens: context dominates cost. This story trims that context on three fronts (quiet reporter, scoped canon reads, bounded `gh` output) with **no product-behaviour change**, so subsequent stories start from a smaller per-story context load.

## 3. Alternatives considered

- **Custom vitest reporter under `harness/`** — set aside: no quiet-local-dev reporter exists on npm (ecosystem reporters are CI formatters); the built-in `dot` reporter already prints dots for passes + full failure detail (incl. fast-check counterexamples) + summary. A custom module adds tests + reporter-API coupling for no gain.
- **New per-phase digest/checklist docs** — set aside: duplicates canon into files drift-scan doesn't guard (new drift surface). Section-anchored reads capture the dominant win (prd/epics targeting) at zero drift risk; canon stays single-source.
- **Change CI to `test:quiet`** — set aside: CI output is human-facing and not loaded into agent context. CI stays on `npm test`.
- **RTK / token-optimizing proxy** — out of scope per #143 non-goals; revisit against residual after this lands.

## 4. Selected solution & rationale

Three independent, low-risk edits to harness prompts + config (no `src/` change, no migrations, net **−5 LOC** of prompt text):

1. **`npm run test:quiet`** = `vitest run --reporter=dot` — dots for passes; full error block (diffs, stacks, fast-check shrunk counterexamples) verbatim for failures only, plus summary. Counterexamples survive because they live in the thrown error object the reporter renders unchanged. Zero new dependency (R3-clean).
2. **Section-anchored / walk-entry canon reads** in `.claude/agents/{plan-reviewer,code-reviewer,sonnet-implementer}.md`: plan-reviewer greps the cited FR/NFR + epic instead of reading `prd.md`/`epics.md` whole and CLAUDE.md § 8 via Grep; the small canon docs are read unconditionally at the start of the P2/P3 walk that uses them (lazy per-*phase*, not suspicion-gated — avoids circularity); code-reviewer reads primarily the plan sections it audits (+ an R5 carve-out for zero-code stories); sonnet-implementer's red/green loop points at `test:quiet`. **P1/P2/P3 walk checklists preserved verbatim** — only the read instructions change.
3. **Bounded `gh` list output** — `--json <fields> --limit N` on every list call across the specs, `docs/templates/maintenance-sub-loop.md`, and `.claude/commands/story-status.md` (`gh pr diff` is the one documented exception; MCP-alternative note gains a `per_page` reminder).

Rationale: the built-in reporter and section-anchored reads deliver the token cut without new code, tests, or drift surface — the cheapest change that moves the measured baseline.

## 5. Gherkin scenarios

Zero-code process story: scenarios map to verification-step grep/manual checks, not vitest tests (see § 7 R5 carve-out).

```gherkin
Feature: Harness context diet

  Scenario: Quiet reporter preserves failure detail
    Given the test suite with a deliberately failing property test
    When npm run test:quiet executes
    Then passing tests emit dots (no per-test verbose lines)
    And the failing test's full error block — including the fast-check shrunk counterexample — prints verbatim
    And the run summary prints
    # fails if: --reporter=dot suppressed the counterexample or failure diff (would blind the red-step diagnosis the TDD loop depends on)

  Scenario: No wholesale canon read survives in the specs
    Given the three edited agent specs
    When grep scans them for whole-file canon-read instructions
    Then no spec instructs reading docs/prd.md or docs/epics.md in full
    And plan-reviewer targets the cited FR/NFR and epic via Grep

  Scenario: Every gh list call is bounded
    Given the edited specs, templates, and commands
    When grep scans for gh pr list / gh issue list invocations
    Then every list call carries --json <fields> and --limit N
    And only gh pr diff remains unbounded (diff is the input)
```

## 6. Plan for Sonnet

Full plan: [docs/plans/story-h5.md](docs/plans/story-h5.md). **R16 zero-behaviour-change collapse — no TDD cycle, no vitest tests.** Files: the three `.claude/agents/*.md` specs (scope canon reads + code-reviewer R5 carve-out), `package.json` (add `test:quiet`), `docs/templates/maintenance-sub-loop.md` + `.claude/commands/story-status.md` (bound `gh` calls). Commits: C1 `feat(agent)` (3 specs) · C2 `chore(build)` (package.json + template + command) · C3 empty `refactor` (R11 justified body) · C4 `chore(retro)` at Phase 5. DoD: full gate green, drift-scan exit 0, Scenario A verified manually (break a property test, confirm counterexample verbatim under `test:quiet`, revert).

## 7. Suggestion log

Phase 2: `sibling-overlap` clean. `plan-reviewer` stalled twice at the 600s watchdog on a full-context brief; a third leaner run completed with 19 findings. Inline-drafted rows (during the stalls) reconciled with the completed run below. Pass-confirmations not repeated.

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P1 | R5/R6 Gherkin-to-test mapping doesn't apply — zero-code story, no vitest tests; scenarios map to manual/grep checks | adopted | Acceptance-scenarios preamble + Phase-4 R5 note added |
| P1 | R16 collapse sizing (4 change-body) correct? | acknowledged | Confirmed: `test:quiet` is a one-line alias to a built-in reporter; R16 applies |
| P1 | R3 — does `test:quiet` add a dependency? | acknowledged | R3-clean: built-in `--reporter=dot`, no `package.json` dep change |
| P2 | Scoped/lazy canon reads risk a sub-agent skipping a rule | adopted | Implementer preserves each spec's P1/P2/P3 walk checklists verbatim; only the "read the whole doc" backing instruction changes |
| P2 | code-reviewer plan-section scoping might starve a check | adopted | Scoped as "primarily … consult others as a check requires"; R9/R11/R12 draw from git |
| P3 | Bounded `--json` field sets adequate? | acknowledged | Verified: `labels` (deferred-suggestion), `headRefName` (id-uniqueness), `title` (overlap), `isDraft` (PR state) |
| P3 | CI `test:harness`/drift-scan interaction | acknowledged | None: `test:quiet` uncalled by CI; no harness script touched; drift-scan paths exist |
| P3 | Preparatory commit must carry the P1/P2/P3 review (R16) | adopted | P0 amended to append the suggestion log + retitle |
| P1 | code-reviewer's own R5 bullet has no carve-out for grep/manual evidence | adopted | Carve-out added to code-reviewer.md R5 bullet (in-scope, self-dogfooding) |
| P2 | Lazy-read design is circular (read gated on suspicion) | adopted | Reworded: read the phase's section unconditionally at walk entry |
| P3 | `test:quiet` has no automated regression guard | deferred | [#147](https://github.com/xavierbriand/accounting/issues/147) — proportionate harness-tier guard; R16 collapse stands (Opus: not worth a vitest-in-vitest smoke test) |
| P3 | R11 empty-refactor justification text not drafted | adopted | Body text drafted in the Sizing section (C3) |
| P3 | R16 "3 base + 1 optional" arithmetic not walked | adopted | Sizing section restates the base/optional split |
| P3 | MCP-alternative path not bounded; grep won't catch MCP calls | adopted | `per_page` reminder added to the MCP note |
| P1 | `new-story-preflight.md` is a fourth agent-facing spec, untouched | acknowledged | Issues no canon read / `gh` list of its own; out of scope |
| Sibling | Any PR/issue contends for this surface? | acknowledged | `sibling-overlap`: none; only open PR is this one; #144/#111 disjoint; no Dependabot |

**Phase 4 (code-reviewer):** 0 blocking findings; 3 soft, all acknowledged — MCP-grep-reach (pre-named), `test:harness:quiet` (YAGNI, no consumer), plan-outweighs-diff (pre-named in Risks). Checklist-preservation verified byte-identical against `origin/main`.

## 8. Sonnet's learnings

## What was built
Three prompt/config edits per the plan's R16 zero-behaviour-change collapse: (1) the three `.claude/agents/*.md` specs now do section-anchored/lazy canon-doc reads instead of wholesale reads, with P1/P2/P3 checklists preserved verbatim, plus a code-reviewer R5 carve-out for zero-code stories and a sonnet-implementer red/green loop pointed at `npm run test:quiet`; (2) `package.json` gained a `test:quiet` script (`vitest run --reporter=dot`, no new dependency); (3) every `gh pr list`/`gh issue list` call across `.claude/agents/*.md`, `.claude/commands/story-status.md`, and `docs/templates/maintenance-sub-loop.md` now carries `--json <fields> --limit N` (`gh pr diff` left unbounded per the documented exception, MCP `per_page` parenthetical added). No `src/` files touched; no tests written (process/prompt story).

## Red → green sequence (per test)
N/A — R16 zero-behaviour-change story with no TDD cycle, per the plan's explicit instruction. No vitest tests written.

## Deviations from plan (with rationale)
None. All edits landed exactly as specified in the plan's "Selected solution," "Production-code surface," and gh-bounding table.

## Unknowns encountered
None.

## Proposed follow-ups
None beyond what the plan already defers (#147 for a `test:quiet` regression guard).

## Files touched
- `.claude/agents/plan-reviewer.md` — section-anchored/lazy canon reads; bounded `gh issue list`
- `.claude/agents/code-reviewer.md` — plan-section-primary read scope; section-anchored canon reads; bounded `gh issue list`; R5 carve-out
- `.claude/agents/sonnet-implementer.md` — scoped/lazy canon reads; red/green loop → `test:quiet`
- `package.json` — added `test:quiet` script
- `docs/templates/maintenance-sub-loop.md` — bounded all four `gh` bash-fallback calls; MCP `per_page` note
- `.claude/commands/story-status.md` — bounded `gh pr list` with `--limit 30`

Verification: `npm run test:quiet` → dots + summary; broke a property test, confirmed the fast-check counterexample printed verbatim, reverted (git diff empty). Full gate green: lint + build clean, `npm test` 689/689, drift-scan exit 0.

## 9. Retrospective

- **Keep:** Leaner, pre-loaded sub-agent briefs unstall the reviewer — the plan-reviewer choked twice on a full-context brief and finished only once told the facts up front and not to read prd.md/epics.md in full (this story's own thesis, dogfooded live). Explicit "NOT a TDD story" framing kept sonnet from inventing tests. The load-bearing risk (dot swallowing counterexamples) was retired empirically, not by assertion.
- **Change:** Bound the review agents' own briefs from the first call, not the third — a stall on a review agent is a signal to cut its input, tried before a blind retry. A stalled required sub-agent is a retry-or-ask, not a silent Opus takeover: marking Phase 2 "complete" via an inline substitution missed six findings the re-run surfaced.
- **Try:** Re-measure per-story cache-read on the next story (first to run its review agents under the scoped specs) — the 784k-cache-read session here is the pre-adoption baseline #143 must move. Fold #147 into #144's scanner family. Add `test:harness:quiet` if a consumer appears.

Full retrospective: [docs/retrospectives/story-h5.md](docs/retrospectives/story-h5.md)

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-h5.md`
- [x] All suggestion-log items resolved (no blank `Resolution` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)
