### PR TITLE
story-maint-19: sandbox metrics integration tests in a temp git repo

### DIFF
--- a/docs/plans/story-maint-19.md
+++ b/docs/plans/story-maint-19.md
@@ -125,4 +125,4 @@ Phase 2 — `plan-reviewer` + `sibling-overlap` in parallel, 2026-07-03.
 - [x] Phase 0 (Model): `No model impact` declared above (R24).
 - [x] Phase 1 (Plan): complete in this document.
 - [x] Phase 2 (Critical review — plan-reviewer + sibling-overlap in parallel): complete 2026-07-03; findings triaged above.
-- [ ] Draft PR with template sections 1–6 filled.
+- [x] Draft PR with template sections 1–6 filled — [#158](https://github.com/xavierbriand/accounting/pull/158).

--- a/docs/plans/story-maint-19.md
+++ b/docs/plans/story-maint-19.md
@@ -1,0 +1,128 @@
+# Story maint-19 — Sandbox metrics integration tests in a temp git repo
+
+## Context
+
+Deferred from story-h6 Phase-4 review (PR #149, finding F7). Tracked by [#150](https://github.com/xavierbriand/accounting/issues/150).
+
+`harness/metrics/tests/loop-metrics.integration.test.ts` invokes `harness/metrics/loop-metrics.ts` with `cwd: REPO_ROOT` (the real repo). `loop-metrics.ts` resolves `repoRoot = process.cwd()` and unconditionally writes `docs/metrics/loop.csv` under it — so running `npm run test:harness` leaves the real, tracked `docs/metrics/loop.csv` modified. Separately, `harness/metrics/tests/usage-reader.integration.test.ts`'s `--story h4` subprocess-smoke test invokes `harness/metrics/usage-reader.ts --story h4` the same way; `usage-reader.ts`'s `runStory()` also resolves `repoRoot = process.cwd()` and writes `docs/metrics/story-<id>.md` under it, leaving an untracked `docs/metrics/story-h4.md` in the real tree.
+
+**Impact:** a dirtied `loop.csv`/story corpus can cause `loop-metrics.integration.test.ts` to fail on a second run, and pollutes the working tree during any harness-test run — easy to mistake for a regression. Confirmed both symptoms trace to `process.cwd()`-relative output paths in the two entrypoints, exercised by two different test files (not just the one named in #150's title).
+
+**Fix (per #150):** sandbox both subprocess-smoke tests in a temp git repo, following the pattern `harness/dod-check/tests/dod-check.integration.test.ts` already uses (`fs.mkdtempSync` scaffold + `afterEach` cleanup) — run each entrypoint with `cwd: tmpDir` instead of `cwd: REPO_ROOT`. No production-code change: both entrypoints already resolve everything relative to `process.cwd()`, so pointing `cwd` at a temp repo is sufficient.
+
+No FR/NFR coverage — harness/test-infra maintenance only.
+
+**Maintenance sub-loop (§ 6.7) run 2026-07-03 pre-planning:**
+
+- [x] **Sibling work check.** `gh pr list --state open --draft --base main` → `[]` (no open/draft PRs). `gh issue list --state open --limit 50` → 32 open issues; none overlaps this story's scope. #119 (drift-scan subprocess tests / temp-git-repo scaffolding) is adjacent (shared temp-dir helper candidate, noted in #150 itself) but out of scope — deferred below.
+- [x] **Story-id uniqueness.** `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ docs/status.d/ | grep -i "story-maint-19"` → no hits. `story-maint-19` is free (highest existing is `story-maint-18`).
+- [x] **Working tree clean.** `git status` clean; branch rebased onto `origin/main` (`9154250`).
+- [x] **Open issues.** Reviewed above; #150 (this story) and #154 (deferred by user — trigger-discipline issue, not yet actionable) are the only issues in scope for this session.
+- [x] **Open PRs.** None open.
+- [x] **`npm audit --audit-level=high`** — 0 vulnerabilities.
+- [x] **Proceed-to-planning.**
+
+## Story
+
+> As a developer running `npm run test:harness`, I want the metrics integration tests to run against an isolated temp git repo instead of the real working tree, so that a routine test run never leaves `docs/metrics/loop.csv` modified or a stray `docs/metrics/story-h4.md` behind — eliminating a source of test pollution that can be mistaken for a regression.
+
+## Domain model
+
+No model impact — harness/test-infra maintenance, not product Core domain (R24 default for maint/process stories).
+
+## Selected solution
+
+Add a small shared helper, `harness/metrics/tests/_helpers/temp-git-repo.ts`, colocated with the two test files it serves (both under `harness/metrics/tests/`), mirroring `dod-check.integration.test.ts`'s inline `initTempRepo`/`git` helpers but factored out since two files need it here. It exposes:
+- `initTempRepo(): string` — `git init` + user config + `commit.gpgsign false` (same 1Password-signing workaround as dod-check's helper) + one base commit.
+- `git(cwd, args): string` — thin `execFileSync` wrapper.
+
+**`loop-metrics.integration.test.ts`** rewritten to: build a temp repo with a handful of `docs/plans/story-<id>.md` files and commits tagged `[story-<id>]` (plus one story with no matching commit, to exercise the skip-report path, and one with a `docs/retrospectives/story-<id>.md` carrying a `## Loop metrics` heading), create an `origin/main` branch at HEAD (matching `getCommitLog`'s `git log ... origin/main` invocation), then run the entrypoint with `cwd: tmpDir`. Assertions move from "the real repo's `docs/metrics/loop.csv` has ≥35 rows sourced from real history" to "the temp repo's `docs/metrics/loop.csv` has exactly the expected header + one row per fixture story, with the fixture's skip case correctly reported." A trailing assertion, captured once via a `beforeEach` snapshot at the top of the file (vitest runs `it()` blocks within one file sequentially, so this is safe from within-file races; no other spec file reads/writes the real `docs/metrics/loop.csv`), confirms the **real** repo's `docs/metrics/loop.csv` (via `REPO_ROOT`) is byte-identical to its state before the test ran — a regression guard for the pollution this story fixes.
+
+**`usage-reader.integration.test.ts`**'s `'writes docs/metrics/story-<id>.md with an attribution note'` test rewritten to: build a temp repo with one commit tagged `[story-zz]`, run `usage-reader.ts --story zz` with `cwd: tmpDir`, assert `tmpDir/docs/metrics/story-zz.md` is written with the expected markers (session count / attribution / unattributed sessions — these lines are unconditional per `formatStoryReport`, independent of whether any real `~/.claude/projects` session file happens to overlap the fabricated commit window). Trailing assertion confirms the real repo's `docs/metrics/story-h4.md` was never created.
+
+**Why not sandbox `findSessionFiles()` too:** it reads `$HOME/.claude/projects`, independent of `cwd` — untouched by this story's `cwd`-based fix and not a source of *repo* pollution (the bug this story targets). Leaving it as-is keeps the fix minimal and matches #150's "no product-code change" framing.
+
+**Why a local helper instead of extracting one shared with `dod-check.integration.test.ts`:** #150 itself flags this as a "shared temp-dir helper candidate" adjacent to #119 (drift-scan subprocess tests), not a requirement of this story. Cross-module extraction (`harness/dod-check` ↔ `harness/metrics`) is a separate, coarser refactor with its own review surface — deferred to #119 rather than bundled here.
+
+## Production-code surface (R2)
+
+None. Files touched: `harness/metrics/tests/loop-metrics.integration.test.ts`, `harness/metrics/tests/usage-reader.integration.test.ts` (one test block), new `harness/metrics/tests/_helpers/temp-git-repo.ts`. No changes to `harness/metrics/loop-metrics.ts`, `harness/metrics/usage-reader.ts`, or any `src/` file.
+
+## Gherkin acceptance scenarios
+
+These are harness-tooling tests (no product `tests/features/*.feature` — consistent with `dod-check.integration.test.ts`'s precedent of subprocess-only coverage for harness scripts). Scenarios below describe the subprocess-smoke behaviour the rewritten tests assert; `fails if` names the guarded regression (R6/R7 — both in-process-launched subprocess tests, R7 scope note: guards script-level `cwd`/output-path wiring, not the pure lib logic already covered elsewhere).
+
+**Scenario A — loop-metrics runs against a temp repo, not the real tree**
+Given a temp git repo with fixture `docs/plans/story-*.md` files, tagged commits, and an `origin/main` branch
+When `harness/metrics/loop-metrics.ts` runs with `cwd` pointed at the temp repo
+Then `<tmpDir>/docs/metrics/loop.csv` is written with the expected header and one row per fixture story (including the skip-case row), and the real repo's `docs/metrics/loop.csv` is unchanged
+`fails if`: the entrypoint's `cwd` argument is ignored/dropped and `docs/metrics/loop.csv` under the real `REPO_ROOT` is modified again — guards the exact regression #150 reports.
+
+**Scenario B — usage-reader story mode runs against a temp repo, not the real tree**
+Given a temp git repo with one commit tagged `[story-zz]`
+When `harness/metrics/usage-reader.ts --story zz` runs with `cwd` pointed at the temp repo
+Then `<tmpDir>/docs/metrics/story-zz.md` is written with session-count/attribution/unattributed-sessions markers, and the real repo never gains a `docs/metrics/story-h4.md` (or `story-zz.md`)
+`fails if`: the entrypoint's `cwd` argument is ignored/dropped and an untracked `docs/metrics/story-<id>.md` appears in the real repo — guards the second regression #150 reports.
+
+Note: `usage-reader.ts`'s `getStoryCommitWindow` resolves the fixture commit via `git log --all ...`, not `origin/main`-scoped like `loop-metrics.ts`'s `getCommitLog`. `initTempRepo`'s `origin/main` branch is therefore inert scaffolding for Scenario B — the fixture commit only needs to exist on *some* ref in the temp repo, matched by `--all`, regardless of `origin/main`.
+
+## Slice plan (R13: target 6–10 commits)
+
+Preparatory (before Phase 3; not counted per R16 convention):
+- **P0:** `chore(docs): story-maint-19 plan + P1/P2/P3 review`
+
+Change-body commits:
+1. **C1:** `test(harness): sandbox loop-metrics integration test in a temp repo — failing [story-maint-19]`
+   Add `harness/metrics/tests/_helpers/temp-git-repo.ts`; rewrite `loop-metrics.integration.test.ts` to build a fixture temp repo and assert against `tmpDir`-relative paths — red, since the `spawnSync` call still points `cwd` at `REPO_ROOT` and never writes those paths.
+2. **C2:** `feat(harness): run loop-metrics entrypoint against the temp repo — green [story-maint-19]`
+   Switch the `spawnSync` call's `cwd` to `tmpDir`; add the real-repo-untouched regression assertion; green.
+3. **C3:** `test(harness): sandbox usage-reader story-mode integration test in a temp repo — failing [story-maint-19]`
+   Rewrite the `'writes docs/metrics/story-<id>.md...'` test to build a fixture temp repo; red.
+4. **C4:** `feat(harness): run usage-reader story-mode entrypoint against the temp repo — green [story-maint-19]`
+   Switch that test's `spawnSync` call's `cwd` to `tmpDir`; add the real-repo-untouched regression assertion; green.
+5. **C5:** `refactor(harness): tidy temp-git-repo helper usage across both metrics integration tests [story-maint-19]`
+   Local cleanup only (naming, shared `afterEach` cleanup list) — no cross-module extraction (see plan's "Why a local helper" note).
+6. **C6:** `chore(retro): story-maint-19 retrospective + status fragment [story-maint-19]`
+
+**Total: 6 change-body commits** — within R13's 6–10 target.
+
+## Risks & deferred items
+
+| Risk | Mitigation |
+|------|-----------|
+| Fixture temp repo drifts from what `getCommitLog`/`getPlanStoryIds`/`countStoryCommits` actually expect (e.g. `origin/main` ref shape), silently passing against a repo shape `loop-metrics.ts` wouldn't see in reality | Model `initTempRepo`'s `origin/main` branch creation directly on the pattern `getCommitLog` uses (`git log --format=... origin/main`), matching `dod-check.integration.test.ts`'s own established `origin/main` branch-creation convention |
+| Shared helper duplicated (not extracted) between `dod-check` and `metrics` test suites — two near-identical `initTempRepo`/`git` implementations now exist in the repo | Acceptable per plan's own reasoning (cross-module extraction is #119's concern, not this story's); flagged here so it isn't silently forgotten |
+| `usage-reader.ts --story` test's session-count/attribution assertions are unconditional per `formatStoryReport`, so a future change weakening that guarantee wouldn't be caught by *this* story's rewrite | Pre-existing test scope (unchanged from today); out of scope for a pollution fix |
+
+Cross-module temp-repo helper extraction → tracked by existing issue [#119](https://github.com/xavierbriand/accounting/issues/119) (no new issue needed; #150 itself named #119 as the adjacent candidate).
+
+## Verification plan
+
+1. `npm run test:harness` (or targeted `npx vitest run harness/metrics/tests/`) — green.
+2. `git status --porcelain -- docs/metrics` immediately after step 1 — empty (the regression this story fixes).
+3. Run step 1 **twice in a row** — both runs green (guards the "second run fails because the corpus is dirtied" failure mode #150 describes).
+4. `npm run lint && npm run build && npm test` — full suite green.
+5. `npx tsx harness/drift-scan/drift-scan.ts --all` — exit 0.
+
+## Suggestion log
+
+Phase 2 — `plan-reviewer` + `sibling-overlap` in parallel, 2026-07-03.
+
+| # | Finding | Tag | Resolution |
+|---|---------|-----|------------|
+| 1 | Scenario B's shared `initTempRepo` `origin/main` branch is inert scaffolding — `usage-reader.ts`'s `getStoryCommitWindow` resolves via `git log --all`, not `origin/main`-scoped, so the plan's risk-table note ("model `origin/main` per `getCommitLog`'s pattern") only covers Scenario A | ADOPT | Added an explicit note under Scenario B clarifying the fixture commit only needs to exist on some ref, matched by `--all`, independent of `origin/main` |
+| 2 | Scenario A's real-repo "byte-identical before/after" regression guard doesn't state snapshot timing, leaving a theoretical race if vitest's file-level parallelism interleaves reads of the real `docs/metrics/loop.csv` | ADOPT | Clarified the snapshot is captured once via `beforeEach` in the one spec file that touches that real path; vitest runs `it()` blocks within a file sequentially, and no other spec file reads/writes it |
+| 3 | Duplicated `initTempRepo`/`git` helper logic between `dod-check.integration.test.ts` and the new `harness/metrics/tests/_helpers/temp-git-repo.ts`, rather than a single shared implementation | ACKNOWLEDGE | Plan's own "Why a local helper" section and risk table already name this and defer cross-module extraction to #119 (per #150's own suggestion) — correctly scoped out of this story |
+| 4 | Scenario B rewrite using synthetic `story-zz` instead of the real `h4` id is a PII/coherence improvement over the current test | ACKNOWLEDGE | Positive observation, no change needed |
+| 5 | Loop-metrics fixture set (skip-case story + retro-with-`## Loop metrics`-heading story) is a reasonable mock-diversity analog (R8) for CSV-row-shape output | ACKNOWLEDGE | Positive observation, no change needed |
+| 6 | Remaining ~20 P1/P2/P3 findings and the full R1–R25 rule-tag coverage check are confirmations that the plan already satisfies each applicable rule (R1, R2, R6, R7, R12, R13, R19, R23, R24) or that the rule doesn't apply (R3–R5, R9–R11, R14–R18, R20–R22, R25) | ACKNOWLEDGE | No plan changes needed — reviewed and confirmed accurate against the plan text |
+| 7 | Sibling-overlap audit: 0 open PRs, no overlapping open issue; #119 adjacency already correctly deferred by the plan | ACKNOWLEDGE | Clean — nothing to resolve |
+
+**Tally:** 2 adopted / 5 acknowledged / 0 deferred / 0 rejected. DoR gate met — no un-tagged suggestions.
+
+## DoR checklist
+
+- [x] Phase 0 (Model): `No model impact` declared above (R24).
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review — plan-reviewer + sibling-overlap in parallel): complete 2026-07-03; findings triaged above.
+- [ ] Draft PR with template sections 1–6 filled.

--- a/docs/retrospectives/story-maint-19.md
+++ b/docs/retrospectives/story-maint-19.md
@@ -1,0 +1,46 @@
+# Story maint-19 retrospective
+
+**PR:** https://github.com/xavierbriand/accounting/pull/158  **Closes:** [#150](https://github.com/xavierbriand/accounting/issues/150)
+
+Sandboxes `harness/metrics/tests/loop-metrics.integration.test.ts` and `harness/metrics/tests/usage-reader.integration.test.ts`'s story-mode test in a temp git repo, following `harness/dod-check/tests/dod-check.integration.test.ts`'s existing pattern. Both entrypoints (`loop-metrics.ts`, `usage-reader.ts`) resolve output paths from `process.cwd()`; the old tests invoked them with `cwd: REPO_ROOT`, so every `npm run test:harness` run modified the real, tracked `docs/metrics/loop.csv` and created an untracked `docs/metrics/story-h4.md`. No production code changed — pointing `cwd` at a temp repo was sufficient.
+
+## Keep
+
+- **Confirming the bug (and its exact shape) before writing a line of fixture code paid off.** Running the pre-change suite and checking `git status --porcelain -- docs/metrics` showed both symptoms directly — a modified `loop.csv` and an untracked `story-h4.md` — and traced the second one to a *different* test file (`usage-reader.integration.test.ts`) than the one named in issue #150's title. Reading `loop-metrics.ts`/`usage-reader.ts` before touching tests also surfaced the `origin/main` (branch-scoped `git log`) vs `--all` (unscoped) asymmetry between the two entrypoints early, which fed directly into a Phase 2 finding rather than a Phase 4 one.
+- **A literal red/green split, even for a "just point cwd at tmpDir" change, caught a real fixture bug.** Committing C1 (fixture assertions, still pointed at `REPO_ROOT`) as genuinely failing, then flipping to `tmpDir` for C2, surfaced that tagging the retro-fixture commit's subject with `[story-aa]` made it double-count in `countStoryCommits('aa')` — a mistake that would have silently produced a wrong `diff_loc`/`commits` value if the test had been written cwd-correct from the start and merely "happened to pass."
+- **Deferring the cross-module helper extraction (dod-check ↔ metrics) to #119, rather than bundling it here, kept the story small.** #150 itself named #119 as the adjacent candidate; both plan-reviewer and code-reviewer independently confirmed the local `harness/metrics/tests/_helpers/temp-git-repo.ts` was the right scope boundary for a single-issue fix.
+
+## Change
+
+- **A stale CI check on the PR (from an earlier, partially-pushed commit) briefly looked like a real P1 finding.** The code-reviewer agent flagged PR #158's `build` check as failing on `harness/drift-scan/tests/drift-scan.integration.test.ts` — a file this story never touched. Investigation showed the failure was on commit `32d1ac5` (the plan/DoR-link prep commits), pushed before C1–C5 existed; C1–C5 were sitting local-only at review time. Once pushed, the concern was moot. Worth internalizing: before treating a `gh pr checks` result as a finding, confirm it matches current `HEAD`, not a stale push.
+- **The C5 refactor commit's actual diff (removing one unused import) didn't match its own slice-plan description** ("Local cleanup only (naming, shared `afterEach` cleanup list)"). Caught by the code-reviewer's Phase 4 pass, not self-caught during implementation — a slice-plan description should be treated as a checklist against the diff, not just prose written in advance.
+
+## Try
+
+- **When a plan's slice description promises a specific refactor shape (e.g. "shared cleanup list"), diff the actual commit against that sentence before moving on**, not just running the tests. This story's fix was cheap (extract `cleanupTempDirs` into the shared helper, ~15 min), but it would have been cheaper still to catch during C5 itself rather than at Phase 4.
+
+## Code-review findings (Phase 4, 2026-07-03)
+
+5 findings total (1 P1, 0 P2, 2 P3 non-soft + 2 soft).
+
+| Finding | Resolution |
+| --- | --- |
+| PR #158's CI `build` check failing on `harness/drift-scan/tests/drift-scan.integration.test.ts`, a file untouched by this diff | acknowledged — traced to a stale CI run on commit `32d1ac5` (before C1–C5 were pushed); the test passes locally against both `origin/main` and this branch's `HEAD`. Resolved by pushing the full commit range for a fresh CI run |
+| C5 (`refactor(harness): tidy temp-git-repo helper usage...`) diff (1-line unused-import removal) didn't match its plan description ("shared `afterEach` cleanup list") | fix-now — amended C5 (unpushed at review time) to add `cleanupTempDirs()` to `temp-git-repo.ts` and use it from both integration test files' `afterEach` blocks, matching the description |
+| (soft) `TEMP_DIRS.push(tmpDir)` + `initTempRepo()` call-site pattern still duplicated across both files | acknowledged — explicitly deferred to #119 in the plan; first candidate for that follow-up when it lands |
+| (soft) One `fails if` comment referenced "Gherkin Scenario A" while its sibling test's comment omitted the scenario tag | fix-now — added the matching scenario reference for consistency |
+| Mock-diversity check (R8): loop-metrics fixture includes both a resolvable and an unresolvable/skip-case row, not defaults-only | acknowledged — positive, no change needed |
+
+## Drift scan (mandatory)
+
+- [x] Did this story introduce contradictions between CLAUDE.md and any `docs/` file? **No.** No CLAUDE.md changes; no new rule tag introduced.
+- [x] If yes, reconciled in this PR? N/A — no contradictions.
+- [x] `npx tsx harness/drift-scan/drift-scan.ts --all` — exit 0.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| `harness/metrics/tests/_helpers/temp-git-repo.ts` shared helper | new file | done |
+| Both metrics integration test files sandboxed in a temp repo | `harness/metrics/tests/*.integration.test.ts` | done |
+| Cross-module (`dod-check` ↔ `metrics`) helper extraction | future story, tracked by [#119](https://github.com/xavierbriand/accounting/issues/119) | open |

--- a/docs/status.d/2026-07-03-story-maint-19.md
+++ b/docs/status.d/2026-07-03-story-maint-19.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-03
+story: maint-19
+pr: 158
+epic: harness
+---
+
+story-maint-19 shipped (#150). Sandboxes `harness/metrics/tests/loop-metrics.integration.test.ts` and `harness/metrics/tests/usage-reader.integration.test.ts`'s story-mode test in a temp git repo (new `harness/metrics/tests/_helpers/temp-git-repo.ts`), following the existing `dod-check.integration.test.ts` pattern. Fixes both entrypoints' `cwd`-relative output writing polluting the real `docs/metrics/` tree (a modified `loop.csv` and an untracked `story-h4.md`) on every `npm run test:harness` run. No production code changed. Cross-module helper extraction (`dod-check` ↔ `metrics`) deferred to #119.

--- a/harness/metrics/tests/_helpers/temp-git-repo.ts
+++ b/harness/metrics/tests/_helpers/temp-git-repo.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+// Commits land directly on a local branch literally named `origin/main` so
+// `git log origin/main` (loop-metrics.ts's getCommitLog) sees them without a
+// real remote — mirrors dod-check.integration.test.ts's temp-repo pattern,
+// but checked out immediately since our fixtures commit straight to it
+// rather than a separate story branch.
+export function initTempRepo(): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metrics-e2e-'));
+  git(tmpDir, ['init', '-q']);
+  git(tmpDir, ['config', 'user.email', 'fixture@example.com']);
+  git(tmpDir, ['config', 'user.name', 'Fixture']);
+  // Disable commit signing for this hermetic temp repo — the global git
+  // config on this machine signs via an SSH agent (1Password), which is
+  // unrelated to what this test exercises and can flake independently.
+  git(tmpDir, ['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(tmpDir, 'base.txt'), 'base\n');
+  git(tmpDir, ['add', 'base.txt']);
+  git(tmpDir, ['commit', '-q', '-m', 'chore: base commit']);
+  git(tmpDir, ['checkout', '-q', '-b', 'origin/main']);
+  return tmpDir;
+}
+
+export function writeAndCommit(tmpDir: string, relPath: string, content: string, subject: string): void {
+  const fullPath = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, 'utf8');
+  git(tmpDir, ['add', relPath]);
+  git(tmpDir, ['commit', '-q', '-m', subject]);
+}

--- a/harness/metrics/tests/_helpers/temp-git-repo.ts
+++ b/harness/metrics/tests/_helpers/temp-git-repo.ts
@@ -35,3 +35,11 @@ export function writeAndCommit(tmpDir: string, relPath: string, content: string,
   git(tmpDir, ['add', relPath]);
   git(tmpDir, ['commit', '-q', '-m', subject]);
 }
+
+// Shared afterEach cleanup for the TEMP_DIRS-array pattern both integration
+// test files use — removes each dir and clears the list.
+export function cleanupTempDirs(dirs: string[]): void {
+  for (const dir of dirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/harness/metrics/tests/loop-metrics.integration.test.ts
+++ b/harness/metrics/tests/loop-metrics.integration.test.ts
@@ -33,12 +33,14 @@ describe('metrics:loop subprocess smoke', () => {
     const tmpDir = initTempRepo();
     TEMP_DIRS.push(tmpDir);
     // story-aa: resolvable commit + a retro carrying the Loop metrics heading.
+    // The retro commit deliberately omits the story tag so it doesn't also
+    // match countStoryCommits('aa') — only the plan commit should count.
     writeAndCommit(tmpDir, 'docs/plans/story-aa.md', '# Story aa\n\nline2\nline3\nline4\n', 'feat(harness): aa fixture — green [story-aa]');
     writeAndCommit(
       tmpDir,
       'docs/retrospectives/story-aa.md',
       '# Retro aa\n\n## Loop metrics\n\nsome content\n',
-      'chore(retro): aa retro [story-aa]',
+      'chore: add aa retro fixture',
     );
     // story-bb: plan file present, but no commit anywhere references story-bb — skip case.
     writeAndCommit(tmpDir, 'docs/plans/story-bb.md', '# Story bb\n\nunresolvable\n', 'chore: add bb plan, no story tag');
@@ -51,7 +53,7 @@ describe('metrics:loop subprocess smoke', () => {
   it('writes <tmpDir>/docs/metrics/loop.csv with a header row and one row per fixture story, reporting top-3 + skips on stderr', () => {
     const tmpDir = buildFixtureRepo();
 
-    const result = spawnSync('npx', ['tsx', ENTRYPOINT], { cwd: REPO_ROOT, encoding: 'utf8' });
+    const result = spawnSync('npx', ['tsx', ENTRYPOINT], { cwd: tmpDir, encoding: 'utf8' });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toContain('top-3 weight-ratio offenders:');
@@ -64,7 +66,7 @@ describe('metrics:loop subprocess smoke', () => {
     const lines = csv.trim().split('\n');
     expect(lines[0]).toBe('story_id,plan_loc,diff_loc,commits,weight_ratio,retro_loop_metrics');
     expect(lines).toHaveLength(3);
-    expect(lines).toContain('aa,4,4,1,1,true');
+    expect(lines).toContain('aa,5,5,1,1,true');
     expect(lines[2]).toMatch(/^bb,\d+,n\/a,0,n\/a,false$/);
   });
 
@@ -76,7 +78,7 @@ describe('metrics:loop subprocess smoke', () => {
   it('never silently drops an unresolvable story — every skip is named with a reason', () => {
     const tmpDir = buildFixtureRepo();
 
-    const result = spawnSync('npx', ['tsx', ENTRYPOINT], { cwd: REPO_ROOT, encoding: 'utf8' });
+    const result = spawnSync('npx', ['tsx', ENTRYPOINT], { cwd: tmpDir, encoding: 'utf8' });
 
     expect(result.stderr).toContain('bb: no merge commit resolved for story id "bb"');
 

--- a/harness/metrics/tests/loop-metrics.integration.test.ts
+++ b/harness/metrics/tests/loop-metrics.integration.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { initTempRepo, writeAndCommit } from './_helpers/temp-git-repo.js';
+import { initTempRepo, writeAndCommit, cleanupTempDirs } from './_helpers/temp-git-repo.js';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
 const ENTRYPOINT = path.join(REPO_ROOT, 'harness', 'metrics', 'loop-metrics.ts');
@@ -24,9 +24,7 @@ describe('metrics:loop subprocess smoke', () => {
   });
 
   afterEach(() => {
-    for (const dir of TEMP_DIRS.splice(0)) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
+    cleanupTempDirs(TEMP_DIRS);
   });
 
   function buildFixtureRepo(): string {
@@ -73,8 +71,9 @@ describe('metrics:loop subprocess smoke', () => {
   // fails if: a story whose commit cannot be resolved is dropped from both
   // the CSV and the skip-report instead of appearing in the CSV as 'n/a'
   // plus a named skip reason — the baseline would then lie by omission
-  // (guards loop-metrics.ts's row-emission path end-to-end, isolated from
-  // the real repo's history via the fixture built above).
+  // (Gherkin Scenario A's skip-case leg; guards loop-metrics.ts's
+  // row-emission path end-to-end, isolated from the real repo's history via
+  // the fixture built above).
   it('never silently drops an unresolvable story — every skip is named with a reason', () => {
     const tmpDir = buildFixtureRepo();
 

--- a/harness/metrics/tests/loop-metrics.integration.test.ts
+++ b/harness/metrics/tests/loop-metrics.integration.test.ts
@@ -1,56 +1,87 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { initTempRepo, writeAndCommit } from './_helpers/temp-git-repo.js';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
 const ENTRYPOINT = path.join(REPO_ROOT, 'harness', 'metrics', 'loop-metrics.ts');
+const REAL_CSV_PATH = path.join(REPO_ROOT, 'docs', 'metrics', 'loop.csv');
 
 describe('metrics:loop subprocess smoke', () => {
-  // fails if: the npm script wiring (tsx invocation, cwd resolution, git
-  // origin/main lookup) breaks even though the in-process lib tests pass —
-  // guards script-level integration, not just the pure lib (R7 scope note).
-  // (Gherkin scenario A: weight-ratio baseline.)
-  it('writes docs/metrics/loop.csv with a header row and reports top-3 + skips on stderr', () => {
-    const result = spawnSync('npx', ['tsx', ENTRYPOINT], {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-    });
+  const TEMP_DIRS: string[] = [];
+  let realCsvBefore: string;
+
+  beforeAll(() => {
+    realCsvBefore = fs.readFileSync(REAL_CSV_PATH, 'utf8');
+  });
+
+  afterAll(() => {
+    // fails if: the entrypoint's cwd argument is ignored/dropped and the
+    // real repo's docs/metrics/loop.csv is modified again — guards the
+    // exact regression #150 reports.
+    expect(fs.readFileSync(REAL_CSV_PATH, 'utf8')).toBe(realCsvBefore);
+  });
+
+  afterEach(() => {
+    for (const dir of TEMP_DIRS.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function buildFixtureRepo(): string {
+    const tmpDir = initTempRepo();
+    TEMP_DIRS.push(tmpDir);
+    // story-aa: resolvable commit + a retro carrying the Loop metrics heading.
+    writeAndCommit(tmpDir, 'docs/plans/story-aa.md', '# Story aa\n\nline2\nline3\nline4\n', 'feat(harness): aa fixture — green [story-aa]');
+    writeAndCommit(
+      tmpDir,
+      'docs/retrospectives/story-aa.md',
+      '# Retro aa\n\n## Loop metrics\n\nsome content\n',
+      'chore(retro): aa retro [story-aa]',
+    );
+    // story-bb: plan file present, but no commit anywhere references story-bb — skip case.
+    writeAndCommit(tmpDir, 'docs/plans/story-bb.md', '# Story bb\n\nunresolvable\n', 'chore: add bb plan, no story tag');
+    return tmpDir;
+  }
+
+  // fails if: loop-metrics.ts writes into the real repo tree instead of the
+  // cwd it's invoked with (Gherkin Scenario A) — guards script-level cwd/
+  // output-path wiring, not the pure lib tested in loop-metrics.test.ts.
+  it('writes <tmpDir>/docs/metrics/loop.csv with a header row and one row per fixture story, reporting top-3 + skips on stderr', () => {
+    const tmpDir = buildFixtureRepo();
+
+    const result = spawnSync('npx', ['tsx', ENTRYPOINT], { cwd: REPO_ROOT, encoding: 'utf8' });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toContain('top-3 weight-ratio offenders:');
+    expect(result.stderr).toContain('aa (weight_ratio=1)');
     expect(result.stderr).toContain('skipped stories:');
 
-    const csvPath = path.join(REPO_ROOT, 'docs', 'metrics', 'loop.csv');
+    const csvPath = path.join(tmpDir, 'docs', 'metrics', 'loop.csv');
     expect(fs.existsSync(csvPath)).toBe(true);
     const csv = fs.readFileSync(csvPath, 'utf8');
     const lines = csv.trim().split('\n');
     expect(lines[0]).toBe('story_id,plan_loc,diff_loc,commits,weight_ratio,retro_loop_metrics');
-    expect(lines.length).toBeGreaterThanOrEqual(35);
+    expect(lines).toHaveLength(3);
+    expect(lines).toContain('aa,4,4,1,1,true');
+    expect(lines[2]).toMatch(/^bb,\d+,n\/a,0,n\/a,false$/);
   });
 
   // fails if: a story whose commit cannot be resolved is dropped from both
   // the CSV and the skip-report instead of appearing in the CSV as 'n/a'
   // plus a named skip reason — the baseline would then lie by omission
-  // (Gherkin scenario A `fails if` note; guards loop-metrics.ts row-emission
-  // path end-to-end through the real repo's git history).
+  // (guards loop-metrics.ts's row-emission path end-to-end, isolated from
+  // the real repo's history via the fixture built above).
   it('never silently drops an unresolvable story — every skip is named with a reason', () => {
-    const result = spawnSync('npx', ['tsx', ENTRYPOINT], {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-    });
+    const tmpDir = buildFixtureRepo();
 
-    const csvPath = path.join(REPO_ROOT, 'docs', 'metrics', 'loop.csv');
+    const result = spawnSync('npx', ['tsx', ENTRYPOINT], { cwd: REPO_ROOT, encoding: 'utf8' });
+
+    expect(result.stderr).toContain('bb: no merge commit resolved for story id "bb"');
+
+    const csvPath = path.join(tmpDir, 'docs', 'metrics', 'loop.csv');
     const csv = fs.readFileSync(csvPath, 'utf8');
-
-    const skipLines = result.stderr
-      .split('\n')
-      .filter((line) => /^\s{2}[\w.-]+: /.test(line) && !line.startsWith('  1.') && !line.startsWith('  2.') && !line.startsWith('  3.'));
-
-    for (const skipLine of skipLines) {
-      const storyId = skipLine.trim().split(':')[0];
-      expect(csv).toContain(`${storyId},`);
-      expect(csv).toMatch(new RegExp(`${storyId},\\d+,n/a,`));
-    }
+    expect(csv).toMatch(/^bb,\d+,n\/a,/m);
   });
 });

--- a/harness/metrics/tests/usage-reader.integration.test.ts
+++ b/harness/metrics/tests/usage-reader.integration.test.ts
@@ -1,15 +1,17 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeAll, afterAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { initTempRepo, writeAndCommit } from './_helpers/temp-git-repo.js';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
 const ENTRYPOINT = path.join(REPO_ROOT, 'harness', 'metrics', 'usage-reader.ts');
 const FIXTURE = path.join(REPO_ROOT, 'harness', 'metrics', 'fixtures', 'session-mixed.jsonl');
+const REAL_STORY_H4_PATH = path.join(REPO_ROOT, 'docs', 'metrics', 'story-h4.md');
 
-function run(args: string[]): ReturnType<typeof spawnSync> {
-  return spawnSync('npx', ['tsx', ENTRYPOINT, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
+function run(args: string[], cwd: string = REPO_ROOT): ReturnType<typeof spawnSync> {
+  return spawnSync('npx', ['tsx', ENTRYPOINT, ...args], { cwd, encoding: 'utf8' });
 }
 
 describe('metrics:usage subprocess smoke', () => {
@@ -73,16 +75,42 @@ describe('metrics:usage subprocess smoke', () => {
 });
 
 describe('metrics:story subprocess smoke', () => {
+  const TEMP_DIRS: string[] = [];
+
+  beforeAll(() => {
+    // fails if: the real repo's docs/metrics/story-h4.md already exists
+    // before this test runs — the regression guard below (no story-h4.md
+    // appears) would be meaningless against an already-polluted tree.
+    expect(fs.existsSync(REAL_STORY_H4_PATH)).toBe(false);
+  });
+
+  afterEach(() => {
+    for (const dir of TEMP_DIRS.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(() => {
+    // fails if: the entrypoint's cwd argument is ignored/dropped and an
+    // untracked docs/metrics/story-h4.md appears in the real repo — guards
+    // the second regression #150 reports.
+    expect(fs.existsSync(REAL_STORY_H4_PATH)).toBe(false);
+  });
+
   // fails if: attribution-window wiring (git log window resolution, real
   // session-file discovery) breaks even though attributeToStory's pure
   // logic is unit-tested. R7 scope note: subprocess smoke covers script
   // wiring only. (Gherkin scenario C: story attribution declares
   // uncertainty.)
-  it('writes docs/metrics/story-<id>.md with an attribution note', () => {
-    const result = run(['--story', 'h4']);
+  it('writes <tmpDir>/docs/metrics/story-<id>.md with an attribution note', () => {
+    const tmpDir = initTempRepo();
+    TEMP_DIRS.push(tmpDir);
+    writeAndCommit(tmpDir, 'touched.txt', 'x\n', 'chore: fixture commit [story-zz]');
+
+    const result = run(['--story', 'zz']);
     expect(result.status).toBe(0);
 
-    const reportPath = path.join(REPO_ROOT, 'docs', 'metrics', 'story-h4.md');
+    const reportPath = path.join(tmpDir, 'docs', 'metrics', 'story-zz.md');
     expect(fs.existsSync(reportPath)).toBe(true);
     const report = fs.readFileSync(reportPath, 'utf8');
     expect(report).toContain('session count:');

--- a/harness/metrics/tests/usage-reader.integration.test.ts
+++ b/harness/metrics/tests/usage-reader.integration.test.ts
@@ -3,7 +3,7 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { initTempRepo, writeAndCommit } from './_helpers/temp-git-repo.js';
+import { initTempRepo, writeAndCommit, cleanupTempDirs } from './_helpers/temp-git-repo.js';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
 const ENTRYPOINT = path.join(REPO_ROOT, 'harness', 'metrics', 'usage-reader.ts');
@@ -85,9 +85,7 @@ describe('metrics:story subprocess smoke', () => {
   });
 
   afterEach(() => {
-    for (const dir of TEMP_DIRS.splice(0)) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
+    cleanupTempDirs(TEMP_DIRS);
   });
 
   afterAll(() => {

--- a/harness/metrics/tests/usage-reader.integration.test.ts
+++ b/harness/metrics/tests/usage-reader.integration.test.ts
@@ -107,7 +107,7 @@ describe('metrics:story subprocess smoke', () => {
     TEMP_DIRS.push(tmpDir);
     writeAndCommit(tmpDir, 'touched.txt', 'x\n', 'chore: fixture commit [story-zz]');
 
-    const result = run(['--story', 'zz']);
+    const result = run(['--story', 'zz'], tmpDir);
     expect(result.status).toBe(0);
 
     const reportPath = path.join(tmpDir, 'docs', 'metrics', 'story-zz.md');


### PR DESCRIPTION
## 1. Story

Story plan: [docs/plans/story-maint-19.md](docs/plans/story-maint-19.md). Closes #150. No epic entry — harness/test-infra maintenance story, not an epic-aligned product story.

## 2. Intent

`harness/metrics/tests/loop-metrics.integration.test.ts` and `harness/metrics/tests/usage-reader.integration.test.ts` invoke their entrypoints with `cwd: REPO_ROOT`, so every `npm run test:harness` run modified the real, tracked `docs/metrics/loop.csv` and created an untracked `docs/metrics/story-h4.md`. This polluted the working tree and could make the loop-metrics test fail on a second run — easy to mistake for a regression. Fix: sandbox both subprocess-smoke tests in a temp git repo (`fs.mkdtempSync` + `afterEach` cleanup), following the pattern already used by `harness/dod-check/tests/dod-check.integration.test.ts`.

## 3. Alternatives considered

- Add a `--output-dir` flag to `loop-metrics.ts`/`usage-reader.ts` and point it at a temp dir — rejected: requires production-code changes; issue #150 explicitly proposes the temp-git-repo pattern with no production-code change, matching the sibling `dod-check` precedent.
- Extract a single shared `temp-git-repo` helper across `harness/dod-check` and `harness/metrics` now — rejected (deferred to #119): cross-module extraction is a coarser refactor with its own review surface; #150 itself names #119 as the adjacent home for that work.

## 4. Selected solution & rationale

Added `harness/metrics/tests/_helpers/temp-git-repo.ts` (local to `harness/metrics/tests/`, mirroring `dod-check.integration.test.ts`'s inline helpers) and rewrote both integration test files to build a fixture temp git repo and run their entrypoints with `cwd: tmpDir`. Both entrypoints already resolve `repoRoot = process.cwd()`, so no production code changes were needed. Each rewritten test adds a trailing regression-guard assertion confirming the real repo's `docs/metrics/` tree is untouched. Full rationale: see plan's "Selected solution" section.

## 5. Gherkin scenarios

```gherkin
Feature: Metrics integration tests run against an isolated temp repo

  Scenario: loop-metrics runs against a temp repo, not the real tree
    Given a temp git repo with fixture docs/plans/story-*.md files, tagged commits, and an origin/main branch
    When harness/metrics/loop-metrics.ts runs with cwd pointed at the temp repo
    Then <tmpDir>/docs/metrics/loop.csv is written with the expected header and one row per fixture story (including the skip-case row), and the real repo's docs/metrics/loop.csv is unchanged

  Scenario: usage-reader story mode runs against a temp repo, not the real tree
    Given a temp git repo with one commit tagged [story-zz]
    When harness/metrics/usage-reader.ts --story zz runs with cwd pointed at the temp repo
    Then <tmpDir>/docs/metrics/story-zz.md is written with session-count/attribution/unattributed-sessions markers, and the real repo never gains a docs/metrics/story-h4.md (or story-zz.md)
```

## 6. Plan for Sonnet

See [docs/plans/story-maint-19.md](docs/plans/story-maint-19.md) § Slice plan for the full 6-commit breakdown (C1–C6). Files touched: `harness/metrics/tests/loop-metrics.integration.test.ts`, `harness/metrics/tests/usage-reader.integration.test.ts`, new `harness/metrics/tests/_helpers/temp-git-repo.ts`. No `src/` or production `harness/metrics/*.ts` changes. DoD: `npm run test:harness` green, `git status --porcelain -- docs/metrics` empty after the run, running it twice in a row both green, full `npm run lint && npm run build && npm test` green, `npx tsx harness/drift-scan/drift-scan.ts --all` exit 0.

## 7. Suggestion log

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P1 (Phase 2) | Scenario B's shared `origin/main` branch scaffolding is inert for usage-reader (`git log --all`, not `origin/main`-scoped) | adopted | Plan clarified — Scenario B note added |
| P2 (Phase 2) | Real-repo "byte-identical before/after" guard didn't state snapshot timing (theoretical file-parallelism race) | adopted | Plan clarified — snapshot captured once via `beforeEach`/`beforeAll`, sequential within-file execution |
| P3 (Phase 2) | Duplicated `initTempRepo`/`git` helper logic vs. `dod-check.integration.test.ts` | acknowledged | Plan already defers cross-module extraction to #119 |
| P2 (Phase 2) | Scenario B's synthetic `story-zz` id (vs. real `h4`) is a PII/coherence improvement | acknowledged | Positive observation, no change needed |
| P2 (Phase 2) | Loop-metrics fixture set (skip-case + retro-heading story) is a reasonable mock-diversity analog (R8) | acknowledged | Positive observation, no change needed |
| — (Phase 2) | Sibling-overlap: 0 open PRs, no overlapping open issue; #119 adjacency already correctly deferred | acknowledged | Clean — nothing to resolve |
| P1 (Phase 4) | PR's CI `build` check appeared to fail on `harness/drift-scan/tests/drift-scan.integration.test.ts`, a file untouched by this diff | acknowledged | Traced to a stale CI run on an earlier, partially-pushed commit; passes locally on `origin/main` and this branch's HEAD — resolved by pushing the full commit range |
| P3 (Phase 4) | C5 refactor commit's diff didn't match its plan description ("shared afterEach cleanup list") | fix-now | Amended C5 to add `cleanupTempDirs()` to the shared helper and use it from both test files |
| P3 soft (Phase 4) | `fails if` comment consistency nit (scenario tag on one test but not its sibling) | fix-now | Added matching scenario reference |
| P2 soft (Phase 4) | Mock-diversity check (R8) — fixture includes both resolvable and skip-case rows | acknowledged | Positive, no change needed |

## 8. Sonnet's learnings

## What was built
`harness/metrics/tests/_helpers/temp-git-repo.ts` (new shared helper: `initTempRepo`, `writeAndCommit`, `git`, `cleanupTempDirs`) plus rewrites of `harness/metrics/tests/loop-metrics.integration.test.ts` and one test block in `harness/metrics/tests/usage-reader.integration.test.ts`, so both subprocess-smoke suites run their entrypoints with `cwd` pointed at a temp git repo instead of the real repo tree. No production code changed.

## Red → green sequence (per test)
- loop-metrics: C1 (`test:` — fixture assertions against `cwd: REPO_ROOT`, red) → C2 (flip to `cwd: tmpDir`, green). Caught a fixture bug in the red→green transition: tagging the retro-fixture commit with `[story-aa]` double-counted it in `countStoryCommits`.
- usage-reader story-mode: C3 (`test:` — fixture assertions against default `cwd: REPO_ROOT`, red) → C4 (pass `tmpDir` explicitly, green).
- C5: refactor — extracted `cleanupTempDirs()` into the shared helper, used from both files' `afterEach` blocks.
- C6: retrospective + status fragment.

## Deviations from plan (with rationale)
- Plan's Scenario B fixture note about `origin/main` branch scaffolding being inert for usage-reader was folded directly into the Gherkin scenario text during Phase 2 review, before implementation — no implementation-time deviation.
- C5's initial commit only removed an unused import (didn't match its "shared cleanup list" description); fixed post-Phase-4-review by amending the still-unpushed commit to add the described `cleanupTempDirs()` consolidation.

## Unknowns encountered
- None blocking. Confirmed via a sibling worktree checkout that `harness/drift-scan/tests/drift-scan.integration.test.ts` passes on `origin/main` baseline, ruling out a pre-existing regression when the PR's CI initially showed it failing (traced to a stale/partially-pushed commit instead).

## Proposed follow-ups
- Cross-module `temp-git-repo` helper extraction (`dod-check` ↔ `metrics`) — tracked by existing issue #119, not opened fresh here.
- Unrelated, out-of-scope: `tests/integration/cli/symlink-dbpath-refuse.test.ts` fails on a clean `origin/main` checkout (`error!.stderr` is `undefined`) — flagged as a background task suggestion, not part of this story.

## Files touched
- `harness/metrics/tests/_helpers/temp-git-repo.ts` (new)
- `harness/metrics/tests/loop-metrics.integration.test.ts`
- `harness/metrics/tests/usage-reader.integration.test.ts`
- `docs/plans/story-maint-19.md`
- `docs/retrospectives/story-maint-19.md`
- `docs/status.d/2026-07-03-story-maint-19.md`

## 9. Retrospective

- **Keep:** Confirming the bug's exact shape (both symptoms, across two different test files) before writing fixture code, and doing a literal red→green split even for a "just point cwd at tmpDir" change — the latter caught a real fixture bug (double-counted commit).
- **Change:** A slice-plan description ("shared afterEach cleanup list") should be diffed against the actual commit before moving on, not just checked via passing tests — this one drifted and was only caught at Phase 4.
- **Try:** Treat plan slice descriptions as a checklist against the diff at commit time, not just prose written in advance.

Full retrospective: [docs/retrospectives/story-maint-19.md](docs/retrospectives/story-maint-19.md)

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-maint-19.md`
- [x] All suggestion-log items resolved (no blank `Resolution` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval
