### PR TITLE
story-h7: dod-check enforcement tiers — non-blocking findings must not gate CI

### DIFF
--- a/docs/plans/story-h7.md
+++ b/docs/plans/story-h7.md
@@ -194,9 +194,9 @@ reports it as advisory and does **not** self-block. That reflexive pass is the s
 - [x] Phase 2 (plan-reviewer + sibling-overlap, parallel) — complete 2026-07-03; #151 filed;
       plan-reviewer 22 findings (13/15 rule-tags apply, design confirmed complete/non-overlapping) +
       sibling-overlap (no overlap); all tagged below
-- [ ] Phase 3 (Sonnet implementation)
-- [ ] Phase 4 (code review + refactor)
-- [ ] Phase 5 (retrospective); merge gate with the user
+- [x] Phase 3 (Sonnet implementation) — complete 2026-07-03; C1–C5 (impl stalled at C3 on signing, coordinator finished); 84 harness + 689 product green
+- [x] Phase 4 (code review + refactor) — complete 2026-07-03; 5 findings, F1–F4 fixed in one commit, F5/F6 acknowledged
+- [x] Phase 5 (retrospective) — complete 2026-07-03; merge gate with the user
 
 ## Suggestion log
 

--- a/docs/plans/story-h7.md
+++ b/docs/plans/story-h7.md
@@ -1,0 +1,218 @@
+# Story-h7: dod-check enforcement tiers — non-blocking findings must not gate CI
+
+Closes [#151](https://github.com/xavierbriand/accounting/issues/151) (dod-check non-story-PR regression).
+
+## Context
+
+**Why:** story-h6 (#149) shipped `harness/dod-check/` into CI, but its exit logic has only two tiers —
+**hard** (always exit 1) and **advisory** (exit 1 when the PR is out of draft). Everything that isn't
+hard falls into the draft-aware bucket, including findings that represent *"the check does not apply
+here,"* not *"the author must fix something."* The result is a **CI regression on every non-story PR**:
+a Dependabot bump or `chore(…)` PR (no story branch, no plan) produces a `story-id-unresolved` finding
+which, once the PR is out of draft, hard-fails the `Run DoD checks` step. Dependabot PRs open
+ready-for-review, so the next one goes red; the `docs/metrics/loop.csv` post-h6 regen chore is the
+first to hit it. The README already promises `story-id-unresolved` is *"reported, never a crash"* — the
+exit logic contradicts that.
+
+Planning this surfaced a **sibling case**: the envelope also hard-fails a story with **fewer** commits
+than the declared range (`count < min`). The envelope's purpose (§ 6.6 sizing, R13/R14/R16) is to stop
+stories being *too big* — the **upper** bound is the real gate; a tightly-scoped 3–4-commit fix
+(story-h2 shape, and story-h7 itself) is fine and should not be blocked. Left unfixed, story-h7 — a
+small fix — would self-block on its own under-count.
+
+**Fix:** a third enforcement tier, **always-advisory** (reported, never affects exit), for the findings
+that mean "check inapplicable / within-guidance":
+
+- `story-id-unresolved` (non-story PR),
+- `commit-envelope` when the rule is **not declared** in the plan (`rule === null`),
+- `commit-envelope` when the count is **below** the declared minimum (`count < min` — under-target).
+
+The draft-aware gate keeps only the findings that flag a *real* problem at merge: `pr-tbd`, and
+`commit-envelope` when the count is **over** the declared maximum (`count > max` — too big). Hard
+findings (`missing-story-id`, `todo-comment`, `unmapped-scenario`, `orphan-step`) are unchanged.
+
+Like story-h1…h6, this is a harness story **outside** the epics FR/NFR numbering — no FR coverage;
+process tooling only.
+
+### Maintenance sub-loop (§ 6.7) — run 2026-07-03 pre-planning
+
+- **Sibling work check:** `gh pr list --state open` → none. No open issue/PR overlaps dod-check.
+- **Story-id uniqueness:** `git ls-tree origin/main -- docs/plans docs/retrospectives docs/status.d`
+  shows story-h1..h6 taken; no `story-h7`; no open PR branch carries it. → **story-h7**.
+- **Working tree:** clean; `story-h7` worktree cut from `origin/main` @ `00474b2`.
+- **Open issues / PRs:** 0 open PRs; the regression itself is filed as a new issue at Phase 2.
+- **`npm audit --audit-level=high`:** 0 vulnerabilities.
+- **Proceed:** yes.
+
+## Story
+
+As the developer running this repo's agentic workflow, I want dod-check to hard-fail CI only on real
+DoD violations — never on "this PR has no story" or "this story is smaller than the target" — so that
+routine Dependabot / chore PRs and tightly-scoped fixes pass CI, while genuine defects and
+over-target stories are still gated at the merge boundary.
+
+## Alternatives considered
+
+- **Make `story-id-unresolved` hard** (require every PR to reference a story) — rejected: the repo
+  merges Dependabot/chore PRs routinely with no story (maintenance sub-loop); gating them is wrong.
+- **Only fix `story-id-unresolved`, leave the envelope alone** — rejected: story-h7 itself (a small
+  fix, count < R13 min 6) would then self-block on its own under-count. The under-count case is the
+  same class of bug and must be fixed for the tool to be self-consistent.
+- **Drop the envelope lower bound entirely** — rejected: keep it as reported guidance (advisory), just
+  don't gate on it. The upper bound stays the gate (that is what § 6.6 sizing is about).
+- **Reclassify at the report layer only** (suppress the finding) — rejected: the finding should still
+  be *reported* (honesty); only its effect on the exit code changes.
+
+## Selected solution
+
+Add an `isAlwaysAdvisory(finding)` predicate and a third partition in `main()`'s exit computation.
+
+- `isHardFinding` — unchanged (`HARD_KINDS`).
+- `isAlwaysAdvisory(finding)` — a **top-level pure predicate** beside `isHardFinding` (directly unit-
+  testable, not inline in `main()`): true for `story-id-unresolved`; and for `commit-envelope` when
+  `rule === null` (not declared) **or** `count < min` (under-target). `min` is already carried on
+  `CommitEnvelopeFinding`. (P3: extract, don't inline.)
+- **draft-aware (soft-gate)** = everything else that isn't hard = `pr-tbd`, and `commit-envelope` with a
+  declared rule and `count > max`.
+- **Exit:** `hardCount > 0 || (softGateCount > 0 && !isDraft)`. Always-advisory findings never count.
+- **Boundary correctness (P1):** `checkCommitEnvelope` already returns `null` (emits no finding) when
+  `min <= count <= max`, and otherwise sets exactly one of `count<min`/`count>max` (never both, since
+  `min <= max`) — so the three tiers partition cleanly. Classification unit tests must pin `min-1`
+  (advisory), `min`/`max` (no finding), `max+1` (draft-aware) explicitly.
+- **Labelling (P2 — three distinguishable human-report lines):**
+  - over-max (draft-aware): `commit-envelope: 12 commits, over the R13 (6–10) envelope` (+
+    `(advisory — PR is draft)` while draft, hard otherwise).
+  - under-min (always-advisory): `commit-envelope: 3 commits, under the R13 (6–10) target (advisory)`.
+  - not-declared (always-advisory): `commit-envelope: N commits, envelope not declared in plan (advisory)`.
+- **Existing test to update:** `dod-check.integration.test.ts`'s "a commit count outside 6-10 does not
+  fail while the PR is a draft" leg uses `count=1` (under-min) and asserts the old
+  `(advisory — PR is draft)` label — it must be relabelled to the new always-advisory `(advisory)`
+  form and its exit-0 assertion re-pointed to the **out-of-draft** case (under-min no longer needs draft
+  to stay green).
+
+No new finding *kinds* — the discriminated union is unchanged; only the exit classification and two
+report labels change. `checkCommitEnvelope` still emits one `commit-envelope` finding carrying
+`count`/`rule`/`min`/`max`; the tiering is derived from those fields in the entrypoint.
+
+## Production-code surface (R2)
+
+No `src/` files. No migrations. No product behaviour. Harness + docs only.
+
+**Modified files:**
+
+| File | Change |
+| --- | --- |
+| `harness/dod-check/dod-check.ts` | `isAlwaysAdvisory` predicate; three-way exit partition; two report labels |
+| `harness/dod-check/tests/dod-check.integration.test.ts` | non-story-PR (exit 0 when ready) + under-count (exit 0) + over-count-still-hard regression legs |
+| `harness/dod-check/tests/commit-subject.test.ts` or a new entrypoint-level unit test | classification unit coverage if the predicate is extracted as a pure helper |
+| `harness/dod-check/README.md` | enforcement table: split `commit-envelope` into over-max (draft-aware) vs not-declared/under-min (always-advisory); `story-id-unresolved` → always-advisory; update the exit-code sentence |
+
+**New files:**
+
+| File | Purpose |
+| --- | --- |
+| `docs/plans/story-h7.md` | This plan (R1) |
+| `docs/retrospectives/story-h7.md` | Phase 5 |
+| `docs/status.d/2026-07-03-story-h7.md` | R17 fragment |
+
+**Output formats (R2):** `--json` shape unchanged (`{ findings, degraded }`); the change is exit-code
+classification + two human-report label strings.
+
+## Acceptance scenarios
+
+Harness tooling → harness vitest tests (in-process where the logic is pure; subprocess smoke for the
+exit-code wiring — R7 noted per scenario).
+
+**Scenario A — a non-story PR does not hard-fail when ready**
+```gherkin
+Given a temp repo on a non-story branch (no story- name, no plan file added)
+When dod-check runs with the PR out of draft
+Then story-id-unresolved is reported as (advisory) and exit code is 0
+fails if: story-id-unresolved gates the exit code — the regression that broke Dependabot/chore PRs
+(guards the always-advisory partition in dod-check.ts main(); subprocess smoke over a temp repo)
+```
+
+**Scenario B — an under-target story is advisory, an over-target story is gated**
+```gherkin
+Given a story branch whose plan declares R13 (6–10) and a commit count of 3 (under min)
+When dod-check runs with the PR out of draft
+Then the envelope finding is reported as (advisory) and exit code is 0
+Given instead a commit count of 12 (over max)
+When dod-check runs with the PR out of draft
+Then the envelope finding is hard and exit code is 1
+fails if: under-count blocks, or over-count stops blocking (guards the count<min vs count>max split;
+in-process classification test + one subprocess smoke)
+```
+
+**Scenario C — real defects and not-declared envelopes are unchanged**
+```gherkin
+Given a commit subject missing the story id, and separately a plan with no declared envelope rule
+When dod-check runs out of draft
+Then missing-story-id is still hard (exit 1) and the not-declared envelope is (advisory, exit 0 on its own)
+fails if: the hard tier regresses, or a not-declared envelope starts gating
+(guards HARD_KINDS untouched + rule===null → always-advisory; in-process + subprocess smoke)
+```
+
+## Slice plan (R13: target 6–10 commits)
+
+Preparatory (not counted, R16): **P0** `chore(docs): story-h7 plan + P1/P2/P3 review [story-h7]`
+
+1. **C1:** `test(harness): always-advisory classification — failing [story-h7]`
+2. **C2:** `feat(harness): always-advisory tier — story-id-unresolved + not-declared envelope — green [story-h7]`
+3. **C3:** `test(harness): envelope under-min advisory vs over-max gated — failing [story-h7]`
+4. **C4:** `feat(harness): split envelope under/over classification — green [story-h7]`
+5. **C5:** `chore(harness): README enforcement tiers + non-story-PR integration regression [story-h7]`
+6. **C6:** `chore(retro): story-h7 retrospective + status fragment [story-h7]`
+
+**5 behaviour slices** (C1–C5; C6 retro and P0 prep excluded from the count). This sits **below** R13's
+6 — which is exactly the under-target case this story makes advisory, so story-h7's own dod-check run
+reports it as advisory and does **not** self-block. That reflexive pass is the story's own proof
+(Scenario B, dogfooded). A `refactor(harness):` slice is Phase-4-conditional (R11).
+
+## Risks & deferred items
+
+| Risk | Mitigation |
+| --- | --- |
+| The under/over split is subtle — an off-by-one at `count === min`/`max` | Classification unit tests pin the boundaries (min-1, min, max, max+1) |
+| story-h7 is small — envelope reports under-target advisory on its own PR | Intended and dogfooded (Scenario B); the fix makes it advisory, not hard |
+| `loop.csv` post-h6 regen still pending | Deferred: it is a non-story chore that this fix unblocks; regenerate after h7 merges |
+
+## Verification plan
+
+1. `npm run test:harness` → green incl. new classification + regression tests.
+2. Reflexive: on the `story-h7` branch, `npx tsx harness/dod-check/dod-check.ts` → the under-target
+   envelope (5 < 6) is reported `(advisory)` and exit is **0** even out of draft.
+3. Negative: a temp non-story repo out of draft → `story-id-unresolved (advisory)`, exit 0; an
+   over-max temp repo out of draft → `commit-envelope` hard, exit 1.
+4. `npm run lint && npm run build && npm test` → green (product tree untouched).
+5. `npm run typecheck:harness`; `grep` for cross-tree imports → empty.
+6. `npx tsx harness/drift-scan/drift-scan.ts` → exit 0 on this plan.
+
+## DoR checklist
+
+- [x] Phase 1 (plan) drafted
+- [x] Phase 2 (plan-reviewer + sibling-overlap, parallel) — complete 2026-07-03; #151 filed;
+      plan-reviewer 22 findings (13/15 rule-tags apply, design confirmed complete/non-overlapping) +
+      sibling-overlap (no overlap); all tagged below
+- [ ] Phase 3 (Sonnet implementation)
+- [ ] Phase 4 (code review + refactor)
+- [ ] Phase 5 (retrospective); merge gate with the user
+
+## Suggestion log
+
+Phase 2 run 2026-07-03: `plan-reviewer` (22 findings; design confirmed complete + non-overlapping;
+13/15 rule-tags apply — R1/R2/R6/R7/R11/R12/R13/R16-convention/R17/R19/R21/R23 satisfied) +
+`sibling-overlap` (no overlap; #151 not a duplicate; loop.csv correctly deferred). Pass-confirmations
+not repeated.
+
+| Phase | Suggestion | Resolution | Link / Reason |
+| --- | --- | --- | --- |
+| P1 | Boundary tests (`min-1`/`min`/`max`/`max+1`) promised only in the risk table, not an acceptance criterion | adopted | Selected solution: explicit boundary-classification unit-test requirement added |
+| P1 | R13 self-consistency (story tunes the rule that judges it) is transparent but a judgment call | acknowledged | Intentional + dogfooded (Scenario B); falsifiable — if the classification were wrong the story would hard-fail on itself. Accepted |
+| P2 | Two always-advisory sub-cases (not-declared vs under-min) both render bare `(advisory)` — CI reader can't distinguish | adopted | Selected solution: three distinguishable label strings specified (over/under/not-declared) |
+| P2 | Honesty — findings still reported, only exit changes | acknowledged | Explicitly designed so; Alternatives rejects report-layer suppression |
+| P3 | Plan hedges whether `isAlwaysAdvisory` is a pure helper vs inline in `main()` | adopted | Committed: top-level pure predicate beside `isHardFinding`, directly unit-tested |
+| P3 | R11 empty-refactor justification deferred | acknowledged | Justification authored at Phase 4 if the slot lands |
+| P3 | CLAUDE.md § 8 jumps R21→R23 (no R22 row) | acknowledged | Pre-existing (R22 was an h1 `*(pending)*` candidate never codified); out of scope for h7, not introduced here |
+| Sibling | loop.csv post-h6 regen must sequence after h7 (it's the PR that first hits the regression) | adopted | Risks table: deferred follow-up, regenerate after h7 merges |
+| Sibling | #150 / #147 adjacent, independent | acknowledged | No file/logic contention; referenced, not absorbed |

--- a/docs/plans/story-h7.md
+++ b/docs/plans/story-h7.md
@@ -216,3 +216,19 @@ not repeated.
 | P3 | CLAUDE.md § 8 jumps R21→R23 (no R22 row) | acknowledged | Pre-existing (R22 was an h1 `*(pending)*` candidate never codified); out of scope for h7, not introduced here |
 | Sibling | loop.csv post-h6 regen must sequence after h7 (it's the PR that first hits the regression) | adopted | Risks table: deferred follow-up, regenerate after h7 merges |
 | Sibling | #150 / #147 adjacent, independent | acknowledged | No file/logic contention; referenced, not absorbed |
+
+**Phase 4 — code-reviewer findings (2026-07-03).** 5 findings (2 P1, 0 P2, 3 P3; design confirmed
+clean — no `any`, no bare catch, `isAlwaysAdvisory` a top-level pure predicate, C1/C3 verified
+genuinely red before their green pair). Classified by Opus:
+
+| # | Finding | Class | Resolution |
+| --- | --- | --- | --- |
+| F1 | R5: Scenario C's not-declared-envelope leg has in-process coverage but no subprocess test | fix-now | Add an integration leg: a plan with no Slice-plan heading, out of draft → `envelope not declared in plan (advisory)`, exit 0 |
+| F2 | R8: the `--json` `commit-envelope` assertion checks only `count`, not `rule`/`min`/`max`, and only a declared fixture | fix-now | Tighten the `--json` shape assertion to `rule`/`min`/`max` (the `--json` shape itself is unchanged by h7) |
+| F3 | README "Story-id resolution" still says "advisory", not "always-advisory" (terminology drift within the file) | fix-now | README wording aligned |
+| F4 | README "Output" section omits the bare `(advisory)` suffix that always-advisory findings now carry | fix-now | README wording added |
+| F5 | `CommitEnvelopeFinding` is a flat type; the `min !== null` guards are compiler-appeasement, not bugs | acknowledge | Opportunistic discriminated-union tightening deferred to a future story that touches the type |
+| F6 | The `import.meta.url` entrypoint guard is untested directly | acknowledge | Low risk; indirectly exercised by `dod-check.unit.test.ts` importing the module without exit |
+
+Fix-now F1–F4 land in one Phase-4 commit (bringing the story to 6 behaviour slices — squarely within
+R13, so the envelope reports clean).

--- a/docs/retrospectives/story-h7.md
+++ b/docs/retrospectives/story-h7.md
@@ -1,0 +1,80 @@
+# Retrospective — story-h7 (dod-check enforcement tiers — non-blocking findings must not gate CI)
+
+Plan: [docs/plans/story-h7.md](../plans/story-h7.md) · PR [#152](https://github.com/xavierbriand/accounting/pull/152) · Closes #151
+
+A fast-follow fix to story-h6 (#149): the dod-check gate it shipped hard-failed non-story PRs
+(Dependabot/chore) and under-target small stories once out of draft. Adds a third **always-advisory**
+enforcement tier.
+
+## Cost
+
+- `metrics:story h7`: 1 attributed session — opus-4-8: input 2,508 · output 94,824 ·
+  cache-creation 129,228 · **cache-read 40,508,904** tokens (cost n/a — no price entry for this model).
+  Cache-read is **~99% of all tokens** — the by-now-familiar context-reload dominance. Attribution
+  caveat is heavier than usual here: h6 and h7 ran back-to-back in **one long coordinator session**, so
+  the attributed cache-read spans both stories' worktree work, not h7 alone. The number is a ceiling,
+  not a clean per-story figure.
+
+## Loop metrics
+
+- **Origin:** this story was **not planned** — it fell out of a tidy-up. Regenerating `docs/metrics/loop.csv`
+  post-h6 (a routine chore) was the first non-story PR to hit dod-check's CI step, which hard-failed on
+  `story-id-unresolved`. The tidy-up surfaced the regression; the user chose full-story treatment.
+- **Plan:** `new-story-preflight`; no Explore agents needed (the fix site was already understood from
+  h6). Planning surfaced a **sibling case** the issue didn't mention — the envelope also hard-fails
+  *under-count* (too-small) stories — folded into scope so h7 wouldn't self-block on its own 5 slices.
+- **Phase 2:** plan-reviewer (22 findings; **design confirmed complete + non-overlapping** — the three
+  tiers partition cleanly because `checkCommitEnvelope` returns null at `min<=count<=max`) +
+  sibling-overlap (no overlap), parallel. #151 filed.
+- **Phase 3:** 1 sonnet-implementer landed C1+C2, then **stalled on 1Password signing** at C3; the
+  coordinator committed C3 and finished C4/C5 directly (retries land where the sub-agent can't).
+- **Phase 4:** code-reviewer — 5 findings (2 P1, 3 P3; design confirmed clean, no `any`, TDD verified
+  genuinely red-before-green). F1–F4 fixed in one commit (added the not-declared subprocess leg,
+  tightened the `--json` assertion, aligned README vocabulary); F5/F6 acknowledged.
+- **Commits:** P0 (prep) + C1–C5 + F1–F4 fix + retro. **6 behaviour slices** (excl prep + retro) —
+  within R13. The Phase-4 fix moved the count from 5 (under-target advisory) to exactly 6 (in-range),
+  so the reflexive `dod-check` on this branch now reports **no envelope finding at all**.
+- **Weight (reflexive):** plan_loc 234 vs 478 insertions / 6 files → weight_ratio ≈ **0.49**, under 1
+  (diff-heavier, healthy). loop.csv regen still deferred to post-merge.
+- **Drift scan:** no new CLAUDE.md § 8 R-tag; no contradictions. (Reviewer noted the pre-existing gap
+  between R21 and R23 in § 8 — the intervening row was an h1 `*(pending)*` candidate that was never
+  codified; out of h7's scope.)
+
+## Keep
+
+- **Dogfooding proved the fix on the story's own branch.** h7 is a small 5→6-slice fix; before the
+  Phase-4 commit it sat under R13's floor, and its own `dod-check` run reported that as `(advisory)`
+  and exited 0 out of draft — the fix validated against itself, live. A gate-tool story should always
+  run the gate against its own branch.
+- **A routine tidy-up caught a real regression.** The loop.csv regen wasn't busywork — it was the
+  first non-story PR, and it exposed that dod-check would red every future Dependabot/chore PR. Doing
+  the small chore surfaced a latent CI break before Dependabot did.
+- **Planning widened scope to the sibling bug.** The issue named only `story-id-unresolved`; planning
+  recognized under-count is the same class and folded it in, avoiding a second fast-follow.
+
+## Change
+
+- **story-h6 shipped a two-tier enforcement model that was too coarse.** Classifying every non-hard
+  finding as draft-aware conflated "you must fix this at merge" (pr-tbd, over-target) with "this check
+  doesn't apply here" (non-story PR, under-target, no envelope declared). **Lesson:** when introducing
+  a CI gate, enumerate each finding's enforcement tier up front — and test the gate against a
+  **non-story / Dependabot-shaped PR** before merging, not just against the story's own PR. h6's tests
+  only ever exercised story-shaped repos, which is why the gap survived to main.
+- **1Password signing stalled again** (C3), as in h6. It's now a documented, recurring session hazard;
+  worth confirming the agent is live before a long implementation handoff.
+
+## Try
+
+- **Tighten `CommitEnvelopeFinding` to a discriminated union** (`{rule:null,min:null,max:null} | {rule,min,max}`)
+  so the `min !== null` guards become compiler-enforced rather than defensive (Phase-4 F5) — a future
+  story that touches the type.
+- **Proceed with the deferred `loop.csv` post-h6 regen** now that non-story PRs pass CI — it is the
+  concrete confirmation that #151 is fixed end-to-end.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| `loop.csv` post-h6/h7 regen (now unblocked) | follow-up chore PR | open |
+| `CommitEnvelopeFinding` discriminated-union tightening | future story (F5) | open |
+| Metrics tests pollute real `docs/metrics/` | [#150](https://github.com/xavierbriand/accounting/issues/150) | open |

--- a/docs/retrospectives/story-h7.md
+++ b/docs/retrospectives/story-h7.md
@@ -62,6 +62,12 @@ enforcement tier.
   only ever exercised story-shaped repos, which is why the gap survived to main.
 - **1Password signing stalled again** (C3), as in h6. It's now a documented, recurring session hazard;
   worth confirming the agent is live before a long implementation handoff.
+- **A pre-existing subprocess-test flake surfaced on CI, not locally.** A dod-check integration test
+  (unchanged h6 test) spawns `npx tsx` and hit ~5.2s on a loaded CI runner — over vitest's 5s default —
+  and red-failed h7's build though it was green locally and on h6's CI. Fixed by setting
+  `testTimeout: 30000` in `vitest.harness.config.ts` for the whole harness suite. **Lesson:** tests
+  that shell out to a cold interpreter need an explicit generous timeout from day one; the default is a
+  latent flake that only shows under CI load.
 
 ## Try
 

--- a/docs/status.d/2026-07-03-story-h7.md
+++ b/docs/status.d/2026-07-03-story-h7.md
@@ -1,0 +1,10 @@
+# 2026-07-03 — story-h7 (dod-check enforcement tiers)
+
+Fast-follow fix to story-h6 (#149): the `harness/dod-check` gate it wired into CI hard-failed every
+non-story PR (Dependabot/chore → `story-id-unresolved`) and every under-target small story
+(`commit-envelope` count < min) once out of draft. Adds a third **always-advisory** enforcement tier
+(reported, never gates) for `story-id-unresolved`, not-declared envelopes, and under-min counts; the
+draft-aware gate keeps only `pr-tbd` and over-max envelopes; the hard tier is unchanged. Human-report
+lines now distinguish over/under/not-declared envelopes. Surfaced by a routine `loop.csv` regen — the
+first non-story PR to hit the gate. Closes #151. R13, 6 behaviour slices; dogfooded (h7's own
+under-target count was advisory, so it did not self-block).

--- a/harness/dod-check/README.md
+++ b/harness/dod-check/README.md
@@ -40,17 +40,26 @@ npx tsx harness/dod-check/dod-check.ts --json
 
 ## Enforcement model
 
+Three tiers:
+
 | Finding | Enforcement |
 | --- | --- |
 | `missing-story-id` | **hard** — always exit 1 |
 | `todo-comment` | **hard** — always exit 1 |
 | `unmapped-scenario` / `orphan-step` | **hard** — always exit 1 |
-| `commit-envelope` | **draft-aware** — advisory while the PR is a draft, hard once ready-for-review |
-| `pr-tbd` | **draft-aware** — same as above |
-| `story-id-unresolved` | advisory — reported, never a crash; skips the commit-subject check |
+| `pr-tbd` | **draft-aware** — advisory while the PR is a draft, hard once ready-for-review |
+| `commit-envelope`, count **over** the declared max | **draft-aware** — same as `pr-tbd` |
+| `commit-envelope`, count **under** the declared min | **always-advisory** — reported, never gates |
+| `commit-envelope`, rule **not declared** in the plan | **always-advisory** — reported, never gates |
+| `story-id-unresolved` (non-story PR — Dependabot/chore) | **always-advisory** — reported, never gates |
 
-Exit code: `1` if any hard finding exists, or any advisory finding exists **and** the PR is out of
-draft. `0` otherwise.
+Exit code: `1` iff a **hard** finding exists, **or** a **draft-aware** finding exists and the PR is
+out of draft. **Always-advisory** findings never affect the exit code — a non-story PR, an
+under-target (small) story, or a plan with no declared envelope is reported but not blocked. The
+envelope's job is to cap stories that are *too big* (§ 6.6 sizing); being small, or having no story at
+all, is not a merge blocker. Human report lines distinguish the three envelope cases: `over the
+R<n> (min–max) envelope`, `under the R<n> (min–max) target (advisory)`, and `envelope not declared in
+plan (advisory)`.
 
 ## Draft-state resolution
 

--- a/harness/dod-check/README.md
+++ b/harness/dod-check/README.md
@@ -102,16 +102,18 @@ findings are still computed and reported regardless of any degradation. Degradat
 
 ## Output
 
-Human-readable findings go to **stderr**, grouped `Commit subjects:` / `TODO/TBD:` / `Gherkin↔step:`,
-with an `(advisory — PR is draft)` suffix on draft-aware findings while the PR is a draft. `--json`
-sends `{ "findings": DodFinding[], "degraded": string[] }` to **stdout** instead.
+Human-readable findings go to **stderr**, grouped `Commit subjects:` / `TODO/TBD:` / `Gherkin↔step:`.
+Draft-aware findings carry an `(advisory — PR is draft)` suffix while the PR is a draft; always-advisory
+findings carry a bare `(advisory)` suffix regardless of draft state. `--json` sends
+`{ "findings": DodFinding[], "degraded": string[] }` to **stdout** instead.
 
 ## Story-id resolution
 
 1. Current branch name, if it matches `story-<id>`.
 2. Otherwise, the single plan file added in `git diff --name-only origin/main...HEAD -- 'docs/plans/*.md'`.
-3. If neither resolves (e.g. a maintenance PR, or zero/multiple plan files added), the commit-subject
-   check is skipped and reports a `story-id-unresolved` advisory finding naming why.
+3. If neither resolves (e.g. a Dependabot/chore PR, or zero/multiple plan files added), the
+   commit-subject check is skipped and reports a `story-id-unresolved` **always-advisory** finding
+   naming why — it never gates the exit code.
 
 ## Wiring
 

--- a/harness/dod-check/dod-check.ts
+++ b/harness/dod-check/dod-check.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 import {
   checkCommitSubjects,
   parseEnvelopeRule,
@@ -411,4 +412,9 @@ function main(): void {
   process.exit(exitCode);
 }
 
-main();
+// Guards against executing the CLI (including process.exit) as a side
+// effect of importing this module for unit-testing isAlwaysAdvisory —
+// dod-check.ts is otherwise only ever invoked directly via tsx/npx.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/harness/dod-check/dod-check.ts
+++ b/harness/dod-check/dod-check.ts
@@ -51,6 +51,14 @@ function isHardFinding(finding: DodFinding): boolean {
   return HARD_KINDS.has(finding.kind);
 }
 
+export function isAlwaysAdvisory(finding: DodFinding): boolean {
+  if (finding.kind === 'story-id-unresolved') return true;
+  if (finding.kind === 'commit-envelope') {
+    return finding.rule === null || (finding.min !== null && finding.count < finding.min);
+  }
+  return false;
+}
+
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
@@ -305,7 +313,16 @@ function resolveDraftState(repoRoot: string): DraftResolution {
 }
 
 function draftSuffix(finding: DodFinding, isDraft: boolean): string {
-  return !isHardFinding(finding) && isDraft ? ' (advisory — PR is draft)' : '';
+  return !isHardFinding(finding) && !isAlwaysAdvisory(finding) && isDraft
+    ? ' (advisory — PR is draft)'
+    : '';
+}
+
+function formatCommitEnvelopeLine(f: CommitEnvelopeFinding, isDraft: boolean): string {
+  if (f.rule === null) {
+    return `  commit-envelope: ${f.count} commits, envelope not declared in plan (advisory)`;
+  }
+  return `  commit-envelope: ${f.count} commits, envelope ${f.rule} (${f.min}–${f.max})${draftSuffix(f, isDraft)}`;
 }
 
 function formatCommitSubjectLines(findings: DodFinding[], isDraft: boolean): string[] {
@@ -319,10 +336,9 @@ function formatCommitSubjectLines(findings: DodFinding[], isDraft: boolean): str
     if (f.kind === 'missing-story-id') {
       lines.push(`  missing-story-id: ${f.sha} "${f.subject}"`);
     } else if (f.kind === 'commit-envelope') {
-      const range = f.rule ? `${f.rule} (${f.min}–${f.max})` : 'not declared in plan';
-      lines.push(`  commit-envelope: ${f.count} commits, envelope ${range}${draftSuffix(f, isDraft)}`);
+      lines.push(formatCommitEnvelopeLine(f, isDraft));
     } else {
-      lines.push(`  story-id-unresolved: ${f.reason}`);
+      lines.push(`  story-id-unresolved: ${f.reason} (advisory)`);
     }
   }
   return lines;
@@ -406,9 +422,9 @@ function main(): void {
     }
   }
 
-  const hardCount = findings.filter(isHardFinding).length;
-  const advisoryCount = findings.length - hardCount;
-  const exitCode = hardCount > 0 || (advisoryCount > 0 && !draft.isDraft) ? 1 : 0;
+  const hard = findings.filter(isHardFinding);
+  const softGate = findings.filter((f) => !isHardFinding(f) && !isAlwaysAdvisory(f));
+  const exitCode = hard.length > 0 || (softGate.length > 0 && !draft.isDraft) ? 1 : 0;
   process.exit(exitCode);
 }
 

--- a/harness/dod-check/dod-check.ts
+++ b/harness/dod-check/dod-check.ts
@@ -322,7 +322,10 @@ function formatCommitEnvelopeLine(f: CommitEnvelopeFinding, isDraft: boolean): s
   if (f.rule === null) {
     return `  commit-envelope: ${f.count} commits, envelope not declared in plan (advisory)`;
   }
-  return `  commit-envelope: ${f.count} commits, envelope ${f.rule} (${f.min}–${f.max})${draftSuffix(f, isDraft)}`;
+  if (f.min !== null && f.count < f.min) {
+    return `  commit-envelope: ${f.count} commits, under the ${f.rule} (${f.min}–${f.max}) target (advisory)`;
+  }
+  return `  commit-envelope: ${f.count} commits, over the ${f.rule} (${f.min}–${f.max}) envelope${draftSuffix(f, isDraft)}`;
 }
 
 function formatCommitSubjectLines(findings: DodFinding[], isDraft: boolean): string[] {

--- a/harness/dod-check/tests/commit-subject.test.ts
+++ b/harness/dod-check/tests/commit-subject.test.ts
@@ -8,6 +8,7 @@ import {
   countChangeBodyCommits,
   type CommitLogEntry,
 } from '../lib/commit-subject.js';
+import { isAlwaysAdvisory } from '../dod-check.js';
 
 const FIXTURES_DIR = path.join(import.meta.dirname, '..', 'fixtures', 'plans');
 
@@ -158,6 +159,44 @@ describe('checkCommitEnvelope', () => {
   it('reports envelope-not-declared when no envelope rule resolved', () => {
     const finding = checkCommitEnvelope(8, null);
     expect(finding).toEqual({ kind: 'commit-envelope', count: 8, rule: null, min: null, max: null });
+  });
+
+  // Boundary classification (story-h7): pins min-1 / min / max / max+1 and
+  // the tier each maps to via isAlwaysAdvisory, so an off-by-one at either
+  // edge is caught immediately rather than discovered via a subprocess
+  // integration failure.
+  describe('boundary classification — min-1 / min / max / max+1', () => {
+    const RULE = { rule: 'R13' as const, min: 6, max: 10 };
+
+    // fails if: count = min-1 stops reporting a finding, or the finding is
+    // classified as anything but always-advisory — guards the under-target
+    // leg of Scenario B.
+    it('count = min-1 (5): reports a finding, classified always-advisory', () => {
+      const finding = checkCommitEnvelope(5, RULE);
+      expect(finding).toEqual({ kind: 'commit-envelope', count: 5, rule: 'R13', min: 6, max: 10 });
+      expect(finding && isAlwaysAdvisory(finding)).toBe(true);
+    });
+
+    // fails if: count = min reports a finding at all — guards the inclusive
+    // lower boundary of the "inside declared range" no-finding path.
+    it('count = min (6): reports no finding', () => {
+      expect(checkCommitEnvelope(6, RULE)).toBeNull();
+    });
+
+    // fails if: count = max reports a finding at all — guards the inclusive
+    // upper boundary of the "inside declared range" no-finding path.
+    it('count = max (10): reports no finding', () => {
+      expect(checkCommitEnvelope(10, RULE)).toBeNull();
+    });
+
+    // fails if: count = max+1 stops reporting a finding, or the finding is
+    // classified as always-advisory instead of the soft (draft-aware) gate
+    // — guards the over-target leg of Scenario B staying gated.
+    it('count = max+1 (11): reports a finding, classified draft-aware (not always-advisory)', () => {
+      const finding = checkCommitEnvelope(11, RULE);
+      expect(finding).toEqual({ kind: 'commit-envelope', count: 11, rule: 'R13', min: 6, max: 10 });
+      expect(finding && isAlwaysAdvisory(finding)).toBe(false);
+    });
   });
 });
 

--- a/harness/dod-check/tests/dod-check.integration.test.ts
+++ b/harness/dod-check/tests/dod-check.integration.test.ts
@@ -140,6 +140,30 @@ describe('dod-check integration — under-min envelope is always-advisory (exits
   });
 });
 
+describe('dod-check integration — a non-story PR does not hard-fail (Scenario A, #151 regression)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = initTempRepo();
+    TEMP_DIRS.push(tmpDir);
+    // A Dependabot/chore-shaped branch: no story- name, no plan file added.
+    git(tmpDir, ['checkout', '-q', '-b', 'chore-loop-csv']);
+    fs.writeFileSync(path.join(tmpDir, 'change.txt'), 'x\n');
+    git(tmpDir, ['add', 'change.txt']);
+    git(tmpDir, ['commit', '-q', '-m', 'chore(metrics): regenerate loop.csv']);
+  });
+
+  // fails if: story-id-unresolved gates the exit code out of draft — the #151
+  // regression that hard-failed every Dependabot/chore PR (guards
+  // isAlwaysAdvisory's story-id-unresolved branch + the exit partition).
+  it('reports story-id-unresolved as (advisory) and exits 0 out of draft', () => {
+    const result = runDodCheck(tmpDir, ['--check', 'commits'], { DOD_PR_DRAFT: 'false' });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('story-id-unresolved');
+    expect(result.stderr).toContain('(advisory)');
+  });
+});
+
 describe('dod-check integration — under-min vs over-max envelope labels are distinguishable (Scenario B)', () => {
   function commitStoryZzCommits(tmpDir: string, extraCount: number): void {
     for (let i = 0; i < extraCount; i++) {

--- a/harness/dod-check/tests/dod-check.integration.test.ts
+++ b/harness/dod-check/tests/dod-check.integration.test.ts
@@ -49,7 +49,7 @@ afterEach(() => {
   }
 });
 
-describe('dod-check integration — commit-subject discipline, draft-aware (Scenario A)', () => {
+describe('dod-check integration — missing-story-id is hard (Scenario A / C)', () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -64,24 +64,24 @@ describe('dod-check integration — commit-subject discipline, draft-aware (Scen
     git(tmpDir, ['commit', '-q', '-m', 'chore: a commit with no story id reference']);
   });
 
-  // fails if: a subject missing the story id is not flagged, or the
-  // envelope finding fails a draft PR (guards commit-subject.ts presence +
-  // envelope paths and the entrypoint draft-aware exit).
-  it('reports missing-story-id (hard) and an advisory envelope finding while the PR is a draft', () => {
+  // fails if: a subject missing the story id is not flagged as hard, or the
+  // co-occurring under-min envelope is not rendered as always-advisory
+  // (guards HARD_KINDS + the under-min always-advisory label).
+  it('flags missing-story-id (hard, exit 1); the under-min envelope is always-advisory', () => {
     const result = runDodCheck(tmpDir, ['--check', 'commits'], { DOD_PR_DRAFT: 'true' });
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('missing-story-id');
     expect(result.stderr).toContain('chore: a commit with no story id reference');
     expect(result.stderr).toContain('commit-envelope');
-    expect(result.stderr).toContain('(advisory — PR is draft)');
+    expect(result.stderr).toMatch(/under the R13 \(6–10\) target \(advisory\)/);
   });
 
-  // fails if: the envelope finding does not become a hard failure once the
-  // PR is out of draft — guards the draft-aware exit-code gate end-to-end.
-  it('the envelope finding becomes a hard failure once the PR is out of draft', () => {
+  // fails if: missing-story-id stops being hard out of draft, or the under-min
+  // envelope wrongly acquires the draft-aware suffix (it is always-advisory).
+  it('missing-story-id stays hard out of draft; the under-min envelope carries no draft suffix', () => {
     const result = runDodCheck(tmpDir, ['--check', 'commits'], { DOD_PR_DRAFT: 'false' });
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain('commit-envelope');
+    expect(result.stderr).toContain('missing-story-id');
     expect(result.stderr).not.toContain('(advisory — PR is draft)');
   });
 });
@@ -117,7 +117,7 @@ describe('dod-check integration — merge commits are excluded from the subject 
   });
 });
 
-describe('dod-check integration — advisory-only envelope does not fail a draft PR', () => {
+describe('dod-check integration — under-min envelope is always-advisory (exits 0 even out of draft)', () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -129,13 +129,14 @@ describe('dod-check integration — advisory-only envelope does not fail a draft
     git(tmpDir, ['commit', '-q', '-m', 'test(harness): plan — failing [story-zz]']);
   });
 
-  // fails if: an advisory-only finding (envelope, count=1, outside 6-10)
-  // fails a draft PR on its own — guards "does not fail on its own".
-  it('a commit count outside 6-10 does not fail while the PR is a draft', () => {
-    const result = runDodCheck(tmpDir, ['--check', 'commits'], { DOD_PR_DRAFT: 'true' });
+  // fails if: an under-min commit count (1 < 6) gates the exit code out of
+  // draft — the regression that would self-block small stories like h7 itself
+  // (guards the isAlwaysAdvisory count<min branch + the exit partition).
+  it('an under-min commit count is (advisory) and exits 0 out of draft', () => {
+    const result = runDodCheck(tmpDir, ['--check', 'commits'], { DOD_PR_DRAFT: 'false' });
     expect(result.status).toBe(0);
     expect(result.stderr).toContain('commit-envelope');
-    expect(result.stderr).toContain('(advisory — PR is draft)');
+    expect(result.stderr).toMatch(/under the R13 \(6–10\) target \(advisory\)/);
   });
 });
 

--- a/harness/dod-check/tests/dod-check.integration.test.ts
+++ b/harness/dod-check/tests/dod-check.integration.test.ts
@@ -139,6 +139,55 @@ describe('dod-check integration — advisory-only envelope does not fail a draft
   });
 });
 
+describe('dod-check integration — under-min vs over-max envelope labels are distinguishable (Scenario B)', () => {
+  function commitStoryZzCommits(tmpDir: string, extraCount: number): void {
+    for (let i = 0; i < extraCount; i++) {
+      fs.writeFileSync(path.join(tmpDir, `extra-${i}.txt`), `${i}\n`);
+      git(tmpDir, ['add', `extra-${i}.txt`]);
+      git(tmpDir, ['commit', '-q', '-m', `feat(harness): extra slice ${i} — green [story-zz]`]);
+    }
+  }
+
+  // fails if: an under-min count (3, below R13's min of 6) renders the old
+  // combined "envelope R13 (6-10)" wording instead of the distinguishable
+  // "under the R13 (6-10) target (advisory)" label, or gates the exit code
+  // once out of draft — guards Scenario B's under-count leg end-to-end.
+  it('under-min (3 commits) is labelled "under ... target (advisory)" and exits 0 out of draft', () => {
+    const tmpDir = initTempRepo();
+    TEMP_DIRS.push(tmpDir);
+    git(tmpDir, ['checkout', '-q', '-b', 'story-zz']);
+    writePlan(tmpDir, 'zz', '## Slice plan (R13: target 6-10 commits)\n\nbody\n');
+    git(tmpDir, ['add', 'docs/plans/story-zz.md']);
+    git(tmpDir, ['commit', '-q', '-m', 'test(harness): plan — failing [story-zz]']);
+    commitStoryZzCommits(tmpDir, 1); // 2 story commits total: under R13's min of 6
+
+    const result = runDodCheck(tmpDir, ['--check', 'commits'], { DOD_PR_DRAFT: 'false' });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('commit-envelope');
+    expect(result.stderr).toMatch(/under the R13 \(6–10\) target \(advisory\)/);
+    expect(result.stderr).not.toContain('(advisory — PR is draft)');
+  });
+
+  // fails if: an over-max count (12, above R13's max of 10) renders the old
+  // combined wording instead of "over the R13 (6-10) envelope", or stops
+  // gating the exit code once out of draft — guards Scenario B's
+  // over-count leg staying hard.
+  it('over-max (12 commits) is labelled "over ... envelope" and exits 1 out of draft', () => {
+    const tmpDir = initTempRepo();
+    TEMP_DIRS.push(tmpDir);
+    git(tmpDir, ['checkout', '-q', '-b', 'story-zz']);
+    writePlan(tmpDir, 'zz', '## Slice plan (R13: target 6-10 commits)\n\nbody\n');
+    git(tmpDir, ['add', 'docs/plans/story-zz.md']);
+    git(tmpDir, ['commit', '-q', '-m', 'test(harness): plan — failing [story-zz]']);
+    commitStoryZzCommits(tmpDir, 11); // 12 story commits total: over R13's max of 10
+
+    const result = runDodCheck(tmpDir, ['--check', 'commits'], { DOD_PR_DRAFT: 'false' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('commit-envelope');
+    expect(result.stderr).toMatch(/over the R13 \(6–10\) envelope/);
+  });
+});
+
 describe('dod-check integration — TODO/TBD honesty (Scenario B)', () => {
   let tmpDir: string;
 

--- a/harness/dod-check/tests/dod-check.integration.test.ts
+++ b/harness/dod-check/tests/dod-check.integration.test.ts
@@ -211,6 +211,23 @@ describe('dod-check integration — under-min vs over-max envelope labels are di
     expect(result.stderr).toContain('commit-envelope');
     expect(result.stderr).toMatch(/over the R13 \(6–10\) envelope/);
   });
+
+  // fails if: a plan with no declared envelope rule (no `## Slice plan` heading)
+  // gates the exit code out of draft — guards Scenario C's not-declared leg as
+  // always-advisory end-to-end (rule===null branch of isAlwaysAdvisory).
+  it('a not-declared envelope is "not declared in plan (advisory)" and exits 0 out of draft', () => {
+    const tmpDir = initTempRepo();
+    TEMP_DIRS.push(tmpDir);
+    git(tmpDir, ['checkout', '-q', '-b', 'story-zz']);
+    // Plan present, but no `## Slice plan` heading → no envelope rule declared.
+    writePlan(tmpDir, 'zz', '# Story zz\n\nNo slice-plan heading here.\n');
+    git(tmpDir, ['add', 'docs/plans/story-zz.md']);
+    git(tmpDir, ['commit', '-q', '-m', 'test(harness): plan — failing [story-zz]']);
+
+    const result = runDodCheck(tmpDir, ['--check', 'commits'], { DOD_PR_DRAFT: 'false' });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toMatch(/envelope not declared in plan \(advisory\)/);
+  });
 });
 
 describe('dod-check integration — TODO/TBD honesty (Scenario B)', () => {
@@ -481,6 +498,10 @@ describe('dod-check integration — --json covers every DodFinding kind (F6, R8)
     const commitEnvelope = byKind('commit-envelope');
     expect(commitEnvelope).toBeDefined();
     expect(typeof commitEnvelope?.['count']).toBe('number');
+    // declared-rule (over-max) fixture: rule/min/max carry the range in the JSON shape.
+    expect(typeof commitEnvelope?.['rule']).toBe('string');
+    expect(typeof commitEnvelope?.['min']).toBe('number');
+    expect(typeof commitEnvelope?.['max']).toBe('number');
 
     const todoComment = byKind('todo-comment');
     expect(todoComment).toBeDefined();

--- a/harness/dod-check/tests/dod-check.unit.test.ts
+++ b/harness/dod-check/tests/dod-check.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { isAlwaysAdvisory, type DodFinding } from '../dod-check.js';
+
+describe('isAlwaysAdvisory', () => {
+  // fails if: a non-story PR's story-id-unresolved finding gates the exit
+  // code — guards the Scenario A regression (Dependabot/chore PRs).
+  it('is true for story-id-unresolved', () => {
+    const finding: DodFinding = { kind: 'story-id-unresolved', reason: 'no story- branch' };
+    expect(isAlwaysAdvisory(finding)).toBe(true);
+  });
+
+  // fails if: an undeclared envelope rule starts gating the exit code —
+  // guards the "not declared" always-advisory path.
+  it('is true for commit-envelope when rule is null (not declared)', () => {
+    const finding: DodFinding = { kind: 'commit-envelope', count: 8, rule: null, min: null, max: null };
+    expect(isAlwaysAdvisory(finding)).toBe(true);
+  });
+
+  // fails if: an under-target story (count < min) hard-blocks — guards
+  // Scenario B's under-count leg (story-h7 dogfoods this on itself).
+  it('is true for commit-envelope when count < min (under-target)', () => {
+    const finding: DodFinding = { kind: 'commit-envelope', count: 3, rule: 'R13', min: 6, max: 10 };
+    expect(isAlwaysAdvisory(finding)).toBe(true);
+  });
+
+  // fails if: an over-target story (count > max) stops being gated at all —
+  // guards Scenario B's over-count leg staying in the draft-aware soft gate.
+  it('is false for commit-envelope when count > max (over-target)', () => {
+    const finding: DodFinding = { kind: 'commit-envelope', count: 12, rule: 'R13', min: 6, max: 10 };
+    expect(isAlwaysAdvisory(finding)).toBe(false);
+  });
+
+  // fails if: a hard finding (e.g. missing-story-id) is reclassified as
+  // always-advisory — guards HARD_KINDS staying untouched.
+  it('is false for a hard finding kind (missing-story-id)', () => {
+    const finding: DodFinding = { kind: 'missing-story-id', sha: 'abc1234', subject: 'chore: x' };
+    expect(isAlwaysAdvisory(finding)).toBe(false);
+  });
+});

--- a/vitest.harness.config.ts
+++ b/vitest.harness.config.ts
@@ -3,5 +3,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['harness/**/*.test.ts'],
+    // Several harness integration tests spawn a real `npx tsx <entrypoint>`
+    // subprocess (drift-scan, dod-check). Cold `tsx` start-up plus git/gh work
+    // can exceed vitest's 5s default on a loaded CI runner — a single dod-check
+    // subprocess test flaked at ~5.2s. A generous ceiling removes the flake
+    // without masking a genuine hang (which would still blow past 30s).
+    testTimeout: 30000,
   },
 });


### PR DESCRIPTION
## 1. Story

Harness story (no FR coverage). Closes [#151](https://github.com/xavierbriand/accounting/issues/151). Plan: [docs/plans/story-h7.md](docs/plans/story-h7.md).

## 2. Intent

story-h6 wired dod-check into CI with only hard + draft-aware tiers, so any non-hard finding hard-fails once out of draft — breaking **non-story PRs** (Dependabot/chore → `story-id-unresolved`) and **under-target small stories** (`commit-envelope` count < min). Add a third **always-advisory** tier so CI gates only on real DoD violations.

## 3. Alternatives considered

- Make `story-id-unresolved` hard (require every PR to name a story) — rejected: Dependabot/chore PRs legitimately have none.
- Fix only `story-id-unresolved`, leave under-count — rejected: story-h7 itself (small) would self-block on its own under-count.
- Drop the envelope lower bound — rejected: keep it as reported guidance (advisory), just don't gate.

## 4. Selected solution & rationale

Top-level pure `isAlwaysAdvisory` predicate: true for `story-id-unresolved`, and `commit-envelope` when `rule===null` (not declared) or `count<min` (under-target). Draft-aware keeps `pr-tbd` + `commit-envelope` with `count>max`. Hard tier unchanged. Three distinguishable envelope labels (over/under/not-declared). Exit: `hard>0 || (softGate>0 && !isDraft)`.

## 5. Gherkin scenarios

```gherkin
Scenario: a non-story PR does not hard-fail when ready
  Given a temp repo on a non-story branch, out of draft
  Then story-id-unresolved is (advisory) and exit is 0

Scenario: under-target advisory, over-target gated
  Given a plan declaring R13 and a count of 3 (under min), out of draft
  Then the envelope finding is (advisory) and exit is 0
  Given instead a count of 12 (over max), out of draft
  Then the envelope finding is hard and exit is 1

Scenario: real defects and not-declared envelopes unchanged
  Given a subject missing the story id, and separately a plan with no declared envelope
  Then missing-story-id stays hard (exit 1) and not-declared envelope is (advisory, exit 0)
```

## 6. Plan for Sonnet

See [docs/plans/story-h7.md](docs/plans/story-h7.md) § Selected solution / Slice plan / Acceptance scenarios. 5 behaviour slices (C1–C5), TDD; boundary unit tests (min-1/min/max/max+1); update the existing under-min integration test's label. Harness isolation; no `any`.

## 7. Suggestion log

Phase 2 (2026-07-03): plan-reviewer (22 findings, design confirmed complete/non-overlapping, 13/15 rule-tags) + sibling-overlap (no overlap), parallel. All tagged in the plan's [Suggestion log](docs/plans/story-h7.md#suggestion-log). Adopted: boundary tests as acceptance criteria; three distinct envelope labels; `isAlwaysAdvisory` as a pure testable predicate.

## 8. Sonnet's learnings

_Pending Phase 3._

## 9. Retrospective

_Pending Phase 5._

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-h7.md`
- [x] All suggestion-log items resolved
- [x] All phase-4 retro-checks pass
- [x] User approval