### PR TITLE
story-4.1: DomainEventRecorder port + append-only event store (FR23 spine)

### DIFF
--- a/docs/plans/story-4.1.md
+++ b/docs/plans/story-4.1.md
@@ -190,17 +190,17 @@ Scenario: Committing an ingest batch records a TransactionIngested event
   `--non-interactive` wording (adopted-finding #2 was a fixture problem; Phase 3 found the deeper
   path gap).
 
-```gherkin
-Scenario: A failed batch commit records no event
-  Given a fresh migrated database
-  And a statement whose commit will fail (simulated saveBatch failure)
-  When I run the ingest commit
-  Then no event is recorded in the audit trail
-```
+**In-process ordering guard (unit spec — not a quickpickle feature).** *No event is recorded on a
+failed batch commit:* given a failing `transactionRepository` stub (saveBatch → `Result.fail`) and
+a spy recorder, running `commitBatch` records **no** event (`recorder.record` never called).
+
 - **fails if:** `record(...)` is called before/independently of `saveBatch` success (guards the
   "only on success" ordering in `commitBatch`).
 - **classification:** **in-process** unit on `commitBatch` with a failing `transactionRepository`
-  stub + a spy recorder (no subprocess — a pure ordering assertion).
+  stub + a spy recorder (no subprocess — a pure ordering assertion). Lives as a unit test
+  (`ingest-command.test.ts` case (f)), **not** a `.feature` scenario — deliberately kept out of
+  Gherkin because a commit-failure is best simulated with an in-process stub, not driven through
+  the CLI.
 
 Store-level append-only + ordering are covered by an **integration** test on
 `SqliteDomainEventRecorder` (see Verification plan), not a Gherkin scenario (they assert on Infra
@@ -274,6 +274,22 @@ the actionable ones:
 | 9 | P3: migration SQL field-comment necessity | **ACKNOWLEDGE** | Phase-4 comment-necessity check (per engineering-standards § Style). Comments kept brief and label-style, mirroring 002/004. |
 
 No un-tagged findings; the one DEFER links [#180](https://github.com/xavierbriand/accounting/issues/180).
+
+### Phase 4 (code-reviewer + ddd-modeler Mode B) dispositions
+
+`ddd-modeler` Mode B: **0 hard violations** (Core purity, no-base-class, timestamp-boundary,
+PII-free payload, vocabulary all conformant). `code-reviewer`: 4 findings + 3 soft.
+
+| # | Finding | Tag | Resolution |
+|---|---------|-----|------------|
+| P4-1 | P2: `record()` failure error written to stderr without `sanitizeSqlError` (unlike sibling `saveBatch` branch) | **FIX-NOW** | [79615d4] wrapped in `sanitizeSqlError`. |
+| P4-2 | P1/R2: plan promised an in-process real-infra "record fires" assertion in `ingest-commit.test.ts`; not delivered (test (g) uses a spy; subprocess covers e2e) | **FIX-NOW** | [79615d4] added the real-infra `domain_events` assertion; slice-4 claim below corrected. |
+| P4-3 | P3 soft: `FORBIDDEN_IMPORT_PATTERNS` textual regex misses `node:fs`/`node:path` | **FIX-NOW** | [79615d4] regex now matches optional `node:` prefix. |
+| P4-4 | P3: migration-004/hash-repo test loosening (`toBe(4)`→`>=4`) bundled into slice-4 feature commit | **ACKNOWLEDGE** | Each edit narrow, commented, justified (migration-005 fallout); not worth a history rewrite. Retro Change: version-fallout tests should be their own `chore:` commit. |
+| P4-5 | P3 soft: `audit-trail.feature` embeds inline `#` `fails if` comments — house-style first | **ACKNOWLEDGE** | Valid Gherkin; retro Try: standardize `fails if` prose in step docstrings. |
+| P4-6 | P3 soft: recorder `catch` loses `Error`/stack via `String(err)` | **ACKNOWLEDGE** | Consistent with existing repos (house pattern). |
+| P4-7 | ddd-modeler: `TransactionIngested.transactionIds` vs modelled `TransactionCorrected.producedTransactionIds` (family naming) | **ACKNOWLEDGE** | Kept `transactionIds` — clearer for an event with no "target"; no consumer exists; `TransactionCorrected` not yet built. Ratify family convention at 4.2 with both events concrete. Retro Change. |
+| P4-8 | ddd-modeler: `sourceAccount` not in the 4.0 note's field list | **ACKNOWLEDGE** | Composed from established "account" vocabulary; account id, not a new domain noun; no glossary edit (R25 clean). |
 
 ## DoR checklist
 

--- a/docs/plans/story-4.1.md
+++ b/docs/plans/story-4.1.md
@@ -1,0 +1,275 @@
+# Story 4.1 — DomainEventRecorder Port & Append-Only Event Store
+
+## Context
+
+Epic 4 (Trust, Transparency & Lifecycle) needs an immutable, ordered **audit trail** (FR23):
+every meaningful action recorded as a plain domain event. Story-4.0 (the Epic-4 defining
+session, issue #156) modelled the vocabulary and sliced the epic; this story ships the
+**spine** — the `DomainEventRecorder` port (#155) + an append-only Infra event store — wired
+to the simplest existing action (ingest) emitting the first event, `TransactionIngested`.
+Every later event (4.2 `TransactionCorrected`, 4.5 `ConfigChanged`/`DissolutionPerformed`,
+Epic-5 Story 5.4) depends on this port.
+
+**FR/NFR:** FR23 (Audit Trail) — the spine only; later events complete the coverage.
+
+**Deferred-decision resolved here (from story-4.0 model note § Event-timestamp boundary):**
+the recorder **call-site** for a ledger-mutating event. Decided **B1 (app-boundary)** — see
+Selected solution.
+
+### Maintenance sub-loop (§ 6.7) run 2026-07-05 pre-planning
+
+- **Sibling work check.** `gh pr list --state open` → none. `gh issue list --state open` → 34
+  open issues reviewed; #155 (this port) and #156 (Epic-4 def) are the parents, not competitors.
+  No open PR/issue is building the event store. No overlap.
+- **Story-id uniqueness.** `git ls-tree -r origin/main … | grep story-4.1` → none. No open PR
+  branch named story-4.1. Id free.
+- **Working tree clean.** `git status` clean; branch `story-4.1` cut from `origin/main` (HEAD c1712e1).
+- **Open issues.** 34 open; `deferred-suggestion` items remain relevant; none block this story.
+- **Backlog refinement.** Not re-run this sub-loop (last pass current); tracker coordinating.
+- **Open PRs.** None (no Dependabot in flight).
+- **`npm audit --audit-level=high`.** 0 vulnerabilities.
+- **Proceed-to-planning:** clear. Full lane (touches `src/core/` + new migration).
+
+## Story
+
+> As the **System**, I want a Core `DomainEventRecorder` port with an append-only Infra event
+> store, wired first to the ingest path emitting a `TransactionIngested` event, so that every
+> meaningful action from here on can be recorded as an immutable, ordered audit trail (FR23) —
+> starting with the simplest existing action to prove the pattern.
+
+## Domain model
+
+Derives from the Phase-0 model note [docs/domain/model-notes/story-4.0.md](../domain/model-notes/story-4.0.md)
+(R24 — Epic-4 numbered stories derive their Domain-model section from the 4.0 note; no fresh
+model-session for 4.1, whose events the 4.0 note already models).
+
+- **Glossary terms used:** Audit trail / domain event, `TransactionIngested`, Ledger, Transaction,
+  Partner, Money. All already in [docs/domain/glossary.md](../domain/glossary.md) (promoted from
+  *forthcoming* in story-4.0). **No new vocabulary → no glossary edit this story.**
+- **Tactical roles introduced:**
+  - `DomainEvent` / `TransactionIngested` — **plain immutable value objects** in a new
+    `src/core/events/`. No base class, no dispatcher, no event sourcing (architecture.md §
+    Domain events).
+  - `DomainEventRecorder` — **Core port** (`src/core/ports/`); Infra persists append-only.
+- **Invariants the diff must not violate:**
+  1. Core stays pure — `src/core/events/` and the port import no Node APIs, no `better-sqlite3`,
+     no clock. The recording timestamp is **not** a Core field.
+  2. Append-only — the event store is INSERT-only; no `UPDATE`/`DELETE` (ledger rule extends to
+     the audit trail).
+  3. Ordered — events carry a monotonic sequence (autoincrement id) so they read in order.
+  4. Event payload carries **no raw PII** (no descriptions; account ids and transaction ids only).
+- **Events emitted:** `TransactionIngested` (first event; proves the recorder + store).
+
+## Selected solution
+
+**A Core `DomainEventRecorder` port + a `SqliteDomainEventRecorder` writing to a new append-only
+`domain_events` table, recorded at the app boundary (B1) after a successful ingest batch commit.**
+
+Four pieces:
+
+1. **Core event value objects** — `src/core/events/domain-event.ts`:
+   ```ts
+   export interface TransactionIngested {
+     readonly type: 'TransactionIngested';
+     readonly transactionIds: readonly string[];
+     readonly sourceAccount: string;
+   }
+   export type DomainEvent = TransactionIngested;   // union grows in 4.2 / 4.5
+   ```
+   Domain fields only — **no timestamp** (no clock in Core).
+
+2. **Core port** — `src/core/ports/domain-event-recorder.ts`:
+   ```ts
+   export interface DomainEventRecorder {
+     record(event: DomainEvent): Result<void>;
+   }
+   ```
+
+3. **Infra store** — migration `005-domain-events.sql` + `SqliteDomainEventRecorder`. The recorder
+   stamps the **recording timestamp** into a `recorded_at` column (UTC ISO, system event) at
+   `record()` time and serializes the event's domain fields to a JSON `payload`. Ordering via
+   autoincrement `seq`. **Column named `recorded_at`, not `occurred_at`** — deliberately distinct
+   from `transactions.occurred_at` (receipt-truth transaction date): the audit column is a system
+   clock value (closer to `transactions.created_at`), and reusing `occurred_at` would be a
+   same-name-different-meaning collision across the schema (P3 review).
+
+4. **Wiring (B1)** — `commitBatch` (ingest) calls `recorder.record(TransactionIngested{…})`
+   **immediately after** `saveBatch` succeeds, built from the committed outcomes' transaction ids
+   + source account. Composition root (`program.ts`) constructs `new SqliteDomainEventRecorder(db)`.
+
+**Call-site = B1 (app-boundary), decided here.** Rationale: ingest is orchestrated at the app
+boundary with **no Core domain service**, so the boundary is its natural seam; keeps
+`DomainEventRecorder` cleanly separate from `TransactionRepository` (no event vocabulary leaking
+into the ingest-ACL port — respects the #155 firewall note); leanest path that proves the
+port + store end-to-end, matching the story's "simplest action to prove the pattern" charter.
+This is consistent with the 4.0 note's *hybrid* model, not a contradiction of its "atomic with
+the rows" line: that line targets **domain-service-mediated** ledger mutations (4.2's
+`CorrectionService` returns `{reversal, correcting, event}` together and will record atomically),
+which ingest is not.
+
+**Known limitation (documented, deferred):** B1 is **not atomic** — a process crash between the
+batch commit and `record()` leaves a committed batch with no ingest event. Low impact: rare, and
+a re-run is idempotent (duplicates skipped) so no double ledger rows; the audit gap is
+recoverable. A `UnitOfWork`/atomic-record path is deferred to story 4.2, where a ledger-mutating
+event genuinely needs it. → Phase-2 deferred issue.
+
+**Alternatives set aside:**
+- **B2 (atomic inside `saveBatch`)** — grows the `TransactionRepository` port with event
+  vocabulary (mixes ingest-ACL + audit concerns the model note keeps apart) or needs a
+  `UnitOfWork` port now; more machinery than a spine story warrants.
+- **Per-transaction events** (N events per ingest) — noisier; the meaningful *action* is the
+  ingest run, so one batch-level event with `transactionIds[]` mirrors it (and mirrors
+  `TransactionCorrected`'s `producedTransactionIds[]`).
+- **Per-event-type columns** — a wide table per event shape; JSON `payload` keeps the store
+  schema-stable as event types grow, matching "plain value objects."
+
+## Production-code surface (R2)
+
+**New files:**
+- `src/core/events/domain-event.ts` — `DomainEvent` union + `TransactionIngested`.
+- `src/core/ports/domain-event-recorder.ts` — `DomainEventRecorder` interface.
+- `src/infra/db/migrations/005-domain-events.sql` — append-only `domain_events` table, `PRAGMA user_version = 5`.
+- `src/infra/db/repositories/sqlite-domain-event-recorder.ts` — `SqliteDomainEventRecorder`.
+
+**Changed signatures / wiring:**
+- `IngestCommandDeps` (`src/cli/commands/ingest-command.ts`) — add
+  `readonly domainEventRecorder: DomainEventRecorder`.
+- `commitBatch` — **two** signature changes (both called out in slice 5): (a) its deps `Pick`
+  grows `'domainEventRecorder'`; (b) a **new `sourceAccount: string` parameter** threaded in from
+  `runIngestCommand` (which holds `account.id`) — `BuildOutcome` carries no `sourceAccount`, so it
+  can't be derived from `outcomes` alone. The event is built inside `commitBatch` from the
+  committed outcomes' `transaction.id`s + `sourceAccount`.
+- `src/cli/program.ts` — construct `SqliteDomainEventRecorder(db)`, pass into ingest deps.
+  (**program.ts touched → R4 composition-root subprocess test required.**)
+
+**Output-format changes:** none (no read surface yet; ingest stdout/stderr unchanged).
+
+**DB schema:**
+```sql
+CREATE TABLE domain_events (
+  seq         INTEGER PRIMARY KEY AUTOINCREMENT,     -- monotonic order
+  event_type  TEXT NOT NULL,
+  recorded_at TEXT NOT NULL,                          -- UTC ISO, stamped at record() (system clock, NOT receipt truth)
+  payload     TEXT NOT NULL                           -- JSON of domain fields
+);
+PRAGMA user_version = 5;
+```
+Append-only: INSERT-only by convention (mirrors `transactions`/the ledger — no DB trigger there
+either; convention-only is house style, not a regression).
+
+**Forward pointer (Zod):** 4.1 has no read surface, so the JSON `payload` is write-only here. The
+future story that *reads* `domain_events.payload` back out must Zod-validate it at the Infra
+boundary (never in Core) before reconstructing an event — noted so the consumer story picks it up.
+
+## Gherkin acceptance scenarios
+
+Feature file: `tests/features/audit-trail.feature`. The `correct`/read surfaces arrive later; 4.1
+is observed by inspecting the `domain_events` table after a real ingest.
+
+```gherkin
+Scenario: Ingesting a statement records a TransactionIngested event
+  Given a fresh migrated database and a valid single-row BPCE statement
+  When I ingest it non-interactively
+  Then the audit trail holds one TransactionIngested event
+  And its payload lists the committed transaction id and source account
+```
+- **fails if:** the ingest path does not call `recorder.record(...)` after `saveBatch` succeeds
+  (guards the B1 wiring in `commitBatch` + the `program.ts` composition-root construction).
+- **classification:** **subprocess** (real CLI via `program.ts`, real SQLite) — this is the R4
+  composition-root test.
+- **fixture note (R6/R7 honesty):** the existing `ingest-end-to-end-wiring.test.ts` uses a
+  low-confidence fixture and asserts **exit 2** — it never reaches `commitBatch`. This scenario
+  needs a **new single-row fixture whose row auto-tags high-confidence** (matches an auto-tag rule
+  in the stub `accounting.yaml`) so `ingest --non-interactive` reaches a successful commit
+  (**exit 0**) and thus `record()`. Without that, the `fails if` clause is never exercised.
+
+```gherkin
+Scenario: A failed batch commit records no event
+  Given a fresh migrated database
+  And a statement whose commit will fail (simulated saveBatch failure)
+  When I run the ingest commit
+  Then no event is recorded in the audit trail
+```
+- **fails if:** `record(...)` is called before/independently of `saveBatch` success (guards the
+  "only on success" ordering in `commitBatch`).
+- **classification:** **in-process** unit on `commitBatch` with a failing `transactionRepository`
+  stub + a spy recorder (no subprocess — a pure ordering assertion).
+
+Store-level append-only + ordering are covered by an **integration** test on
+`SqliteDomainEventRecorder` (see Verification plan), not a Gherkin scenario (they assert on Infra
+mechanics, not user-observable behaviour).
+
+## Slice plan
+
+Full lane, target 6–10 commits (R13); one slice = one behaviour. Subjects carry the story id
+(§ 6.4, R12).
+
+0. `chore(docs): story-4.1 plan + P1/P2/P3 review` — this plan + suggestion log (pre-Phase-3, not counted in behaviour slices).
+1. `test/feat(db): story-4.1 domain_events append-only table — migration 005` — migration + idempotent-apply integration test, `user_version = 5`.
+2. `test/feat(core): story-4.1 TransactionIngested event + DomainEventRecorder port` — Core value object + port; unit test on event shape + a Core-purity assertion (no forbidden imports).
+3. `test/feat(infra): story-4.1 SqliteDomainEventRecorder append-only, ordered, UTC-stamped` — integration test (real SQLite): record two events → strictly increasing `seq`, UTC `recorded_at`, JSON payload round-trips (no raw PII); insert-only.
+4. `test/feat(cli): story-4.1 ingest records TransactionIngested on successful commit` — **subprocess** acceptance (R4): new high-confidence single-row fixture → exit 0 → one `domain_events` row; wire `SqliteDomainEventRecorder` through `program.ts` + thread `sourceAccount`/recorder into `commitBatch`.
+5. `test/feat(cli): story-4.1 no event on failed batch commit` — **in-process** `commitBatch` unit with a failing `transactionRepository` stub + spy recorder → recorder never called (the success-ordering guard, unbundled from slice 4).
+6. `refactor(events): story-4.1 <cleanup>` — or empty slot with justification (R11) if none needed.
+7. `chore(retro): story-4.1 Keep/Change/Try + status fragment` — retro + `docs/status.d/` fragment (advances the "Next" line → status.md edit; R17).
+
+7 counted behaviour slices (was 6 — slice 4 unbundled into 4+5 per P3 review; now mid-band of R13's 6–10).
+
+## Risks & deferred items
+
+| Risk | Mitigation |
+| --- | --- |
+| B1 non-atomicity (crash between commit and `record`) | Documented limitation; idempotent re-run bounds impact. **Deferred issue:** atomic-record via `UnitOfWork` when 4.2's `CorrectionService` needs it. |
+| Migration ordering quirk (001/002 don't bump `user_version`; 003/004 do) | 005 sets `PRAGMA user_version = 5` like 003/004; idempotent-apply test asserts no re-run. |
+| PII leaking into `payload` | Payload carries only `transactionIds` + `sourceAccount` (account id, not a name/IBAN); no descriptions. Assert in the recorder test. |
+| `program.ts` regression (R4) | Composition-root subprocess acceptance test exercises the wired recorder end-to-end. |
+
+Deferred follow-ups each get a GitHub issue at Phase-2 tagging.
+
+## Verification plan
+
+- `npm run lint && npm run build && npm test` green (DoD 1).
+- **Migration idempotency (DoD 2):** integration test runs `005` twice → second run a no-op
+  (`user_version` already 5); table + schema assertions.
+- **Append-only + ordering:** integration test on `SqliteDomainEventRecorder` — two `record()`
+  calls → `seq` strictly increasing, `recorded_at` parses as UTC ISO, `payload` JSON round-trips,
+  payload holds no descriptions (PII assertion), no update/delete path exposed.
+- **B1 wiring (R4):** subprocess ingest via `program.ts` on a real temp DB → assert one
+  `domain_events` row with the committed transaction id.
+- **Ordering-on-failure:** in-process `commitBatch` unit with a failing repo stub → recorder spy
+  never called.
+- **Core purity:** unit/lint assertion that `src/core/events/` + the port import no `better-sqlite3`,
+  no Node APIs, no clock.
+- **100% branch coverage on new `src/core/` files** (DoD; event value object + port are trivial
+  but covered).
+
+## Suggestion log
+
+<!-- Filled at Phase 2 (plan-reviewer + sibling-overlap in parallel). Every row tagged ADOPT / DEFER (issue link) / REJECT (reason) / ACKNOWLEDGE. -->
+
+Phase 2 ran `plan-reviewer` + `sibling-overlap` in parallel. `sibling-overlap`: **no overlap**
+(#155/#156 confirmed parents; #93/#103/#104/#107/#109/#110 are categorize/auto-tag scoped, not
+`commitBatch`; #77 is `transaction_entries` indexing — no migration-number/goal collision). Of
+`plan-reviewer`'s 31 findings, most confirm conformance (P1/P2/P3 "conforms", 8 N/A rule-tags);
+the actionable ones:
+
+| # | Finding | Tag | Resolution |
+|---|---------|-----|------------|
+| 1 | P3 naming-drift: `domain_events.occurred_at` collides semantically with `transactions.occurred_at` (receipt-truth) — it's a system recording clock | **ADOPT** | Column renamed `recorded_at`; distinctness noted in Selected solution + schema. |
+| 2 | P1: existing `ingest-end-to-end-wiring.test.ts` hits exit 2 (low-confidence) and never reaches `commitBatch`; the subprocess scenario needs a fixture that reaches a successful commit or its `fails if` is never exercised | **ADOPT** | Fixture note added to scenario 1 (new high-confidence single-row fixture → exit 0); called out in slice 4. |
+| 3 | P1: threading `sourceAccount` into `commitBatch` is a second signature change (new parameter), not just a deps-`Pick` widen — under-stated in Production-code surface | **ADOPT** | Production-code surface now enumerates both `commitBatch` changes; slice 4 names the param. |
+| 4 | P3 slice health: slice 4 bundled 6 sub-changes; 6 counted slices sat at the low edge of R13 | **ADOPT** | Slice 4 split into 4 (success wiring + acceptance) and 5 (failure-ordering unit) → 7 slices, mid-band. |
+| 5 | P3 Zod forward-pointer: a future story reading `payload` back needs boundary validation; plan didn't note it | **ADOPT** | Forward-pointer note added under the schema (Zod at Infra boundary on read-back; out of scope for 4.1). |
+| 6 | P2 coherence: B1 non-atomicity is a narrow tension with QA "every action leaves a traceable entry" | **DEFER** | [#180](https://github.com/xavierbriand/accounting/issues/180) — atomic-record via `UnitOfWork`, designed in 4.2 (`CorrectionService`). QA invariant read as holding in the successful case; documented limitation. |
+| 7 | P3 soft: use `Result.flatMap`/`map` for the `saveBatch → record` chain in `commitBatch` | **REJECT** | `commitBatch` uses explicit `isFailure` branching throughout for per-branch stderr messaging; a mid-function combinator would break house style. CLI-boundary code — combinator use is optional, not a purity rule. |
+| 8 | P3: append-only is convention-only (no DB trigger) | **ACKNOWLEDGE** | Matches the existing `transactions`/ledger house style (no trigger there either); consistent, not a regression. Noted in schema. |
+| 9 | P3: migration SQL field-comment necessity | **ACKNOWLEDGE** | Phase-4 comment-necessity check (per engineering-standards § Style). Comments kept brief and label-style, mirroring 002/004. |
+
+No un-tagged findings; the one DEFER links [#180](https://github.com/xavierbriand/accounting/issues/180).
+
+## DoR checklist
+
+- [x] Phase 0 (Model): derives from story-4.0 model note (R24); no fresh model-session (events already modelled there); no glossary delta this story.
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review — plan-reviewer + sibling-overlap in parallel): findings triaged above; DEFER links #180.
+- [ ] Draft PR with template sections 1–6 filled (on approval).

--- a/docs/plans/story-4.1.md
+++ b/docs/plans/story-4.1.md
@@ -167,21 +167,28 @@ Feature file: `tests/features/audit-trail.feature`. The `correct`/read surfaces 
 is observed by inspecting the `domain_events` table after a real ingest.
 
 ```gherkin
-Scenario: Ingesting a statement records a TransactionIngested event
-  Given a fresh migrated database and a valid single-row BPCE statement
-  When I ingest it non-interactively
-  Then the audit trail holds one TransactionIngested event
-  And its payload lists the committed transaction id and source account
+Scenario: Committing an ingest batch records a TransactionIngested event
+  Given a fresh migrated database and a valid BPCE statement
+  When I ingest it and confirm the batch
+  Then the audit trail holds a TransactionIngested event
+  And its payload lists the committed transaction ids and source account
 ```
 - **fails if:** the ingest path does not call `recorder.record(...)` after `saveBatch` succeeds
   (guards the B1 wiring in `commitBatch` + the `program.ts` composition-root construction).
 - **classification:** **subprocess** (real CLI via `program.ts`, real SQLite) — this is the R4
   composition-root test.
-- **fixture note (R6/R7 honesty):** the existing `ingest-end-to-end-wiring.test.ts` uses a
-  low-confidence fixture and asserts **exit 2** — it never reaches `commitBatch`. This scenario
-  needs a **new single-row fixture whose row auto-tags high-confidence** (matches an auto-tag rule
-  in the stub `accounting.yaml`) so `ingest --non-interactive` reaches a successful commit
-  (**exit 0**) and thus `record()`. Without that, the `fails if` clause is never exercised.
+- **commit-path note (Phase-3 discovery — R6/R7 honesty).** `commitBatch`/`saveBatch` is reached
+  **only via the interactive confirm path** (`ingest-command.ts:164`, after
+  `prompt.confirmBatch`). `runNonInteractive` (taken for `--non-interactive` **or** `--json`)
+  prints a preview and exits **without persisting** — it never calls `commitBatch` for any fixture
+  or confidence level. So the acceptance test drives the **interactive** path via
+  `--scripted-prompts '[…confirmBatch:true…]'` (NODE_ENV=test), reusing the existing
+  `bpce-valid.csv` fixture — **no new fixture needed**. Precedent: subprocess+scripted+commit in
+  `tests/integration/cli/ingest-remember-rule-wiring.test.ts`; in-process real-infra commit in
+  `tests/integration/cli/ingest-commit.test.ts`. The `runNonInteractive`-never-commits behavior is
+  **pre-existing and out of scope** for 4.1 (see Risks). This corrects the plan's earlier
+  `--non-interactive` wording (adopted-finding #2 was a fixture problem; Phase 3 found the deeper
+  path gap).
 
 ```gherkin
 Scenario: A failed batch commit records no event
@@ -208,7 +215,7 @@ Full lane, target 6–10 commits (R13); one slice = one behaviour. Subjects carr
 1. `test/feat(db): story-4.1 domain_events append-only table — migration 005` — migration + idempotent-apply integration test, `user_version = 5`.
 2. `test/feat(core): story-4.1 TransactionIngested event + DomainEventRecorder port` — Core value object + port; unit test on event shape + a Core-purity assertion (no forbidden imports).
 3. `test/feat(infra): story-4.1 SqliteDomainEventRecorder append-only, ordered, UTC-stamped` — integration test (real SQLite): record two events → strictly increasing `seq`, UTC `recorded_at`, JSON payload round-trips (no raw PII); insert-only.
-4. `test/feat(cli): story-4.1 ingest records TransactionIngested on successful commit` — **subprocess** acceptance (R4): new high-confidence single-row fixture → exit 0 → one `domain_events` row; wire `SqliteDomainEventRecorder` through `program.ts` + thread `sourceAccount`/recorder into `commitBatch`.
+4. `test/feat(cli): story-4.1 ingest records TransactionIngested on successful commit` — **subprocess** acceptance (R4) via the interactive confirm path (`--scripted-prompts` confirmBatch, NODE_ENV=test), reusing `bpce-valid.csv` → a `domain_events` row; wire `SqliteDomainEventRecorder` through `program.ts` + thread `sourceAccount`/recorder into `commitBatch`. Also an **in-process** real-infra assertion (following `ingest-commit.test.ts`) that `record()` fires on the successful commit with the right ids.
 5. `test/feat(cli): story-4.1 no event on failed batch commit` — **in-process** `commitBatch` unit with a failing `transactionRepository` stub + spy recorder → recorder never called (the success-ordering guard, unbundled from slice 4).
 6. `refactor(events): story-4.1 <cleanup>` — or empty slot with justification (R11) if none needed.
 7. `chore(retro): story-4.1 Keep/Change/Try + status fragment` — retro + `docs/status.d/` fragment (advances the "Next" line → status.md edit; R17).
@@ -223,6 +230,7 @@ Full lane, target 6–10 commits (R13); one slice = one behaviour. Subjects carr
 | Migration ordering quirk (001/002 don't bump `user_version`; 003/004 do) | 005 sets `PRAGMA user_version = 5` like 003/004; idempotent-apply test asserts no re-run. |
 | PII leaking into `payload` | Payload carries only `transactionIds` + `sourceAccount` (account id, not a name/IBAN); no descriptions. Assert in the recorder test. |
 | `program.ts` regression (R4) | Composition-root subprocess acceptance test exercises the wired recorder end-to-end. |
+| **Pre-existing gap (Phase-3 discovery):** `ingest --non-interactive`/`--json` never persists (`runNonInteractive` skips `commitBatch`) | **Out of scope** for 4.1 — this story only wires the recorder into the *existing* `commitBatch` (interactive path). Acceptance test uses the interactive scripted-confirm path accordingly. Filed as [#181](https://github.com/xavierbriand/accounting/issues/181) (bug) per user decision; not silently ridden into this story. |
 
 Deferred follow-ups each get a GitHub issue at Phase-2 tagging.
 

--- a/docs/retrospectives/story-4.1.md
+++ b/docs/retrospectives/story-4.1.md
@@ -1,0 +1,80 @@
+# Retrospective — story-4.1
+
+The FR23 audit-trail spine (PR #182): a Core `DomainEventRecorder` port (#155) + `TransactionIngested`
+event value object, migration 005 (append-only `domain_events` table), `SqliteDomainEventRecorder`, and
+B1 app-boundary wiring into `commitBatch` recording the first event after a successful ingest commit.
+First code materialization of the domain-events tactical pattern modelled in story-4.0. No new glossary
+vocabulary (all terms pre-promoted in 4.0).
+
+## Keep
+
+- **The deferred call-site decision was resolved with a written rationale, not a coin-flip.** Story-4.0
+  parked B1-vs-B2 for "story-4.1 Phase 1"; the plan decided B1 (app-boundary) with an argument that
+  *reconciles* with the 4.0 hybrid model rather than contradicting it (ingest has no Core domain service,
+  so the boundary is its natural seam; the atomic-in-service path lands in 4.2's `CorrectionService`). A
+  fork inherited from a prior story got closed deliberately, and `ddd-modeler` Mode B confirmed the
+  resolution as conformant.
+- **The implementer stopped at a real blocker instead of guessing.** Mid-implementation it found that
+  `ingest --non-interactive`/`--json` never reaches `commitBatch` for *any* fixture — a pre-existing gap,
+  not the fixture problem Phase-2 had anticipated. It halted and asked rather than silently expanding
+  scope into `runNonInteractive`. Resolution (interactive scripted-confirm path) kept the story in scope;
+  the gap became #181 with a decision recorded, not a silent rider.
+- **Model-conformance review at first materialization paid off.** Running `ddd-modeler` Mode B against the
+  4.0 note (even without a fresh story-4.1 note) validated the whole event family's foundations — Core
+  purity, no base class, timestamp-at-boundary, PII-free payload, past-tense vocabulary — at the exact
+  moment the abstraction became code. Two family-naming observations surfaced for 4.2 to inherit.
+- **Phase-4 caught a PII-hygiene inconsistency the tests didn't.** Both the acceptance and unit tests were
+  green, but `code-reviewer` saw the `record()` failure branch wrote a raw SQLite error to stderr while
+  the sibling `saveBatch` branch three lines above sanitized it. Green ≠ consistent; the diff-adjacency
+  read is what the human-style review adds over the test suite.
+
+## Change
+
+- **Version-fallout tests belong in their own `chore:` commit.** Migration 005 legitimately advanced
+  `user_version` past 4, so two pre-existing tests (`migration-004`, `sqlite-hash-repository`) loosened
+  `toBe(4)` → `>=4`. Correct and commented, but bundled into slice 4's feature commit — a slice-boundary
+  blur. A schema-version bump has predictable test fallout; carve it into a labelled `chore(test):` slice
+  so the feature commit stays about the feature.
+- **The event-family field vocabulary needs one ratification pass when the second event lands.**
+  `TransactionIngested.transactionIds` vs the modelled `TransactionCorrected.producedTransactionIds` is a
+  fork left open (kept `transactionIds` — clearer with no "target" to disambiguate, no consumer exists
+  yet). This is fine for one event but becomes real when 4.2 builds the second: decide then whether the
+  audit-store payloads should be self-similar (`producedTransactionIds` everywhere) or role-precise.
+- **A plan-vs-diff coverage claim went stale between Phase 1 and Phase 3.** The plan promised an in-process
+  real-infra assertion in `ingest-commit.test.ts`; the implementer delivered equivalent coverage elsewhere
+  (spy unit + subprocess) but left the named file un-asserted. Phase-4 caught it and it was added. When a
+  plan names a specific test *location*, the implementer should either honor it or flag the substitution in
+  the return report's Deviations — this one wasn't flagged.
+
+## Try
+
+- **Standardize where `fails if` prose lives for `.feature` files.** `audit-trail.feature` is the repo's
+  first Gherkin file to embed `fails if` as inline `#` comments; every other test carries it in the step
+  docstring or the `it` header. Pick one home (step docstring reads cleanest) so R6 evidence is found in a
+  consistent place.
+- **Re-verify plan premises at phase *transitions*, not only before pushes.** The `--non-interactive`
+  gap would have surfaced at Phase 1 with a five-minute trace of `runNonInteractive`'s call graph. Echoes
+  story-ddd-2's "maintenance sub-loop is a point-in-time snapshot" — the same lesson for *code* premises,
+  not just tracker state: before locking a plan's acceptance mechanism, trace that the path it names is
+  actually reachable.
+
+## Phase-4 disposition record
+
+`code-reviewer` + `ddd-modeler` Mode B (parallel). ddd-modeler: **0 hard violations**. code-reviewer:
+2 P1, 1 P2, 1 P3 + 3 soft. **Fixed now** (79615d4): P2 sanitize the `record()` failure error before
+stderr; P1/R2 add the promised real-infra `domain_events` assertion in `ingest-commit.test.ts`; P3-soft
+harden the Core-purity guard regex for `node:`-prefixed specifiers. **Acknowledged:** version-fallout test
+bundling (→ Change above), inline-`#`-comment style (→ Try), recorder `catch` stack-loss (house pattern),
+`transactionIds` family naming (→ Change; ratify at 4.2), `sourceAccount` field origination (established
+"account" vocabulary, no glossary edit). **Deferred (prior phase):** B1 non-atomicity → #180.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| Atomic audit-event recording (`UnitOfWork`) — close B1 gap | #180 | Open (design in 4.2) |
+| `ingest --non-interactive`/`--json` never persists (runNonInteractive skips commitBatch) | #181 | Open |
+| Ratify event-family payload field naming (`transactionIds` vs `producedTransactionIds`) | story-4.2 Phase 1 | Pending |
+
+No new rule minted — this story consumed existing rules (R24 derive-from-4.0 note, R25 glossary
+currency, R13 slicing, R4 composition-root, R6/R7 test honesty).

--- a/docs/status.d/2026-07-05-story-4.1.md
+++ b/docs/status.d/2026-07-05-story-4.1.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-05
+story: 4.1
+pr: 182
+epic: 4
+---
+
+The FR23 audit-trail spine shipped, closing #155. A Core `DomainEventRecorder` port + a `TransactionIngested` value object (plain immutable, no clock — `src/core/events/`), an append-only Infra event store (migration 005: `domain_events` with a monotonic `seq` and a system-clock `recorded_at`, deliberately distinct from `transactions.occurred_at` receipt truth), a `SqliteDomainEventRecorder`, and **B1 app-boundary** wiring: the ingest `commitBatch` records one batch-level `TransactionIngested` (all committed transaction ids + source account, no PII in the payload) after `saveBatch` succeeds. The B1-vs-B2 call-site fork parked in story-4.0 was decided B1 with a written rationale (ingest has no Core domain service; the atomic-in-service path lands in 4.2's `CorrectionService`); its non-atomicity is documented and deferred to #180. Phase 3 uncovered that `ingest --non-interactive`/`--json` never persists (`runNonInteractive` skips `commitBatch` for any fixture) — out of scope, filed as #181; the acceptance test drives the real interactive scripted-confirm path instead. `ddd-modeler` Mode B found 0 model-conformance violations. Next: **story-4.2** — Correction (reverse-and-correct), the `correct` command emitting `TransactionCorrected` via this recorder; depends on 4.1.

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,8 +8,8 @@ Authoritative source for "where we are." [CLAUDE.md § 1](../CLAUDE.md) points h
 - **Epic 2** — complete. Stories 2.1–2.5 (Ingest + Tagging + Commit) shipped.
 - **Epic 3** — **complete.** Stories 3.1 (Versioned Split Rules) + 3.2 (Buffer State Reader) + 3.3 (Recurring Cost Forecast) + 3.4 (Safe Monthly Transfer Calculator) + 3.5 (Status CLI Command) shipped.
 - **Refactor epic (Epic M-A)** — story-maint-01 through story-maint-16 shipped.
-- **Epic 4** (Trust, Transparency & Lifecycle — corrections, audit trail, dissolution) — **defined** (story-4.0, Phase-0 model note + glossary + slices 4.1–4.5). Implementation not started.
-- **Next:** **story-4.1** — `DomainEventRecorder` port + append-only event store + first event (`TransactionIngested`); ships the FR23 spine that unblocks the rest of Epic 4 and Epic-5 Story 5.4. **Epic 5** (Year-in-Review & Annual Planner) scaffolded — Stories 5.1 / 5.2a / 5.2b / 5.3 are read-only and unblocked, but Story 5.4 sequences after FR23 (Audit Trail) lands. See [epics.md](epics.md).
+- **Epic 4** (Trust, Transparency & Lifecycle — corrections, audit trail, dissolution) — **defined** (story-4.0) + **story-4.1 shipped**: the FR23 audit-trail spine — `DomainEventRecorder` port + append-only `domain_events` store + first event (`TransactionIngested`), recorded at the app boundary (B1) on ingest commit. Closes #155.
+- **Next:** **story-4.2** — Correction (reverse-and-correct): the `correct` command writes a reversal + a correcting entry (original never mutated) and emits `TransactionCorrected` via the 4.1 recorder. Depends on 4.1. **Epic 5** (Year-in-Review & Annual Planner) scaffolded — Stories 5.1 / 5.2a / 5.2b / 5.3 are read-only and unblocked, but Story 5.4 sequences after FR23 (Audit Trail) completes (needs 4.1 + the `ConfigChanged` event from 4.5). See [epics.md](epics.md).
 
 ### Non-product initiatives
 

--- a/src/cli/commands/ingest-command.ts
+++ b/src/cli/commands/ingest-command.ts
@@ -7,6 +7,7 @@ import type { AccountConfig, AppConfig } from '@core/config/app-config.js';
 import type { TransactionRepository } from '@core/ports/transaction-repository.js';
 import type { SnapshotService } from '@core/ports/snapshot-service.js';
 import type { ConfigWriter } from '@core/ports/config-writer.js';
+import type { DomainEventRecorder } from '@core/ports/domain-event-recorder.js';
 import type { InteractivePrompter } from '../utils/interactive.js';
 import type { pickSourceAccount as PickSourceAccountFn } from '../../infra/fs/pick-source-account.js';
 import type { readBpceCsv as ReadBpceCsvFn } from '../../infra/fs/read-bpce-csv.js';
@@ -40,6 +41,7 @@ export interface IngestCommandDeps {
   readonly snapshotService: SnapshotService;
   readonly dbPath: string;
   readonly configWriter: ConfigWriter;
+  readonly domainEventRecorder: DomainEventRecorder;
 }
 
 function writeln(stream: Writable, msg: string): void {
@@ -93,7 +95,7 @@ export async function runIngestCommand(
   opts: IngestCommandOptions,
   deps: IngestCommandDeps,
 ): Promise<void> {
-  const { config, idempotencyService, transactionBuilder, prompt, stdout, stderr, exitCode, transactionRepository, snapshotService, dbPath, configWriter } = deps;
+  const { config, idempotencyService, transactionBuilder, prompt, stdout, stderr, exitCode, transactionRepository, snapshotService, dbPath, configWriter, domainEventRecorder } = deps;
 
   const parsed = await loadAndParse(opts, deps);
   if (parsed === null) return;
@@ -161,14 +163,15 @@ export async function runIngestCommand(
     }
   }
 
-  await commitBatch(resolvedOutcomes, { transactionRepository, snapshotService, dbPath, stderr, exitCode });
+  await commitBatch(resolvedOutcomes, account.id, { transactionRepository, snapshotService, dbPath, stderr, exitCode, domainEventRecorder });
 }
 
 async function commitBatch(
   outcomes: readonly BuildOutcome[],
-  deps: Pick<IngestCommandDeps, 'transactionRepository' | 'snapshotService' | 'dbPath' | 'stderr' | 'exitCode'>,
+  sourceAccount: string,
+  deps: Pick<IngestCommandDeps, 'transactionRepository' | 'snapshotService' | 'dbPath' | 'stderr' | 'exitCode' | 'domainEventRecorder'>,
 ): Promise<void> {
-  const { transactionRepository, snapshotService, dbPath, stderr, exitCode } = deps;
+  const { transactionRepository, snapshotService, dbPath, stderr, exitCode, domainEventRecorder } = deps;
   const snapshotPath = dbPath + '.bak';
 
   const snapResult = await snapshotService.create(dbPath, snapshotPath);
@@ -187,6 +190,18 @@ async function commitBatch(
     writeln(stderr, `Snapshot retained at ${snapshotPath} for recovery.`);
     exitCode(4);
     return;
+  }
+
+  // Recorded only after saveBatch succeeds (B1 app-boundary wiring, story-4.1) — a
+  // failed record() does not roll back the already-committed batch; the rows are
+  // durable, so we warn rather than fail (mirrors the snapshot-removal pattern below).
+  const recordResult = domainEventRecorder.record({
+    type: 'TransactionIngested',
+    transactionIds: outcomes.map((o) => o.transaction.id),
+    sourceAccount,
+  });
+  if (recordResult.isFailure) {
+    writeln(stderr, `Warning: committed successfully but could not record the audit event: ${recordResult.error}`);
   }
 
   const removeResult = await snapshotService.remove(snapshotPath);

--- a/src/cli/commands/ingest-command.ts
+++ b/src/cli/commands/ingest-command.ts
@@ -201,7 +201,10 @@ async function commitBatch(
     sourceAccount,
   });
   if (recordResult.isFailure) {
-    writeln(stderr, `Warning: committed successfully but could not record the audit event: ${recordResult.error}`);
+    // sanitizeSqlError: the recorder returns String(SqliteError) on failure, which can
+    // embed hex-like fingerprint tokens — redact before stderr, same as the saveBatch
+    // branch above (P2 review, security-checklist PII hygiene).
+    writeln(stderr, `Warning: committed successfully but could not record the audit event: ${sanitizeSqlError(recordResult.error)}`);
   }
 
   const removeResult = await snapshotService.remove(snapshotPath);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -8,6 +8,7 @@ import { IdempotencyService } from '../core/ingest/idempotency-service.js';
 import { TransactionBuilder } from '../core/ingest/transaction-builder.js';
 import { SqliteHashRepository } from '../infra/db/repositories/sqlite-hash-repository.js';
 import { SqliteTransactionRepository } from '../infra/db/repositories/sqlite-transaction-repo.js';
+import { SqliteDomainEventRecorder } from '../infra/db/repositories/sqlite-domain-event-recorder.js';
 import { NodeSqliteSnapshotService } from '../infra/db/node-sqlite-snapshot-service.js';
 import { nodeHashFn } from '../infra/crypto/node-hash-fn.js';
 import { nodeUuidGen } from '../infra/crypto/node-uuid-gen.js';
@@ -146,6 +147,7 @@ program
       new TransactionBuilder(accounts, config.autoTagRules, nodeUuidGen);
     const transactionRepository = new SqliteTransactionRepository(db);
     const snapshotService = new NodeSqliteSnapshotService(db);
+    const domainEventRecorder = new SqliteDomainEventRecorder(db);
 
     await runIngestCommand(
       { file: options.file, nonInteractive: options.nonInteractive, json: options.json },
@@ -164,6 +166,7 @@ program
         snapshotService,
         dbPath: resolvedDb,
         configWriter,
+        domainEventRecorder,
       },
     );
   });

--- a/src/core/events/domain-event.ts
+++ b/src/core/events/domain-event.ts
@@ -1,0 +1,7 @@
+export interface TransactionIngested {
+  readonly type: 'TransactionIngested';
+  readonly transactionIds: readonly string[];
+  readonly sourceAccount: string;
+}
+
+export type DomainEvent = TransactionIngested;

--- a/src/core/ports/domain-event-recorder.ts
+++ b/src/core/ports/domain-event-recorder.ts
@@ -1,0 +1,6 @@
+import type { Result } from '@core/shared/result.js';
+import type { DomainEvent } from '@core/events/domain-event.js';
+
+export interface DomainEventRecorder {
+  record(event: DomainEvent): Result<void>;
+}

--- a/src/infra/db/migrations/005-domain-events.sql
+++ b/src/infra/db/migrations/005-domain-events.sql
@@ -1,0 +1,9 @@
+-- Append-only audit trail (FR23). recorded_at is a system recording clock,
+-- deliberately distinct from transactions.occurred_at (receipt truth).
+CREATE TABLE domain_events (
+  seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_type  TEXT NOT NULL,
+  recorded_at TEXT NOT NULL,
+  payload     TEXT NOT NULL
+);
+PRAGMA user_version = 5;

--- a/src/infra/db/repositories/sqlite-domain-event-recorder.ts
+++ b/src/infra/db/repositories/sqlite-domain-event-recorder.ts
@@ -1,0 +1,27 @@
+import Database from 'better-sqlite3';
+import { Result } from '@core/shared/result.js';
+import type { DomainEvent } from '@core/events/domain-event.js';
+import type { DomainEventRecorder } from '@core/ports/domain-event-recorder.js';
+
+export class SqliteDomainEventRecorder implements DomainEventRecorder {
+  private readonly insertEvent: Database.Statement;
+
+  constructor(private readonly db: Database.Database) {
+    this.insertEvent = db.prepare(
+      'INSERT INTO domain_events (event_type, recorded_at, payload) VALUES (?, ?, ?)',
+    );
+  }
+
+  record(event: DomainEvent): Result<void> {
+    const { type, ...domainFields } = event;
+    const recordedAt = new Date().toISOString();
+    const payload = JSON.stringify(domainFields);
+
+    try {
+      this.insertEvent.run(type, recordedAt, payload);
+      return Result.ok();
+    } catch (err) {
+      return Result.fail(String(err));
+    }
+  }
+}

--- a/tests/features/audit-trail.feature
+++ b/tests/features/audit-trail.feature
@@ -1,0 +1,15 @@
+Feature: Audit trail records domain events for meaningful actions (FR23)
+
+  Scenario: Committing an ingest batch records a TransactionIngested event
+    Given a fresh migrated DB and accounting.yaml at a temp dir
+    And a BPCE CSV copied to that temp dir as "bpce-valid_real.csv"
+    When I run scripted ingest confirming the batch on "bpce-valid_real.csv"
+    Then the process exits with code 0
+    And the audit trail holds one TransactionIngested event
+    And its payload lists the committed transaction ids and source account
+    # fails if: the ingest path does not call recorder.record(...) after saveBatch
+    # succeeds (guards the B1 wiring in commitBatch + the program.ts composition-root
+    # construction). commitBatch/saveBatch is reached only via the interactive confirm
+    # path (ingest-command.ts:164) — --non-interactive/--json never call commitBatch
+    # for any fixture (pre-existing, out of scope for 4.1). This scenario drives the
+    # interactive path via --scripted-prompts (NODE_ENV=test).

--- a/tests/features/steps/audit-trail.steps.ts
+++ b/tests/features/steps/audit-trail.steps.ts
@@ -1,0 +1,68 @@
+import { expect, afterEach } from 'vitest';
+import { When, Then } from 'quickpickle';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { spawnCli } from '../../_helpers/spawn-cli.js';
+
+// AuditTrailWorld mirrors IngestWorld's field shape (ingest.steps.ts) so the shared
+// Given/Then steps registered there ('a fresh migrated DB…', 'a BPCE CSV copied…',
+// 'the process exits with code') can read/write the same quickpickle state object.
+interface AuditTrailWorld {
+  tmpDir?: string;
+  csvPath?: string;
+  dbPath?: string;
+  lastResult?: { status: number; stdout: string; stderr: string };
+}
+
+const dbs: Database.Database[] = [];
+
+afterEach(() => {
+  for (const db of dbs.splice(0)) {
+    if (db.open) db.close();
+  }
+});
+
+/**
+ * bpce-valid.csv (copied as bpce-valid_real.csv by the shared step) has 5 rows;
+ * with the autoTagRules set by 'a fresh migrated DB and accounting.yaml at a temp
+ * dir' (mutuelle→Insurance, abonnement→Subscriptions), 2 rows auto-tag high-confidence
+ * and 3 remain low-confidence, each requiring one selectCategory 'keep' prompt before
+ * the single confirmBatch prompt fires (ingest-command.ts runInteractiveLoop order).
+ */
+function makeScriptedConfirmBatch(): string {
+  return JSON.stringify([
+    { type: 'selectCategory', action: 'keep' },
+    { type: 'selectCategory', action: 'keep' },
+    { type: 'selectCategory', action: 'keep' },
+    { type: 'confirmBatch', confirm: true },
+  ]);
+}
+
+When('I run scripted ingest confirming the batch on {string}', function (state: AuditTrailWorld, filename: string) {
+  const csvPath = path.join(state.tmpDir!, filename);
+  const script = makeScriptedConfirmBatch();
+  state.lastResult = spawnCli(
+    ['ingest', '--file', csvPath, '--scripted-prompts', script],
+    { cwd: state.tmpDir, env: { NODE_ENV: 'test' } },
+  );
+});
+
+Then('the audit trail holds one TransactionIngested event', function (state: AuditTrailWorld) {
+  const db = new Database(state.dbPath!);
+  dbs.push(db);
+  const rows = db.prepare('SELECT event_type FROM domain_events').all() as { event_type: string }[];
+  expect(rows).toHaveLength(1);
+  expect(rows[0].event_type).toBe('TransactionIngested');
+});
+
+Then('its payload lists the committed transaction ids and source account', function (state: AuditTrailWorld) {
+  const db = new Database(state.dbPath!);
+  dbs.push(db);
+  const row = db.prepare('SELECT payload FROM domain_events').get() as { payload: string };
+  const payload = JSON.parse(row.payload) as { transactionIds: string[]; sourceAccount: string };
+
+  const committedIds = (db.prepare('SELECT id FROM transactions ORDER BY id').all() as { id: string }[]).map((r) => r.id);
+  expect(committedIds).toHaveLength(5);
+  expect([...payload.transactionIds].sort()).toEqual([...committedIds].sort());
+  expect(payload.sourceAccount).toBe('bpce-valid-account');
+});

--- a/tests/features/steps/commit.steps.ts
+++ b/tests/features/steps/commit.steps.ts
@@ -9,6 +9,7 @@ import { IdempotencyService } from '../../../src/core/ingest/idempotency-service
 import { TransactionBuilder } from '../../../src/core/ingest/transaction-builder.js';
 import { SqliteHashRepository } from '../../../src/infra/db/repositories/sqlite-hash-repository.js';
 import { SqliteTransactionRepository } from '../../../src/infra/db/repositories/sqlite-transaction-repo.js';
+import { SqliteDomainEventRecorder } from '../../../src/infra/db/repositories/sqlite-domain-event-recorder.js';
 import { NodeSqliteSnapshotService } from '../../../src/infra/db/node-sqlite-snapshot-service.js';
 import { nodeHashFn } from '../../../src/infra/crypto/node-hash-fn.js';
 import { nodeUuidGen } from '../../../src/infra/crypto/node-uuid-gen.js';
@@ -61,6 +62,7 @@ async function runIngestInProcess(
   const realRepo = new SqliteTransactionRepository(db);
   const transactionRepository = saveBatchOverride ?? realRepo;
   const snapshotService = new NodeSqliteSnapshotService(db);
+  const domainEventRecorder = new SqliteDomainEventRecorder(db);
 
   const stdoutSink = new PassThrough();
   stdoutSink.resume();
@@ -93,6 +95,7 @@ async function runIngestInProcess(
       snapshotService,
       dbPath: state.dbPath!,
       configWriter: { appendAutoTagRules: async () => Result.ok() },
+      domainEventRecorder,
     },
   );
 

--- a/tests/features/steps/index.ts
+++ b/tests/features/steps/index.ts
@@ -6,3 +6,4 @@ import './recurring-forecast.steps.js';
 import './safe-transfer.steps.js';
 import './status.steps.js';
 import './categorize.steps.js';
+import './audit-trail.steps.js';

--- a/tests/features/steps/ingest.steps.ts
+++ b/tests/features/steps/ingest.steps.ts
@@ -12,6 +12,7 @@ import { IdempotencyService } from '../../../src/core/ingest/idempotency-service
 import { TransactionBuilder } from '../../../src/core/ingest/transaction-builder.js';
 import { SqliteHashRepository } from '../../../src/infra/db/repositories/sqlite-hash-repository.js';
 import { SqliteTransactionRepository } from '../../../src/infra/db/repositories/sqlite-transaction-repo.js';
+import { SqliteDomainEventRecorder } from '../../../src/infra/db/repositories/sqlite-domain-event-recorder.js';
 import { NodeSqliteSnapshotService } from '../../../src/infra/db/node-sqlite-snapshot-service.js';
 import { nodeHashFn } from '../../../src/infra/crypto/node-hash-fn.js';
 import { nodeUuidGen } from '../../../src/infra/crypto/node-uuid-gen.js';
@@ -106,6 +107,7 @@ Given('the CSV has been committed interactively', async function (state: IngestW
     new TransactionBuilder(accounts, config.autoTagRules, nodeUuidGen);
   const transactionRepository = new SqliteTransactionRepository(db);
   const snapshotService = new NodeSqliteSnapshotService(db);
+  const domainEventRecorder = new SqliteDomainEventRecorder(db);
 
   const sink = new PassThrough();
   sink.resume();
@@ -131,6 +133,7 @@ Given('the CSV has been committed interactively', async function (state: IngestW
       snapshotService,
       dbPath: state.dbPath!,
       configWriter: { appendAutoTagRules: async () => Result.ok() },
+      domainEventRecorder,
     },
   );
 

--- a/tests/integration/cli/ingest-commit.test.ts
+++ b/tests/integration/cli/ingest-commit.test.ts
@@ -22,6 +22,7 @@ import { runIngestCommand } from '../../../src/cli/commands/ingest-command.js';
 import type { IngestCommandDeps } from '../../../src/cli/commands/ingest-command.js';
 import { runMigrations } from '../../../src/infra/db/migrator.js';
 import { SqliteTransactionRepository } from '../../../src/infra/db/repositories/sqlite-transaction-repo.js';
+import { SqliteDomainEventRecorder } from '../../../src/infra/db/repositories/sqlite-domain-event-recorder.js';
 import { SqliteHashRepository } from '../../../src/infra/db/repositories/sqlite-hash-repository.js';
 import { NodeSqliteSnapshotService } from '../../../src/infra/db/node-sqlite-snapshot-service.js';
 import { NodeCsvParser } from '../../../src/infra/csv/node-csv-parser.js';
@@ -36,6 +37,7 @@ import type { AppConfig } from '@core/config/app-config.js';
 import type { SnapshotService } from '@core/ports/snapshot-service.js';
 import type { BatchWriteOutcome } from '@core/ports/transaction-repository.js';
 import type { ConfigWriter } from '@core/ports/config-writer.js';
+import type { DomainEventRecorder } from '@core/ports/domain-event-recorder.js';
 
 function makeNoOpConfigWriter(): ConfigWriter {
   return { appendAutoTagRules: async () => Result.ok() };
@@ -74,6 +76,7 @@ function makeRealDeps(
   csvPath: string,
   snapshotOverride?: SnapshotService,
   repoOverride?: { saveBatch: IngestCommandDeps['transactionRepository']['saveBatch'] },
+  recorderOverride?: DomainEventRecorder,
 ): { deps: IngestCommandDeps; stdout: Writable & { captured: string }; stderr: Writable & { captured: string }; exitCodes: number[] } {
   const stdout = makeCapture();
   const stderr = makeCapture();
@@ -85,6 +88,7 @@ function makeRealDeps(
   const idempotencyService = new IdempotencyService(nodeHashFn, hashRepo);
   const mainAccount = { id: 'main-account', type: 'bank' as const, filenamePrefix: 'bpce-valid' };
   const snapshotService = snapshotOverride ?? new NodeSqliteSnapshotService(db);
+  const domainEventRecorder = recorderOverride ?? new SqliteDomainEventRecorder(db);
 
   const config: AppConfig = {
     dbPath,
@@ -116,6 +120,7 @@ function makeRealDeps(
     snapshotService,
     dbPath,
     configWriter: makeNoOpConfigWriter(),
+    domainEventRecorder,
   };
 
   return { deps, stdout, stderr, exitCodes };

--- a/tests/integration/cli/ingest-commit.test.ts
+++ b/tests/integration/cli/ingest-commit.test.ts
@@ -154,6 +154,18 @@ describe('runIngestCommand — end-to-end commit (real temp-file DB)', () => {
     const nullHashCount = (db.prepare('SELECT COUNT(*) as n FROM transactions WHERE idempotency_hash IS NULL').get() as { n: number }).n;
     expect(nullHashCount).toBe(0);
 
+    // Real-infra audit trail: exactly one batch-level TransactionIngested event,
+    // recorded via the real SqliteDomainEventRecorder after the successful commit
+    // (story-4.1 B1 wiring — in-process real-infra layer between the spy-based unit
+    // test and the subprocess acceptance test).
+    const events = db.prepare('SELECT event_type, payload FROM domain_events ORDER BY seq').all() as { event_type: string; payload: string }[];
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe('TransactionIngested');
+    const committedIds = (db.prepare('SELECT id FROM transactions ORDER BY id').all() as { id: string }[]).map((r) => r.id);
+    const eventPayload = JSON.parse(events[0].payload) as { transactionIds: string[]; sourceAccount: string };
+    expect([...eventPayload.transactionIds].sort()).toEqual(committedIds);
+    expect(eventPayload.sourceAccount).toBe('main-account');
+
     // Snapshot removed on success
     expect(fs.existsSync(snapshotPath)).toBe(false);
 

--- a/tests/integration/infra/db/migration-004.test.ts
+++ b/tests/integration/infra/db/migration-004.test.ts
@@ -59,14 +59,17 @@ afterEach(() => {
 });
 
 describe('migration 004 — idempotency_hash NOT NULL tightening', () => {
-  it('(a) user_version advances from 3 to 4 after running migrations', () => {
-    // fails if: migration 004 does not execute or PRAGMA user_version is not bumped
+  it('(a) user_version advances from 3 past 4 after running migrations', () => {
+    // fails if: migration 004 does not execute or PRAGMA user_version is not bumped.
+    // Asserts >= 4 (not === 4): runMigrations also applies any later migrations
+    // (e.g. 005 domain_events, story-4.1) present on disk — this test targets 004's
+    // own behavior, not the final schema version.
     const db = tracked(makeV3Db());
     expect(db.pragma('user_version', { simple: true })).toBe(3);
 
     runMigrations(db);
 
-    expect(db.pragma('user_version', { simple: true })).toBe(4);
+    expect(db.pragma('user_version', { simple: true }) as number).toBeGreaterThanOrEqual(4);
   });
 
   it('(b) INSERT with idempotency_hash = NULL fails after migration', () => {
@@ -106,15 +109,15 @@ describe('migration 004 — idempotency_hash NOT NULL tightening', () => {
     expect(issues).toHaveLength(0);
   });
 
-  it('(e) running migrations a second time at v4 is a no-op (idempotent)', () => {
+  it('(e) running migrations a second time is a no-op (idempotent)', () => {
     // fails if: runner loses the version guard and re-runs the rebuild
     const db = tracked(makeV3Db());
     runMigrations(db);
-    expect(db.pragma('user_version', { simple: true })).toBe(4);
+    const versionAfterFirstRun = db.pragma('user_version', { simple: true });
 
     // Second call must be a no-op
     runMigrations(db);
-    expect(db.pragma('user_version', { simple: true })).toBe(4);
+    expect(db.pragma('user_version', { simple: true })).toBe(versionAfterFirstRun);
 
     // Schema is still valid
     expect(() => {

--- a/tests/integration/infra/db/migration-005.test.ts
+++ b/tests/integration/infra/db/migration-005.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration tests for migration 005 — append-only domain_events table (FR23 audit trail spine).
+ *
+ * Gherkin coverage: none directly (store-level mechanics, not user-observable behaviour) —
+ *   see docs/plans/story-4.1.md "Verification plan" § Migration idempotency.
+ *
+ * fails if: migration 005 does not execute, PRAGMA user_version is not bumped to 5,
+ *   the domain_events table/columns are missing or mistyped, or the migrator re-runs
+ *   the migration on a second call (idempotency guard regression).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../../../../src/infra/db/migrator.js';
+
+const dbs: Database.Database[] = [];
+
+function makeFreshDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  dbs.push(db);
+  return db;
+}
+
+afterEach(() => {
+  for (const db of dbs.splice(0)) {
+    if (db.open) db.close();
+  }
+});
+
+describe('migration 005 — domain_events append-only table', () => {
+  it('(a) user_version advances to 5 and the domain_events table exists with expected columns', () => {
+    // fails if: migration 005 does not execute or PRAGMA user_version is not bumped
+    const db = makeFreshDb();
+    runMigrations(db);
+
+    expect(db.pragma('user_version', { simple: true })).toBe(5);
+
+    const columns = db.prepare("PRAGMA table_info(domain_events)").all() as Array<{
+      name: string;
+      type: string;
+      notnull: number;
+      pk: number;
+    }>;
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    expect(byName.get('seq')?.pk).toBe(1);
+    expect(byName.get('event_type')?.notnull).toBe(1);
+    expect(byName.get('recorded_at')?.notnull).toBe(1);
+    expect(byName.get('payload')?.notnull).toBe(1);
+  });
+
+  it('(b) running migrations a second time at v5 is a no-op (idempotent)', () => {
+    // fails if: the migrator re-runs migration 005 on a second call (e.g. AUTOINCREMENT
+    //   collision, or a duplicate CREATE TABLE throwing "table already exists")
+    const db = makeFreshDb();
+    runMigrations(db);
+    expect(db.pragma('user_version', { simple: true })).toBe(5);
+
+    runMigrations(db);
+    expect(db.pragma('user_version', { simple: true })).toBe(5);
+
+    const count = (db.prepare('SELECT COUNT(*) as n FROM domain_events').get() as { n: number }).n;
+    expect(count).toBe(0);
+  });
+
+  it('(c) domain_events is INSERT-only by convention — a row can be inserted and read back', () => {
+    // fails if: the table schema rejects a well-formed insert (e.g. a NOT NULL column
+    //   the recorder relies on is missing)
+    const db = makeFreshDb();
+    runMigrations(db);
+
+    db.prepare(
+      "INSERT INTO domain_events (event_type, recorded_at, payload) VALUES ('TransactionIngested', '2026-07-05T10:00:00.000Z', '{}')",
+    ).run();
+
+    const row = db.prepare('SELECT * FROM domain_events').get() as {
+      seq: number;
+      event_type: string;
+      recorded_at: string;
+      payload: string;
+    };
+    expect(row.seq).toBe(1);
+    expect(row.event_type).toBe('TransactionIngested');
+    expect(row.payload).toBe('{}');
+  });
+});

--- a/tests/integration/infra/db/sqlite-domain-event-recorder.test.ts
+++ b/tests/integration/infra/db/sqlite-domain-event-recorder.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Integration tests for SqliteDomainEventRecorder (real SQLite) — append-only, ordered,
+ * UTC-stamped event store (FR23 audit-trail spine).
+ *
+ * Gherkin coverage: none directly (store-level mechanics) — see
+ *   docs/plans/story-4.1.md "Verification plan" § Append-only + ordering.
+ *
+ * fails if: seq does not strictly increase across record() calls, recorded_at is not a
+ *   valid UTC ISO string, payload does not round-trip the event's domain fields, or the
+ *   payload leaks a description / any field beyond transactionIds + sourceAccount.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../../../../src/infra/db/migrator.js';
+import { SqliteDomainEventRecorder } from '../../../../src/infra/db/repositories/sqlite-domain-event-recorder.js';
+import type { TransactionIngested } from '../../../../src/core/events/domain-event.js';
+
+const dbs: Database.Database[] = [];
+
+function makeMigratedDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  dbs.push(db);
+  return db;
+}
+
+afterEach(() => {
+  for (const db of dbs.splice(0)) {
+    if (db.open) db.close();
+  }
+});
+
+describe('SqliteDomainEventRecorder', () => {
+  it('records an event and returns Result.ok', () => {
+    const db = makeMigratedDb();
+    const recorder = new SqliteDomainEventRecorder(db);
+
+    const event: TransactionIngested = {
+      type: 'TransactionIngested',
+      transactionIds: ['tx-1'],
+      sourceAccount: 'main-account',
+    };
+
+    const result = recorder.record(event);
+    expect(result.isSuccess).toBe(true);
+  });
+
+  it('two record() calls produce strictly increasing seq values (ordering)', () => {
+    const db = makeMigratedDb();
+    const recorder = new SqliteDomainEventRecorder(db);
+
+    recorder.record({ type: 'TransactionIngested', transactionIds: ['tx-1'], sourceAccount: 'a' });
+    recorder.record({ type: 'TransactionIngested', transactionIds: ['tx-2'], sourceAccount: 'b' });
+
+    const rows = db.prepare('SELECT seq FROM domain_events ORDER BY seq').all() as { seq: number }[];
+    expect(rows).toHaveLength(2);
+    expect(rows[1].seq).toBeGreaterThan(rows[0].seq);
+  });
+
+  it('recorded_at parses as a valid UTC ISO date', () => {
+    const db = makeMigratedDb();
+    const recorder = new SqliteDomainEventRecorder(db);
+
+    recorder.record({ type: 'TransactionIngested', transactionIds: ['tx-1'], sourceAccount: 'a' });
+
+    const row = db.prepare('SELECT recorded_at FROM domain_events').get() as { recorded_at: string };
+    expect(row.recorded_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(Number.isNaN(Date.parse(row.recorded_at))).toBe(false);
+  });
+
+  it('payload JSON round-trips the event domain fields and carries no description/PII', () => {
+    const db = makeMigratedDb();
+    const recorder = new SqliteDomainEventRecorder(db);
+
+    recorder.record({
+      type: 'TransactionIngested',
+      transactionIds: ['tx-1', 'tx-2'],
+      sourceAccount: 'main-account',
+    });
+
+    const row = db.prepare('SELECT event_type, payload FROM domain_events').get() as {
+      event_type: string;
+      payload: string;
+    };
+    expect(row.event_type).toBe('TransactionIngested');
+
+    const payload = JSON.parse(row.payload) as Record<string, unknown>;
+    expect(payload).toEqual({ transactionIds: ['tx-1', 'tx-2'], sourceAccount: 'main-account' });
+    expect(payload['description']).toBeUndefined();
+    expect(Object.keys(payload).sort()).toEqual(['sourceAccount', 'transactionIds']);
+  });
+
+  it('exposes no update/delete path (insert-only surface)', () => {
+    const db = makeMigratedDb();
+    const recorder = new SqliteDomainEventRecorder(db);
+
+    expect((recorder as unknown as Record<string, unknown>)['update']).toBeUndefined();
+    expect((recorder as unknown as Record<string, unknown>)['delete']).toBeUndefined();
+  });
+});

--- a/tests/integration/infra/db/sqlite-hash-repository.test.ts
+++ b/tests/integration/infra/db/sqlite-hash-repository.test.ts
@@ -35,13 +35,15 @@ function seedHashes(db: Database.Database, hashes: string[]): void {
 }
 
 describe('migration 003 (idempotency_hash column) + migration 004 (NOT NULL)', () => {
-  it('adds the idempotency_hash column on a fresh DB (user_version 0→4 after all migrations)', () => {
+  it('adds the idempotency_hash column on a fresh DB (user_version >= 4 after all migrations)', () => {
     // fails if: migration 003 does not exist, or the migrator skips it
-    // Note: full migration run now goes to user_version 4 (migration 004 tightens NOT NULL)
+    // Note: full migration run now goes to user_version >= 4 (migration 004 tightens
+    // NOT NULL); asserting >= 4 rather than === 4 tolerates later migrations (e.g. 005
+    // domain_events, story-4.1) — this test targets 003/004's own behavior.
     const db = freshDb();
     runMigrations(db);
     const version = db.pragma('user_version', { simple: true }) as number;
-    expect(version).toBe(4);
+    expect(version).toBeGreaterThanOrEqual(4);
 
     // Column must exist and be NOT NULL (migration 004)
     const cols = db.pragma('table_info(transactions)') as { name: string; notnull: number }[];
@@ -51,14 +53,15 @@ describe('migration 003 (idempotency_hash column) + migration 004 (NOT NULL)', (
     db.close();
   });
 
-  it('re-running migrator is a no-op (user_version stays 4 after two runs)', () => {
+  it('re-running migrator is a no-op (user_version stable after two runs)', () => {
     // fails if: the migrator does not gate on user_version — SQLite would throw
     // "duplicate column name: idempotency_hash" if ALTER TABLE fired twice
     const db = freshDb();
-    runMigrations(db); // first run: 0→4
+    runMigrations(db); // first run: 0 -> latest
+    const versionAfterFirstRun = db.pragma('user_version', { simple: true });
     expect(() => runMigrations(db)).not.toThrow(); // second run: no-op
     const version = db.pragma('user_version', { simple: true }) as number;
-    expect(version).toBe(4);
+    expect(version).toBe(versionAfterFirstRun);
     db.close();
   });
 });

--- a/tests/perf/ingest-throughput.test.ts
+++ b/tests/perf/ingest-throughput.test.ts
@@ -30,6 +30,7 @@ import { runIngestCommand } from '../../src/cli/commands/ingest-command.js';
 import type { IngestCommandDeps } from '../../src/cli/commands/ingest-command.js';
 import { runMigrations } from '../../src/infra/db/migrator.js';
 import { SqliteTransactionRepository } from '../../src/infra/db/repositories/sqlite-transaction-repo.js';
+import { SqliteDomainEventRecorder } from '../../src/infra/db/repositories/sqlite-domain-event-recorder.js';
 import { SqliteHashRepository } from '../../src/infra/db/repositories/sqlite-hash-repository.js';
 import { NodeSqliteSnapshotService } from '../../src/infra/db/node-sqlite-snapshot-service.js';
 import { NodeCsvParser } from '../../src/infra/csv/node-csv-parser.js';
@@ -133,6 +134,7 @@ describe('ingest-throughput (perf)', () => {
       const hashRepo = new SqliteHashRepository(db);
       const idempotencyService = new IdempotencyService(nodeHashFn, hashRepo);
       const snapshotService = new NodeSqliteSnapshotService(db);
+      const domainEventRecorder = new SqliteDomainEventRecorder(db);
 
       const config: AppConfig = {
         dbPath,
@@ -168,6 +170,7 @@ describe('ingest-throughput (perf)', () => {
         snapshotService,
         dbPath,
         configWriter: { appendAutoTagRules: async () => Result.ok() },
+        domainEventRecorder,
       };
 
       const start = performance.now();

--- a/tests/unit/cli/commands/ingest-command-flags.test.ts
+++ b/tests/unit/cli/commands/ingest-command-flags.test.ts
@@ -10,6 +10,7 @@ import type { SnapshotService } from '@core/ports/snapshot-service.js';
 import type { TransactionRepository } from '@core/ports/transaction-repository.js';
 import { Money } from '@core/shared/money.js';
 import type { ConfigWriter } from '@core/ports/config-writer.js';
+import type { DomainEventRecorder } from '@core/ports/domain-event-recorder.js';
 
 // fails if: --non-interactive falsely flags high-confidence as needing review,
 //           or the command hangs waiting for a prompt in CI mode (timeout guards this),
@@ -75,6 +76,10 @@ function makeNoOpConfigWriterStub(): ConfigWriter {
   return { appendAutoTagRules: vi.fn().mockResolvedValue(Result.ok()) };
 }
 
+function makeNoOpDomainEventRecorder(): DomainEventRecorder {
+  return { record: vi.fn().mockReturnValue(Result.ok()) };
+}
+
 const noOpConfirmRememberRule = vi.fn().mockResolvedValue({ action: 'skip' as const });
 
 function makeStreams(): { stdout: Writable & { captured: string }; stderr: Writable & { captured: string } } {
@@ -110,6 +115,7 @@ describe('--non-interactive mode', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: true, json: false }, deps);
@@ -140,6 +146,7 @@ describe('--non-interactive mode', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: true, json: false }, deps);
@@ -173,6 +180,7 @@ describe('--json mode', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: true }, deps);
@@ -218,6 +226,7 @@ describe('--json mode', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: true }, deps);
@@ -258,6 +267,7 @@ describe('--json mode', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/ambig.csv', nonInteractive: false, json: false }, deps);

--- a/tests/unit/cli/commands/ingest-command.test.ts
+++ b/tests/unit/cli/commands/ingest-command.test.ts
@@ -11,6 +11,7 @@ import type { SnapshotService } from '@core/ports/snapshot-service.js';
 import type { TransactionRepository } from '@core/ports/transaction-repository.js';
 import { Money } from '@core/shared/money.js';
 import type { ConfigWriter } from '@core/ports/config-writer.js';
+import type { DomainEventRecorder } from '@core/ports/domain-event-recorder.js';
 
 // fails if: the summary table is not written to stdout,
 //           or the interactive loop is skipped for low-confidence items,
@@ -90,6 +91,10 @@ function makeNoOpConfigWriterStub(): ConfigWriter {
   };
 }
 
+function makeNoOpDomainEventRecorder(): DomainEventRecorder {
+  return { record: vi.fn().mockReturnValue(Result.ok()) };
+}
+
 // No-op InteractivePrompter stub that satisfies the updated interface.
 // Used in tests that don't exercise confirmRememberRule.
 const noOpConfirmRememberRule = vi.fn().mockResolvedValue({ action: 'skip' as const });
@@ -134,6 +139,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     const opts: IngestCommandOptions = {
@@ -184,6 +190,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
@@ -220,6 +227,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
@@ -256,6 +264,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
@@ -285,6 +294,7 @@ describe('runIngestCommand — happy path (interactive)', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/orphan.csv', nonInteractive: false, json: false }, deps);
@@ -339,6 +349,7 @@ describe('runIngestCommand — interactive re-categorisation preserves idempoten
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
@@ -401,6 +412,7 @@ describe('runIngestCommand — commitBatch flow (Story 2.5)', () => {
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
       ...overrides,
     };
 
@@ -567,6 +579,7 @@ describe('runIngestCommand — new category propagates to subsequent prompts (St
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter: makeNoOpConfigWriterStub(),
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
@@ -634,6 +647,7 @@ describe('runIngestCommand — configWriter buffer-then-flush (Story C)', () => 
       snapshotService: makeNoOpSnapshotService(),
       dbPath: TEST_DB_PATH,
       configWriter,
+      domainEventRecorder: makeNoOpDomainEventRecorder(),
     };
 
     return { deps, stdout, stderr, exitCodes, saveBatchMock };

--- a/tests/unit/cli/commands/ingest-command.test.ts
+++ b/tests/unit/cli/commands/ingest-command.test.ts
@@ -526,6 +526,48 @@ describe('runIngestCommand — commitBatch flow (Story 2.5)', () => {
     expect(snapshotService.remove).not.toHaveBeenCalled();
     expect(exitCodes).toContain(0);
   });
+
+  it('(f) saveBatch fails: domainEventRecorder.record is NEVER called (story-4.1 ordering guard)', async () => {
+    // fails if: record(...) is called before/independently of saveBatch success —
+    //   guards the "only on success" ordering in commitBatch (docs/plans/story-4.1.md
+    //   Gherkin scenario "A failed batch commit records no event").
+    const transactionRepository: Pick<TransactionRepository, 'saveBatch'> = {
+      saveBatch: vi.fn().mockReturnValue(Result.fail('SQLITE_CONSTRAINT: UNIQUE constraint failed: transactions.idempotency_hash')),
+    };
+    const domainEventRecorder: DomainEventRecorder = {
+      record: vi.fn().mockReturnValue(Result.ok()),
+    };
+
+    const { deps, exitCodes } = makeBaseInteractiveDeps({ transactionRepository, domainEventRecorder });
+
+    await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
+
+    expect(exitCodes).toContain(4);
+    expect(domainEventRecorder.record).not.toHaveBeenCalled();
+  });
+
+  it('(g) saveBatch succeeds: domainEventRecorder.record is called once with the committed ids + source account', async () => {
+    // fails if: record(...) is never called on a successful commit, called more than
+    //   once (should be one batch-level event), or built from the wrong ids/account.
+    const transactionRepository: Pick<TransactionRepository, 'saveBatch'> = {
+      saveBatch: vi.fn().mockReturnValue(Result.ok({ written: 3 })),
+    };
+    const domainEventRecorder: DomainEventRecorder = {
+      record: vi.fn().mockReturnValue(Result.ok()),
+    };
+
+    const { deps, exitCodes } = makeBaseInteractiveDeps({ transactionRepository, domainEventRecorder });
+
+    await runIngestCommand({ file: '/tmp/X_2026.csv', nonInteractive: false, json: false }, deps);
+
+    expect(exitCodes).toContain(0);
+    expect(domainEventRecorder.record).toHaveBeenCalledOnce();
+    expect(domainEventRecorder.record).toHaveBeenCalledWith({
+      type: 'TransactionIngested',
+      transactionIds: ['tx-CARREFOUR', 'tx-EDF', 'tx-AMAZON'],
+      sourceAccount: 'main-X',
+    });
+  });
 });
 
 describe('runIngestCommand — new category propagates to subsequent prompts (Story A)', () => {

--- a/tests/unit/core/events/domain-event.test.ts
+++ b/tests/unit/core/events/domain-event.test.ts
@@ -21,8 +21,8 @@ const __dirname = path.dirname(__filename);
 
 const FORBIDDEN_IMPORT_PATTERNS = [
   /from ['"]better-sqlite3['"]/,
-  /from ['"]fs['"]/,
-  /from ['"]path['"]/,
+  /from ['"](?:node:)?fs['"]/,
+  /from ['"](?:node:)?path['"]/,
   /from ['"]commander['"]/,
   /require\(['"]better-sqlite3['"]\)/,
   /new Date\(/,

--- a/tests/unit/core/events/domain-event.test.ts
+++ b/tests/unit/core/events/domain-event.test.ts
@@ -62,7 +62,7 @@ describe('TransactionIngested — value object shape', () => {
 describe('DomainEventRecorder — port shape', () => {
   it('a conforming implementation returns Result<void>', () => {
     const recorder: DomainEventRecorder = {
-      record: (_event: DomainEvent): Result<void> => Result.ok(),
+      record: (): Result<void> => Result.ok(),
     };
 
     const result = recorder.record({

--- a/tests/unit/core/events/domain-event.test.ts
+++ b/tests/unit/core/events/domain-event.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the DomainEvent value object + DomainEventRecorder port (FR23 audit-trail spine).
+ *
+ * Gherkin coverage: none directly — Core value-object shape + purity, exercised end-to-end
+ *   by tests/features/audit-trail.feature (see docs/plans/story-4.1.md).
+ *
+ * fails if: TransactionIngested carries fields beyond type/transactionIds/sourceAccount
+ *   (a clock or PII field would leak into Core), or src/core/events/ or the port import
+ *   Node APIs / better-sqlite3 / a clock (Core purity — architecture.md § Domain events).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import type { DomainEvent, TransactionIngested } from '../../../../src/core/events/domain-event.js';
+import type { DomainEventRecorder } from '../../../../src/core/ports/domain-event-recorder.js';
+import { Result } from '@core/shared/result.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const FORBIDDEN_IMPORT_PATTERNS = [
+  /from ['"]better-sqlite3['"]/,
+  /from ['"]fs['"]/,
+  /from ['"]path['"]/,
+  /from ['"]commander['"]/,
+  /require\(['"]better-sqlite3['"]\)/,
+  /new Date\(/,
+  /Date\.now\(/,
+];
+
+function sourceFilesUnder(relDir: string): string[] {
+  const dir = path.join(__dirname, '../../../../src', relDir);
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.ts'))
+    .map((f) => path.join(dir, f));
+}
+
+describe('TransactionIngested — value object shape', () => {
+  it('carries only type, transactionIds, and sourceAccount (no clock, no PII)', () => {
+    const event: TransactionIngested = {
+      type: 'TransactionIngested',
+      transactionIds: ['tx-1', 'tx-2'],
+      sourceAccount: 'main-account',
+    };
+
+    expect(Object.keys(event).sort()).toEqual(['sourceAccount', 'transactionIds', 'type']);
+  });
+
+  it('is assignable to the DomainEvent union', () => {
+    const event: DomainEvent = {
+      type: 'TransactionIngested',
+      transactionIds: ['tx-1'],
+      sourceAccount: 'main-account',
+    };
+
+    expect(event.type).toBe('TransactionIngested');
+  });
+});
+
+describe('DomainEventRecorder — port shape', () => {
+  it('a conforming implementation returns Result<void>', () => {
+    const recorder: DomainEventRecorder = {
+      record: (_event: DomainEvent): Result<void> => Result.ok(),
+    };
+
+    const result = recorder.record({
+      type: 'TransactionIngested',
+      transactionIds: ['tx-1'],
+      sourceAccount: 'main-account',
+    });
+
+    expect(result.isSuccess).toBe(true);
+  });
+});
+
+describe('Core purity — src/core/events/ and the DomainEventRecorder port', () => {
+  it('no file under src/core/events/ imports Node APIs, better-sqlite3, or a clock', () => {
+    const files = sourceFilesUnder('core/events');
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const contents = fs.readFileSync(file, 'utf8');
+      for (const pattern of FORBIDDEN_IMPORT_PATTERNS) {
+        expect(contents, `${file} matched forbidden pattern ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('src/core/ports/domain-event-recorder.ts imports no Node APIs, better-sqlite3, or a clock', () => {
+    const filePath = path.join(__dirname, '../../../../src/core/ports/domain-event-recorder.ts');
+    const contents = fs.readFileSync(filePath, 'utf8');
+    for (const pattern of FORBIDDEN_IMPORT_PATTERNS) {
+      expect(contents, `port file matched forbidden pattern ${pattern}`).not.toMatch(pattern);
+    }
+  });
+});


### PR DESCRIPTION
## 1. Story

[Story 4.1: DomainEventRecorder Port & Append-Only Event Store](docs/epics.md) — the FR23 audit-trail spine. Plan: [docs/plans/story-4.1.md](docs/plans/story-4.1.md).

## 2. Intent

Epic 4 needs an immutable, ordered **audit trail** (FR23): every meaningful action recorded as a plain domain event. This story ships the **spine** — a Core `DomainEventRecorder` port (#155) + an append-only Infra event store — wired to the simplest existing action (ingest) emitting the first event, `TransactionIngested`. Every later event (4.2 `TransactionCorrected`, 4.5 `ConfigChanged`/`DissolutionPerformed`, Epic-5 Story 5.4) depends on this port.

## 3. Alternatives considered

- **B2 (atomic inside `saveBatch`)** — grows the `TransactionRepository` port with event vocabulary (mixes ingest-ACL + audit concerns) or needs a `UnitOfWork` port now; more machinery than a spine story warrants.
- **Per-transaction events** — noisier; the meaningful *action* is the ingest run, so one batch-level event with `transactionIds[]` mirrors it (and mirrors `TransactionCorrected`'s `producedTransactionIds[]`).
- **Per-event-type columns** — a wide table per event shape; JSON `payload` keeps the store schema-stable as event types grow.

## 4. Selected solution & rationale

A Core `DomainEventRecorder` port + a `SqliteDomainEventRecorder` writing to a new append-only `domain_events` table (`seq`, `event_type`, `recorded_at`, JSON `payload`), recorded at the **app boundary (B1)** in `commitBatch` after a successful ingest batch commit. Core event value objects (`src/core/events/`) carry domain fields only — no timestamp/clock (`recorded_at` is stamped by Infra at `record()`). B1 is the right call-site for ingest: no Core domain service exists, so the boundary is its natural seam, and it keeps the recorder cleanly separate from the ingest-ACL `TransactionRepository` port. Consistent with the story-4.0 hybrid model (the atomic-in-service path lands in 4.2's `CorrectionService`).

**Known limitation (deferred):** B1 is not atomic — a crash between commit and `record()` leaves an unrecorded ingest (rare, idempotent re-run bounds impact). Atomic-record via `UnitOfWork` deferred to 4.2 → #180.

## 5. Gherkin scenarios

```gherkin
Feature: Audit trail

  Scenario: Committing an ingest batch records a TransactionIngested event
    Given a fresh migrated database and a valid BPCE statement
    When I ingest it and confirm the batch
    Then the audit trail holds a TransactionIngested event
    And its payload lists the committed transaction ids and source account
```

Plus an in-process ordering guard: a failed batch commit records **no** event.

## 6. Plan for Sonnet

See [docs/plans/story-4.1.md](docs/plans/story-4.1.md) § Slice plan (7 behaviour slices, Full lane). New files: Core event + port, migration 005, `SqliteDomainEventRecorder`; wiring into `commitBatch` + `program.ts`.

## 7. Suggestion log

Phase-2 (`plan-reviewer` + `sibling-overlap`, parallel). Sibling-overlap: no overlap. Full triage in [the plan](docs/plans/story-4.1.md#suggestion-log).

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P3 | `occurred_at` collides semantically with `transactions.occurred_at` | adopted | Renamed `recorded_at` |
| P1 | Acceptance fixture must reach a successful commit | adopted | Interactive scripted-confirm path (Phase-3 found `--non-interactive` never commits → #181) |
| P1 | `commitBatch` gains a new `sourceAccount` param (2nd signature change) | adopted | Enumerated in plan + slice 4 |
| P3 | Slice 4 over-bundled; 6 slices at low edge of R13 | adopted | Split 4→4+5 (7 slices) |
| P3 | Future `payload` read-back needs Zod at the boundary | adopted | Forward-pointer noted |
| P2 | B1 non-atomicity vs "every action leaves a trace" | deferred | #180 |
| P3 | Use `Result.flatMap` for `saveBatch → record` chain | rejected | House style: explicit `isFailure` branching in `commitBatch` |
| P3 | Append-only is convention-only (no trigger) | acknowledged | Matches existing ledger house style |
| P3 | Migration SQL comment necessity | acknowledged | Phase-4 check; kept brief/label-style |

## 8. Sonnet's learnings

## What was built
FR23 audit-trail spine: `DomainEvent`/`TransactionIngested` (Core), `DomainEventRecorder` port, migration 005 (`domain_events`), `SqliteDomainEventRecorder`, B1 wiring into `commitBatch`/`program.ts`. Acceptance scenario passes end-to-end via the composition root through the interactive scripted-confirm path.

## Red → green sequence
migration 005 (schema + idempotency) → Core event+port (+ purity grep) → recorder (ordering/UTC/payload/no-PII/insert-only) → CLI acceptance (subprocess R4) → in-process ordering guard → empty refactor slot.

## Deviations from plan
- Acceptance commit path changed from `--non-interactive` to interactive scripted-confirm — mid-implementation discovery that `runNonInteractive` never calls `commitBatch` for any fixture (pre-existing gap, out of scope, → #181). Coordinator-confirmed; plan updated.
- Two pre-existing migration tests loosened from `user_version === 4` to `>= 4` — direct fallout of adding migration 005.
- `IngestCommandDeps` widened at every existing call site (real recorder in infra tests, no-op/spy in unit tests).

## Unknowns encountered
None beyond the resolved blocker.

## Proposed follow-ups
None beyond #180 (deferred) and #181 (opened this session).

## Files touched
Core: `events/domain-event.ts`, `ports/domain-event-recorder.ts`. Infra: `migrations/005-domain-events.sql`, `repositories/sqlite-domain-event-recorder.ts`. CLI: `commands/ingest-command.ts`, `program.ts`. Tests: migration-005, domain-event, recorder, `audit-trail.feature`+steps, ingest-command ordering guards, plus deps-widen at existing call sites.

## 9. Retrospective

- **Keep:** the parked B1-vs-B2 call-site fork was closed with a written rationale that reconciles with the 4.0 hybrid model (not a coin-flip); the implementer stopped at a real blocker (#181) instead of guessing; model-conformance review at first materialization validated the whole event family; Phase-4 caught a PII-hygiene inconsistency the green tests didn't.
- **Change:** schema-version test fallout (`toBe(4)`→`>=4`) belongs in its own `chore(test):` slice, not bundled into a feature commit; ratify the event-family field vocabulary (`transactionIds` vs `producedTransactionIds`) when 4.2 builds the second event; flag plan-named test *locations* in the return report when substituted.
- **Try:** standardize where `fails if` prose lives for `.feature` files (step docstring); re-verify plan premises (e.g. call-graph reachability) at phase transitions, not only before pushes.

Full retrospective: [docs/retrospectives/story-4.1.md](../blob/story-4.1/docs/retrospectives/story-4.1.md)


## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-4.1.md`
- [x] All suggestion-log items resolved (no blank `Resolution` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [ ] User approval

