### PR TITLE
story-4.2b: correct CLI command + boundary wiring (Correction, FR14)

### DIFF
--- a/docs/plans/story-4.2b.md
+++ b/docs/plans/story-4.2b.md
@@ -1,0 +1,325 @@
+# Story 4.2b — Correction CLI Command + Boundary Wiring
+
+## Context
+
+Story 4.2 (Correction) is split into **4.2a — the correction domain** (shipped, PR #184) and
+**4.2b — the `correct` CLI command + boundary wiring** (this plan). The split was
+pre-authorized by the epic and confirmed in the 4.2a plan (CLAUDE.md §6.6: >~3 scenarios →
+split).
+
+**4.2a delivered** the pure domain + schema + persistence: `Transaction.kind`/`correctsId`,
+`CorrectionChanges`, pure `CorrectionService.correct(original, changes, ids, reason)`
+(reverse-and-correct), `TransactionCorrected` in the `DomainEvent` union, migration 006
+(kind-conditioned `idempotency_hash` CHECK), atomic hash-free `saveCorrection`. No CLI, no
+event recording.
+
+**4.2b delivers** the user-facing `correct` command: parses explicit flags (no interactive
+mode — user-confirmed in 4.2a), loads the original transaction, builds `CorrectionChanges`,
+calls `CorrectionService.correct`, persists via `saveCorrection`, and records
+`TransactionCorrected` at the app boundary (the B1 pattern story-4.1 shipped for ingest).
+Targets **FR14** (Correction). **Lane: Full** (touches `src/core/ledger/correction-service.ts`
+— two new guards, see Domain model).
+
+Also picks up **[#185](https://github.com/xavierbriand/accounting/issues/185)** (deferred from
+4.2a's Phase-4 review): `CorrectionService` decides `changedFields` via truthy checks, silently
+dropping an intentional empty-string clear (e.g. blanking a description). Unreachable in 4.2a
+(no CLI existed); reachable now that `correct`'s flags can supply an explicit empty string.
+
+### Maintenance sub-loop (§ 6.7) run 2026-07-06 pre-planning
+
+- **Sibling work check.** `gh pr list --state open --draft --base main` → **none.**
+  `gh issue list --state open` scanned (40+ items): no issue targets the `correct` CLI build-out
+  itself. Adjacent-but-not-overlapping: **#180** (atomic audit-event `UnitOfWork`) — this story's
+  `record()` call inherits the same B1 non-atomicity as ingest, tracked by #180, not fixed here
+  (per 4.2a's already-recorded user decision, reconfirmed in Risks below). **#183**
+  (split-correction, >2-entry) — still out of scope; `CorrectionService` already guards it,
+  this story just surfaces the message. **#185** — in scope for this story (see Context).
+  **story-maint-21** (E2E journey tests, in flight on a sibling branch) has a `correct`
+  journey (journey 3) explicitly gated on this story shipping first — no collision, it
+  consumes this story's output as a dependency.
+- **Story-id uniqueness.** `git ls-tree -r origin/main -- docs/plans/ docs/retrospectives/
+  docs/status.d/ | grep -i "4\.2"` → only `story-4.2a.md` files exist. No open PR branch
+  carries `4.2b`. **`story-4.2b` is free.**
+- **Working tree clean.** Dedicated worktree (`../accounting-4.2b`) cut fresh from
+  `origin/main` (8747d84, story-4.2a merged); `git status` clean.
+- **Open issues.** 40+ open; scanned — none block. Deferred-suggestion backlog unrelated to the
+  correction CLI path.
+- **Open PRs.** None. No Dependabot bumps pending.
+- **`npm audit --audit-level=high`.** 0 vulnerabilities.
+- **Proceed-to-planning:** ✅ — clean surface, no overlap, domain pre-decided in 4.0/4.2a.
+
+## Story
+
+> As a **User**, I want to run `accounting correct <transactionId>` with explicit flags for
+> the field(s) I'm fixing and a required reason, so that the system writes a reversal and a
+> correcting entry, records the correction in the audit trail, and I can see confirmation of
+> what changed — all without erasing the original transaction.
+
+## Domain model
+
+Derives from the Phase-0 model note [story-4.0](../domain/model-notes/story-4.0.md) (R24),
+same as 4.2a. No new glossary vocabulary — `correct`, `Correction`, `Reversal`, `Correcting
+entry` are all already defined.
+
+- **Aggregates / value objects / services touched:**
+  - `CorrectionService` (existing domain service, [correction-service.ts](../../src/core/ledger/correction-service.ts))
+    gains **two new guards** and **one bug fix**, all inside the existing `correct()` method —
+    no new public surface.
+    1. **New guard (proposed delta, user-approved 2026-07-06):** reject when
+       `original.kind === 'reversal'` — a reversal is a system-generated bookkeeping artifact,
+       never a user-authored row; only `original` or `correcting` transactions are meaningful
+       correction targets. Not stated in the 4.0 note's invariant list; proposed as a new
+       invariant 9, to reconcile into the note at retro (same pattern as 4.2a's date-correction
+       clarification).
+    2. **New guard:** reject when zero fields are present in `CorrectionChanges` (nothing to
+       correct) — a CLI-usability guard, not a model-note invariant.
+    3. **Bug fix, closes #185:** `changedFieldsOf`'s truthy checks (`if (changes.account)`,
+       `if (changes.date)`, `if (changes.description)`) silently treat an explicit empty string
+       as "no change." Fix: `!== undefined` checks (matches `changes.amount`'s existing
+       object-truthy behaviour, which was already correct since `Money` objects are always
+       truthy). `buildCorrecting`'s account-application truthy check
+       (`changes.account && isDebitSide`) gets the same fix, for consistency, even though an
+       empty-string category has no real business meaning (CLI-side zod rejects it before it
+       reaches Core — see Production-code surface).
+
+    **Guard order (Phase-2 P1 finding — adopted)**, inserted into the existing sequence so a
+    compound-invalid input reports the most fundamental problem first: (1) reason non-empty
+    [existing] → (2) `original.kind !== 'reversal'` [**new**] → (3) `entries.length <= 2`
+    [existing, #183 guard] → (4) `changedFieldsOf(changes).length > 0` [**new**] → (5) currency
+    match [existing] → (6) build (`Result.all([buildReversal, buildCorrecting])`) [existing].
+
+    - **Phase-3 implementation note (Phase-2 P3 finding — acknowledged, optional):** the two
+      new guards plus the three existing ones (reason, entry-count, currency) are five
+      sequential early-return `if`s. A `validate(original, changes): Result<void>` helper
+      ahead of the `Result.all` build would consolidate them; soft suggestion, Sonnet's
+      discretion, not required for DoD.
+    - **Phase-3 implementation note (Phase-2 P1 finding — acknowledged):** scenario 5's
+      `kind: 'reversal'` fixture should be constructed directly via
+      `Transaction.create({ kind: 'reversal', ... })` rather than a full prior
+      `CorrectionService.correct` round-trip — faster, and the round-trip path is already
+      covered by 4.2a's own tests.
+  - `correct-command.ts` (**new**, CLI/Infra layer) — orchestrates: `findById` → build
+    `CorrectionChanges` from parsed flags → `CorrectionService.correct` → `saveCorrection` →
+    `domainEventRecorder.record` → render output. No new Core types.
+- **Invariants the diff must not violate:** all eight from the 4.0 note (unchanged, already
+  covered by 4.2a's tests) plus the two new guards above (covered by this story's tests).
+- **Events emitted:** none new — `TransactionCorrected` (4.2a) is recorded here for the first
+  time, via the existing `DomainEventRecorder` port (#155), at the app boundary (B1),
+  immediately after `saveCorrection` succeeds — mirroring `ingest`'s `commitBatch`
+  ([ingest-command.ts:169-218](../../src/cli/commands/ingest-command.ts)) exactly: record only
+  after the ledger write is durable; a `record()` failure warns to stderr but does not roll
+  back the already-committed rows (same B1 trade-off story-4.1 accepted for ingest; **#180**
+  remains the dedicated story that would close this non-atomicity gap for both paths at once —
+  not reopened here, per 4.2a's user-confirmed decision).
+
+## Selected solution
+
+A new `runCorrectCommand(options, deps)` in `src/cli/commands/correct-command.ts`, registered
+in `program.ts` as `correct <transactionId>` with explicit flags (no interactive prompt loop —
+matches 4.2a's "explicit flags" user-confirmed design). Flags:
+
+- `--amount <decimal>` — e.g. `45.30`. **Parsed as a string directly to integer cents, never
+  through a float intermediate (Phase-2 P2 finding — adopted).** `Number()`/`parseFloat` on a
+  decimal string is exactly what `security-checklist.md` line 12 forbids ("No
+  `Number.parseFloat`... for money"); `Money.fromDecimal` takes a `number` and is only safe when
+  that number didn't come from an unchecked string→float conversion. Mirror the codebase's own
+  established pattern — `parseCentsFromString` in
+  [node-csv-parser.ts](../../src/infra/csv/node-csv-parser.ts) parses a decimal string straight
+  to integer cents via `String.split`/`parseInt` on the whole/fractional parts, no float ever
+  constructed. `correct-command-options.ts` gets a period-separated sibling of that function
+  (the CSV one is comma-separated, French-locale-specific — not directly reusable), then calls
+  `Money.fromCents(cents, originalCurrency)`. Currency is always taken from the original — no
+  `--currency` flag; cross-currency is rejected by `CorrectionService` itself.
+- `--category <name>` — the expense category; CLI maps it to the full ledger account string
+  via the existing `expenseAccount(category)` helper
+  ([account-names.ts](../../src/core/ingest/account-names.ts)) before building
+  `CorrectionChanges.account`. Must be non-empty if the flag is passed (zod) — clearing a
+  category to "" has no business meaning, unlike clearing a free-text description.
+- `--date <YYYY-MM-DD>` — **bare date, user-confirmed 2026-07-06.** The command combines it
+  with the *original* transaction's time-of-day and UTC offset (splicing the date portion of
+  `occurredAt`), so the user never has to reproduce the exact receipt timestamp to fix a
+  date typo. No full-ISO8601-with-offset input required.
+- `--description <text>` — any string, including `""` (explicit clear — closes #185).
+- `--reason <text>` — **required** (commander `requiredOption`, plus a zod non-empty check as
+  belt-and-suspenders ahead of `CorrectionService`'s own check).
+- `--json` — **shipped now, user-confirmed 2026-07-06** (not deferred to story-4.4), for
+  consistency with `ingest`/`status`'s existing convention.
+- `--db-path-override <path>` — existing global convention, wired the same way as other
+  commands.
+
+**No pre-write snapshot** (user-confirmed 2026-07-06): `saveCorrection` is a single atomic
+SQLite transaction inserting exactly two new rows; unlike `ingest`'s larger batch commit, there
+is no partial-batch corruption mode for a snapshot to guard against, and correction is
+purely additive (never touches/deletes existing rows). FR17's "before any write operation
+(ingest/settle)" is read as scoped to those two operations' specific risk profile, not as a
+blanket rule; `correct` relies on `saveCorrection`'s own atomicity.
+
+**Alternatives set aside:**
+- *Interactive prompt mode for `correct`* — already rejected in 4.2a's planning (explicit
+  flags chosen for a mutation this precise; interactive mode fits discovery-heavy flows like
+  `ingest`/`categorize`, not a targeted single-field fix).
+- *A `--dry-run`/preview flag* — not requested by FR14 or the model note; would add scope
+  without a concrete need yet. Can be a follow-up if real usage shows a demand for it.
+- *Snapshot before write* — considered and set aside above (Selected solution).
+- *`--json` deferred to story-4.4* — considered and set aside; shipping now keeps the
+  convention consistent from day one at low marginal cost.
+
+## Production-code surface (R2)
+
+| File | Change |
+| --- | --- |
+| `src/core/ledger/correction-service.ts` | Add guard: `Result.fail` if `original.kind === 'reversal'`. Add guard: `Result.fail` if `changedFieldsOf(changes).length === 0`. Fix `changedFieldsOf`'s `account`/`date`/`description` truthy checks → `!== undefined` (closes #185). Fix `buildCorrecting`'s account truthy check → `!== undefined`. No signature changes. |
+| `src/cli/commands/correct-command.ts` *(new)* | `runCorrectCommand(options, deps): Promise<void>` — **matches the existing `ingest`/`status`/`categorize` convention (Phase-2 P3 finding — adopted; the draft's `Promise<number>` return was an unjustified deviation)**: an injected `exitCode: (code: number) => void` callback in `CorrectCommandDeps`, same as `IngestCommandDeps`/`StatusCommandDeps`. Decomposed into named helpers mirroring `ingest-command.ts`'s shape (Phase-2 P3 finding — adopted, keeps each under ~50 LOC): `loadOriginal` (findById + not-found/reversal-guard reporting), `buildChanges` (options → `CorrectionChanges`), `persistAndRecord` (saveCorrection → record, mirrors `commitBatch`; a `saveCorrection` failure is reported via the existing `sanitizeSqlError` helper and exits 4, matching ingest's write-failure code — no event recorded), `renderOutcome` (plain-text or `--json`). Exit codes: 0 success, 1 config/DB-setup error, 2 validation (not found / reversal-guard / no-fields-changed / bad flag shape), 4 DB write failure. |
+| `src/cli/commands/correct-command-options.ts` *(new)* | Zod schema + parsing: amount (decimal string → integer cents, see Selected solution — never a float intermediate), date (`YYYY-MM-DD` shape), category (non-empty if present), description (any string), reason (non-empty). Exported `parseCorrectOptions` returning `Result<ParsedCorrectOptions>` for a clean CLI-boundary validation layer (mirrors the shape of validation elsewhere, e.g. `status-command.ts`'s `ISO_DATE` regex). |
+| `src/cli/commands/correct-formatter-json.ts` *(new)* | `--json` output: `{ targetTransactionId, producedTransactionIds: [reversalId, correctingId], changedFields, reason }` — mirrors `TransactionCorrected`'s own shape for consistency. |
+| `src/cli/program.ts` | Register `correct <transactionId>` command: options `--amount`, `--category`, `--date`, `--description`, `--reason` (required), `--json`, `--db-path-override`; DI wiring (`SqliteTransactionRepository`, `SqliteDomainEventRecorder`, a `UuidGen`, `process.stdout`/`stderr`, `exitCode`). |
+| `docs/domain/model-notes/story-4.0.md` | Proposed delta (user-approved 2026-07-06, to reconcile at retro): new invariant 9 — a correction may not target a `kind: 'reversal'` transaction. |
+
+No DB migration (schema unchanged since 4.2a's migration 006). No changes to
+`src/core/ledger/transaction.ts`, `correction-changes.ts`, or
+`src/core/ports/transaction-repository.ts` — their 4.2a shapes are sufficient.
+
+## Gherkin acceptance scenarios
+
+Scenarios 1–7 (including 6b) are **in-process** (R7) — direct calls into `runCorrectCommand`
+against a real SQLite temp DB (no subprocess). Scenario 8 is the **R4 composition-root
+subprocess test**
+(program.ts is touched by this story) — spawns the real built binary via `spawnCli`.
+
+1. **Correct an amount (happy path, human output)** — *Given* a persisted two-entry original
+   transaction, *When* I run `correct <id> --amount 45.30 --reason "wrong amount on receipt"`,
+   *Then* the process exits 0, stdout reports the reversal id, the correcting id, and
+   `changedFields: ["amount"]`, the DB holds three transactions (original untouched, a
+   `reversal`, a `correcting`), and one `TransactionCorrected` event is recorded whose payload
+   names the target id, the two produced ids, `changedFields`, and the reason.
+   *fails if* the command doesn't call `saveCorrection` + `record`, or misreports changed
+   fields.
+2. **`--json` output, multiple changed fields** — *Given* the same setup, *When* I run
+   `correct <id> --amount 45.30 --category Insurance --reason "..." --json` (**two** fields
+   changed at once — Phase-2 P2 finding, mock-diversity/R8 — adopted, avoids defaulting to a
+   single-element `changedFields` fixture that would mask an array-truncation bug), *Then*
+   stdout is a single JSON document `{ targetTransactionId, producedTransactionIds,
+   changedFields: ["amount", "account"], reason }` and no human-readable text is mixed in.
+   *fails if* the JSON is missing a field, only reports one of the two changed fields, or human
+   prose leaks into stdout under `--json`.
+3. **Reason required** — *When* I omit `--reason`, *Then* commander rejects before Core is
+   reached, with a clear stderr message and a non-zero exit; no rows written, no event
+   recorded.
+   *fails if* the command proceeds without a reason.
+4. **Transaction not found** — *Given* no transaction exists with the given id, *When* I run
+   `correct <bogus-id> --amount 10.00 --reason "test"`, *Then* the process exits 2, stderr
+   names the missing id, no rows are written, no event is recorded.
+   *fails if* the command crashes uncaught or silently no-ops with exit 0.
+5. **Reject correcting a reversal** — *Given* a transaction with `kind: 'reversal'` (produced
+   by a prior correction), *When* I try to `correct` it, *Then* the process exits 2 with a
+   message citing that a reversal cannot be corrected; no new rows, no event.
+   *fails if* the new guard is missing and a reversal gets corrected.
+6. **No fields to correct** — *Given* a valid original, *When* I run
+   `correct <id> --reason "just checking"` with no `--amount`/`--category`/`--date`/
+   `--description`, *Then* the process exits 2 citing that at least one field must be
+   corrected; no rows written.
+   *fails if* the service accepts and persists a no-op correction.
+6b. **`saveCorrection` write failure (Phase-2 P2 finding — adopted; parity with `ingest`'s
+   explicit "commit failed" handling, `ingest-command.ts:184-193`)** — *Given* a valid
+   correction request but `saveCorrection` returns `Result.fail` (simulated via a
+   fault-injecting repository double), *When* `correct` runs, *Then* the process exits 4 with a
+   `sanitizeSqlError`-redacted stderr message (reusing the existing redaction helper — no raw
+   SQLite error text, no hash-like tokens), and no `TransactionCorrected` event is recorded
+   (mirrors ingest's "don't record after a failed write").
+   *fails if* the command records an event despite the write failing, or leaks an unredacted DB
+   error to stderr.
+7. **Clearing a description to empty text (closes #185)** — *Given* an original with a
+   non-empty description, *When* I run `correct <id> --description "" --reason "typo cleanup"`,
+   *Then* the correcting entry's description is empty and `changedFields` includes
+   `"description"`.
+   *fails if* the empty-string clear is silently dropped from the correcting entry or omitted
+   from `changedFields`.
+8. **Full CLI journey through the real binary (composition-root, subprocess, R4)** — *Given* a
+   fresh migrated DB with a transaction committed via a real `ingest` subprocess run, *When* I
+   run `accounting correct <id> --category Insurance --reason "miscategorized" --json` as a
+   real subprocess against the same DB, *Then* the process exits 0, the JSON output matches
+   the documented shape, and a direct read of the DB confirms the reversal + correcting rows
+   and the recorded `TransactionCorrected` event.
+   *fails if* `correct` isn't actually wired into `program.ts`, or any DI seam is broken
+   end-to-end (the class of bug per-unit tests can't catch — same rationale as
+   story-maint-21's e2e tier, which gates its own `correct` journey on this scenario existing).
+
+**No new property tests** — this story adds CLI wiring and two Core guards, not new algebraic
+invariants; 4.2a's property tests (net-to-zero, observational equality) already cover the
+domain algebra this command exercises.
+
+## Slice plan
+
+Target 8–9 slices (R13, upper end of Full lane's 6–10 — CLI wiring is usually leaner, but two
+Core guards + a bug fix + `--json` add real surface). One slice = one behaviour; § 6.4 rhythm,
+story id in every subject.
+
+1. `test/feat(ledger): CorrectionService — reject correcting a reversal + require ≥1 changed field`.
+2. `test/feat(ledger): CorrectionService — #185 fix, absent-vs-empty-string field detection`.
+3. `test/feat(cli): correct command — options parsing + zod boundary validation`.
+4. `test/feat(cli): correct command — happy path (load, correct, persist, record)`.
+5. `test/feat(cli): correct command — --json output`.
+6. `test/feat(cli): correct command — error paths (not found, reversal guard, no-fields guard, saveCorrection write-failure w/ sanitizeSqlError) → exit codes`.
+7. `test(acceptance): correct.feature — in-process CLI journeys`.
+8. `test(acceptance): correct.feature — composition-root subprocess journey (R4)`.
+9. `refactor(cli): <extraction from review>` (or R11 empty slot with justification).
+
+If Sonnet reports > 1 round, split at the Core-guards seam (1–2) vs the CLI-command seam
+(3–8) — same contingency 4.2a used.
+
+## Risks & deferred items
+
+| Risk | Mitigation |
+| --- | --- |
+| **#180 (B1 non-atomicity)** — `record()` here is not atomic with `saveCorrection`, same as ingest. | Accepted, same as 4.2a's decision: #180 remains the dedicated `UnitOfWork` story closing the gap for both paths together. Not reopened here. |
+| `reason` (PII-adjacent, glossary: "redacted in logs") could leak via an error/warning message. | `CorrectionService.correct`'s `Result.fail` messages never echo `reason` (already true in 4.2a). This story's own error/warning strings (not-found, reversal-guard, no-fields, record-failure warning) must not interpolate `reason` — verified by a unit test asserting the `record()`-failure warning string excludes the literal reason text. |
+| Split-correction (>2-entry) is still deferred. | `CorrectionService` already guards it (4.2a, #183); the CLI surfaces the `Result.fail` message via exit code 2, no new work here. |
+| `--date`'s bare-date-plus-original-offset combining logic has an edge case around DST-transition offsets. | Splice the date portion of the stored `occurredAt` string directly (string manipulation on the ISO components), not a `Date` object round-trip — avoids timezone-library DST pitfalls entirely; unit-tested with an offset-bearing fixture. |
+| New invariant (reject correcting a reversal) diverges from the literal 4.0 note, which doesn't mention it. | Recorded as a proposed model-note delta (user-approved 2026-07-06); reconcile into the 4.0 note at retro (same pattern 4.2a used for the date-correction clarification). |
+| `--category`'s empty-string edge case (no business meaning) vs `--description`'s (meaningful clear) — inconsistent-looking CLI validation. | Called out explicitly in the plan (Selected solution) and in code comments at the zod schema; the asymmetry is real business semantics, not an oversight. |
+
+Deferred follow-ups: none new. #180 and #183 remain open, unaffected by this story.
+
+## Verification plan
+
+- `npm run lint && npm run build && npm test` green (DoD 1).
+- No migration in this story (DoD 2 — N/A, nothing to run twice).
+- Both new Core guards get a unit test each (DoD 3); the #185 fix gets a regression test
+  (empty-string description clear, scenario 7).
+- 100% branch coverage on the changed `src/core/ledger/correction-service.ts` lines and the new
+  `src/cli/commands/correct-command*.ts` files (Infra/CLI coverage target per CLAUDE.md §5 is
+  lower than Core's 100%, but the new CLI files should still be fully exercised by the Gherkin
+  scenarios above — no untested branch in the option-parsing or exit-code paths).
+- All 9 Gherkin scenarios (1–7 incl. 6b, plus 8) green, including the one composition-root subprocess test (R4).
+- `reason`-leakage check: a unit test asserts the `record()`-failure warning string (mocked
+  recorder returning `Result.fail`) does not contain the literal reason text.
+- No `any`, no TODO, no dead code; commits follow §6.4 with the story id.
+
+## Suggestion log
+
+Phase 2: `plan-reviewer` (P1/P2/P3, 28 findings — 17/27 rule-tags apply, rest N/A; most
+confirmations) + `sibling-overlap` in parallel. Substantive findings dispositioned below; pure
+confirmations omitted (per 4.2a's precedent).
+
+| # | Finding | Tag | Resolution |
+|---|---------|-----|------------|
+| 1 | P2: `--amount` parsed via `Number()`/`parseFloat` before `Money.fromDecimal` is exactly what `security-checklist.md` ("No `Number.parseFloat`... for money") forbids; the codebase's own CSV parser avoids this via string→integer-cents parsing. | **ADOPT** | `correct-command-options.ts` gets a period-separated sibling of `node-csv-parser.ts`'s `parseCentsFromString` (string→integer cents, no float intermediate), then `Money.fromCents`. Selected-solution + Production-code-surface updated. |
+| 2 | P1: guard-insertion order for the two new `CorrectionService` guards (reversal-kind, zero-changed-fields) relative to the three existing guards (reason, entry-count, currency) wasn't specified; a compound-invalid input's reported error would be non-deterministic across implementations. | **ADOPT** | Explicit 6-step guard order specified in Domain-model section: reason → reversal-kind → entry-count → changed-fields → currency → build. |
+| 3 | P2: `--json` output test (scenario 2) only exercised a single-changed-field case, risking a mock that masks an array-truncation bug in `changedFields` (R8 mock-diversity). | **ADOPT** | Scenario 2 rewritten to correct **two** fields at once (`--amount` + `--category`) and assert both appear in `changedFields`. |
+| 4 | P2: no Gherkin scenario covers `saveCorrection` returning `Result.fail` (DB write failure) — `ingest` has an explicit "commit failed, rolled back" path (`ingest-command.ts:184-193`) but the draft plan didn't mirror it for `correct`. | **ADOPT** | New scenario 6b: fault-injecting repository double, exit 4, `sanitizeSqlError`-redacted stderr, no event recorded. Slice 6 updated to include it. |
+| 5 | P3: draft's `runCorrectCommand(...): Promise<number>` deviates from the established `ingest`/`status`/`categorize` convention (`Promise<void>` + injected `exitCode` callback) without justification. | **ADOPT** | Signature changed to `Promise<void>` + `exitCode` callback in `CorrectCommandDeps`, matching `IngestCommandDeps`/`StatusCommandDeps` exactly. |
+| 6 | P3: `runCorrectCommand`'s described responsibilities (load, build, call, persist, record, render) risk exceeding ~50 LOC as one function, the way `ingest`'s top-level orchestration avoids this via named helpers (`commitBatch`, `runNonInteractive`, etc.). | **ADOPT** | Plan now names the decomposition explicitly: `loadOriginal`, `buildChanges`, `persistAndRecord`, `renderOutcome`. |
+| 7 | P1: FR17 ("Snapshot Backup... before any write operation (ingest/settle)") is read narrowly to exclude `correct`; textually defensible but a unilateral interpretive call. | **ACKNOWLEDGE** | Already surfaced to and confirmed by the user before this plan was drafted (2026-07-06, "No snapshot" — see Selected solution); not a silent narrowing. |
+| 8 | P1: scenario 5's `kind: 'reversal'` fixture construction path (direct `Transaction.create` vs. full correction round-trip) left unspecified. | **ACKNOWLEDGE** | Phase-3 implementation note added: construct directly via `Transaction.create({ kind: 'reversal', ... })` — faster, and the round-trip path is already covered by 4.2a's tests. |
+| 9 | P3: the five sequential guard `if`s (three existing + two new) in `CorrectionService.correct` could fold into one `validate()` helper ahead of the `Result.all` build. | **ACKNOWLEDGE** | Soft suggestion per the review itself ("not a blocker"); recorded as an optional Phase-3 implementation note, Sonnet's discretion. |
+| 10 | sibling-overlap: #180/#183/#185/#186(story-maint-21) all verified against the live tracker — characterizations in the plan's Maintenance sub-loop section confirmed accurate; no PR or branch currently competes for #185; #186 is a one-directional consumer dependency, not a collision. | **ACKNOWLEDGE** | No blocking overlap; no plan change needed. |
+
+No un-tagged items. No deferred capability in this batch (all substantive findings were either
+adopted into the plan or acknowledged as already-resolved/soft).
+
+## DoR checklist
+
+- [x] Phase 0 (Model): derives from [story-4.0 model note](../domain/model-notes/story-4.0.md) (R24); reversal-guard recorded as a proposed delta (user-approved 2026-07-06).
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review — Full lane: `plan-reviewer` + `sibling-overlap` in parallel): findings triaged above; no un-tagged items.
+- [ ] Draft PR with template sections 1–6 filled.

--- a/docs/plans/story-4.2b.md
+++ b/docs/plans/story-4.2b.md
@@ -322,4 +322,4 @@ adopted into the plan or acknowledged as already-resolved/soft).
 - [x] Phase 0 (Model): derives from [story-4.0 model note](../domain/model-notes/story-4.0.md) (R24); reversal-guard recorded as a proposed delta (user-approved 2026-07-06).
 - [x] Phase 1 (Plan): complete in this document.
 - [x] Phase 2 (Critical review — Full lane: `plan-reviewer` + `sibling-overlap` in parallel): findings triaged above; no un-tagged items.
-- [ ] Draft PR with template sections 1–6 filled.
+- [x] Draft PR with template sections 1–6 filled: [PR #187](https://github.com/xavierbriand/accounting/pull/187).

--- a/src/cli/commands/correct-command-options.ts
+++ b/src/cli/commands/correct-command-options.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+import { Result } from '@core/shared/result.js';
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const DECIMAL_AMOUNT_REGEX = /^[+-]?\d+(\.\d{1,2})?$/;
+
+export interface CorrectCommandOptions {
+  readonly transactionId: string;
+  readonly amount?: string;
+  readonly category?: string;
+  readonly date?: string;
+  readonly description?: string;
+  readonly reason: string;
+  readonly json: boolean;
+}
+
+export interface ParsedCorrectOptions {
+  readonly transactionId: string;
+  readonly amountCents?: number;
+  readonly category?: string;
+  readonly date?: string;
+  readonly description?: string;
+  readonly reason: string;
+  readonly json: boolean;
+}
+
+const RawCorrectOptionsSchema = z
+  .object({
+    transactionId: z.string().min(1),
+    amount: z.string().optional(),
+    category: z.string().min(1, '--category must not be empty').optional(),
+    date: z.string().regex(ISO_DATE_REGEX, '--date must be ISO 8601 date (YYYY-MM-DD)').optional(),
+    description: z.string().optional(),
+    reason: z.string().min(1, '--reason must not be empty'),
+    json: z.boolean(),
+  })
+  .strict();
+
+/**
+ * String-to-integer-cents conversion for a period decimal separator (CLI
+ * locale), mirroring node-csv-parser.ts's comma-separated parseCentsFromString.
+ * Never constructs a float — security-checklist.md bans Number.parseFloat for
+ * money; Result.fail on invalid shape stands on its own (this function owns
+ * amount validation — no redundant zod regex ahead of it).
+ */
+function parseCentsFromDecimalString(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!DECIMAL_AMOUNT_REGEX.test(trimmed)) return null;
+  const withoutSign = trimmed.replace(/^[+-]/, '');
+  const dotIdx = withoutSign.indexOf('.');
+  if (dotIdx === -1) {
+    return parseInt(withoutSign, 10) * 100;
+  }
+  const whole = withoutSign.slice(0, dotIdx);
+  const frac = withoutSign.slice(dotIdx + 1).padEnd(2, '0');
+  return parseInt(whole, 10) * 100 + parseInt(frac, 10);
+}
+
+function formatZodError(err: z.ZodError): string {
+  const issues = err.issues.map((issue) => {
+    const pathStr = issue.path.length > 0 ? issue.path.join('.') + ': ' : '';
+    return `${pathStr}${issue.message}`;
+  });
+  return issues.join('; ');
+}
+
+export function parseCorrectOptions(raw: CorrectCommandOptions): Result<ParsedCorrectOptions> {
+  const parsed = RawCorrectOptionsSchema.safeParse(raw);
+  if (!parsed.success) {
+    return Result.fail(formatZodError(parsed.error));
+  }
+  const data = parsed.data;
+
+  let amountCents: number | undefined;
+  if (data.amount !== undefined) {
+    const cents = parseCentsFromDecimalString(data.amount);
+    if (cents === null) {
+      return Result.fail(`--amount: invalid decimal amount "${data.amount}"`);
+    }
+    amountCents = cents;
+  }
+
+  return Result.ok({
+    transactionId: data.transactionId,
+    amountCents,
+    category: data.category,
+    date: data.date,
+    description: data.description,
+    reason: data.reason,
+    json: data.json,
+  });
+}

--- a/src/cli/commands/correct-command.ts
+++ b/src/cli/commands/correct-command.ts
@@ -1,0 +1,140 @@
+import type { Writable } from 'stream';
+import type { TransactionRepository } from '@core/ports/transaction-repository.js';
+import type { DomainEventRecorder } from '@core/ports/domain-event-recorder.js';
+import type { UuidGen } from '@core/ports/uuid-gen.js';
+import type { CorrectionChanges } from '@core/ledger/correction-changes.js';
+import { Transaction } from '@core/ledger/transaction.js';
+import { Money } from '@core/shared/money.js';
+import { CorrectionService, type CorrectionIds, type CorrectionOutcome } from '@core/ledger/correction-service.js';
+import { expenseAccount } from '@core/ingest/account-names.js';
+import { sanitizeSqlError } from '../utils/sanitize-sql-error.js';
+import { parseCorrectOptions, type CorrectCommandOptions, type ParsedCorrectOptions } from './correct-command-options.js';
+import { formatCorrectJson } from './correct-formatter-json.js';
+
+export type { CorrectCommandOptions } from './correct-command-options.js';
+
+export interface CorrectCommandDeps {
+  readonly transactionRepository: Pick<TransactionRepository, 'findById' | 'saveCorrection'>;
+  readonly domainEventRecorder: DomainEventRecorder;
+  readonly uuidGen: UuidGen;
+  readonly stdout: Writable;
+  readonly stderr: Writable;
+  readonly exitCode: (code: number) => void;
+}
+
+function writeln(stream: Writable, msg: string): void {
+  stream.write(msg + '\n');
+}
+
+function spliceDate(originalOccurredAt: string, newDatePart: string): string {
+  // Splices the date portion of the original ISO-8601-with-offset string,
+  // preserving time-of-day + UTC offset verbatim. String manipulation only —
+  // no Date object round-trip — avoids DST-transition offset pitfalls entirely.
+  const timePart = originalOccurredAt.slice(10);
+  return newDatePart + timePart;
+}
+
+function loadOriginal(
+  transactionId: string,
+  deps: Pick<CorrectCommandDeps, 'transactionRepository' | 'stderr' | 'exitCode'>,
+): Transaction | null {
+  const { transactionRepository, stderr, exitCode } = deps;
+
+  const result = transactionRepository.findById(transactionId);
+  if (result.isFailure) {
+    writeln(stderr, `error: could not load transaction "${transactionId}": ${sanitizeSqlError(result.error)}`);
+    exitCode(1);
+    return null;
+  }
+  if (result.value === null) {
+    writeln(stderr, `error: no transaction found with id "${transactionId}"`);
+    exitCode(2);
+    return null;
+  }
+  return result.value;
+}
+
+function buildChanges(parsed: ParsedCorrectOptions, original: Transaction): CorrectionChanges {
+  // Money.fromCents cannot fail here: amountCents is always an integer (from
+  // parseCentsFromDecimalString) and the currency is already proven valid —
+  // it comes from an already-successfully-constructed original Transaction.
+  // Mirrors Transaction.ts's own internal `Money.fromCents(...).value` usage.
+  const originalCurrency = original.entries[0].amount.currency;
+  return {
+    amount: parsed.amountCents !== undefined
+      ? Money.fromCents(parsed.amountCents, originalCurrency).value
+      : undefined,
+    account: parsed.category !== undefined ? expenseAccount(parsed.category) : undefined,
+    date: parsed.date !== undefined ? spliceDate(original.occurredAt, parsed.date) : undefined,
+    description: parsed.description,
+  };
+}
+
+async function persistAndRecord(
+  outcome: CorrectionOutcome,
+  json: boolean,
+  deps: Pick<CorrectCommandDeps, 'transactionRepository' | 'domainEventRecorder' | 'stdout' | 'stderr' | 'exitCode'>,
+): Promise<void> {
+  const { transactionRepository, domainEventRecorder, stdout, stderr, exitCode } = deps;
+  const { reversal, correcting, event } = outcome;
+
+  const writeResult = transactionRepository.saveCorrection(reversal, correcting);
+  if (writeResult.isFailure) {
+    writeln(stderr, `Correction failed: ${sanitizeSqlError(writeResult.error)}`);
+    exitCode(4);
+    return;
+  }
+
+  const recordResult = domainEventRecorder.record(event);
+  if (recordResult.isFailure) {
+    writeln(stderr, `Warning: correction committed successfully but could not record the audit event: ${sanitizeSqlError(recordResult.error)}`);
+  }
+
+  renderOutcome(event, json, stdout);
+  exitCode(0);
+}
+
+function renderOutcome(
+  event: CorrectionOutcome['event'],
+  json: boolean,
+  stdout: Writable,
+): void {
+  if (json) {
+    stdout.write(formatCorrectJson(event));
+    return;
+  }
+  writeln(stdout, `Correction recorded for ${event.targetTransactionId}.`);
+  writeln(stdout, `  Reversal:        ${event.producedTransactionIds[0]}`);
+  writeln(stdout, `  Correcting:      ${event.producedTransactionIds[1]}`);
+  writeln(stdout, `  Changed fields:  ${event.changedFields.join(', ')}`);
+}
+
+export async function runCorrectCommand(
+  options: CorrectCommandOptions,
+  deps: CorrectCommandDeps,
+): Promise<void> {
+  const { stderr, exitCode } = deps;
+
+  const parsedResult = parseCorrectOptions(options);
+  if (parsedResult.isFailure) {
+    writeln(stderr, `error: ${parsedResult.error}`);
+    exitCode(2);
+    return;
+  }
+  const parsed = parsedResult.value;
+
+  const original = loadOriginal(parsed.transactionId, deps);
+  if (original === null) return;
+
+  const changes = buildChanges(parsed, original);
+  const ids: CorrectionIds = { reversalId: deps.uuidGen(), correctingId: deps.uuidGen() };
+
+  const correctionResult = CorrectionService.correct(original, changes, ids, parsed.reason);
+  if (correctionResult.isFailure) {
+    writeln(stderr, `error: ${correctionResult.error}`);
+    exitCode(2);
+    return;
+  }
+
+  await persistAndRecord(correctionResult.value, parsed.json, deps);
+}

--- a/src/cli/commands/correct-command.ts
+++ b/src/cli/commands/correct-command.ts
@@ -11,8 +11,6 @@ import { sanitizeSqlError } from '../utils/sanitize-sql-error.js';
 import { parseCorrectOptions, type CorrectCommandOptions, type ParsedCorrectOptions } from './correct-command-options.js';
 import { formatCorrectJson } from './correct-formatter-json.js';
 
-export type { CorrectCommandOptions } from './correct-command-options.js';
-
 export interface CorrectCommandDeps {
   readonly transactionRepository: Pick<TransactionRepository, 'findById' | 'saveCorrection'>;
   readonly domainEventRecorder: DomainEventRecorder;

--- a/src/cli/commands/correct-command.ts
+++ b/src/cli/commands/correct-command.ts
@@ -9,7 +9,7 @@ import { CorrectionService, type CorrectionIds, type CorrectionOutcome } from '@
 import { expenseAccount } from '@core/ingest/account-names.js';
 import { sanitizeSqlError } from '../utils/sanitize-sql-error.js';
 import { parseCorrectOptions, type CorrectCommandOptions, type ParsedCorrectOptions } from './correct-command-options.js';
-import { formatCorrectJson } from './correct-formatter-json.js';
+import { formatCorrectJson, toDisplayFieldName } from './correct-formatter-json.js';
 
 export interface CorrectCommandDeps {
   readonly transactionRepository: Pick<TransactionRepository, 'findById' | 'saveCorrection'>;
@@ -104,7 +104,7 @@ function renderOutcome(
   writeln(stdout, `Correction recorded for ${event.targetTransactionId}.`);
   writeln(stdout, `  Reversal:        ${event.producedTransactionIds[0]}`);
   writeln(stdout, `  Correcting:      ${event.producedTransactionIds[1]}`);
-  writeln(stdout, `  Changed fields:  ${event.changedFields.join(', ')}`);
+  writeln(stdout, `  Changed fields:  ${event.changedFields.map(toDisplayFieldName).join(', ')}`);
 }
 
 export async function runCorrectCommand(

--- a/src/cli/commands/correct-formatter-json.ts
+++ b/src/cli/commands/correct-formatter-json.ts
@@ -1,10 +1,19 @@
 import type { TransactionCorrected } from '@core/events/domain-event.js';
 
+// User-facing display only — the recorded TransactionCorrected event (audit trail)
+// always keeps Core's "account" vocabulary (glossary: "account/category"); this
+// remaps just what's shown to the CLI user, who typed --category.
+const DISPLAY_FIELD_NAMES: Readonly<Record<string, string>> = { account: 'category' };
+
+export function toDisplayFieldName(field: string): string {
+  return DISPLAY_FIELD_NAMES[field] ?? field;
+}
+
 export function formatCorrectJson(event: TransactionCorrected): string {
   const doc = {
     targetTransactionId: event.targetTransactionId,
     producedTransactionIds: event.producedTransactionIds,
-    changedFields: event.changedFields,
+    changedFields: event.changedFields.map(toDisplayFieldName),
     reason: event.reason,
   };
   return JSON.stringify(doc) + '\n';

--- a/src/cli/commands/correct-formatter-json.ts
+++ b/src/cli/commands/correct-formatter-json.ts
@@ -1,0 +1,11 @@
+import type { TransactionCorrected } from '@core/events/domain-event.js';
+
+export function formatCorrectJson(event: TransactionCorrected): string {
+  const doc = {
+    targetTransactionId: event.targetTransactionId,
+    producedTransactionIds: event.producedTransactionIds,
+    changedFields: event.changedFields,
+    reason: event.reason,
+  };
+  return JSON.stringify(doc) + '\n';
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -19,6 +19,7 @@ import { ScriptedPrompter, scriptHasForceMtimeRace, type Script } from './utils/
 import { runIngestCommand } from './commands/ingest-command.js';
 import { runCategorizeCommand } from './commands/categorize-command.js';
 import { runStatusCommand } from './commands/status-command.js';
+import { runCorrectCommand } from './commands/correct-command.js';
 import { runMigrate } from './migrate.js';
 import { assertMigrated } from '../infra/db/migration-check.js';
 import { validateDbPath } from '../infra/db/db-path-validator.js';
@@ -167,6 +168,58 @@ program
         dbPath: resolvedDb,
         configWriter,
         domainEventRecorder,
+      },
+    );
+  });
+
+program
+  .command('correct <transactionId>')
+  .description('Correct a past transaction (writes a reversal + a correcting entry; the original is never mutated)')
+  .option('--amount <decimal>', 'New amount, e.g. 45.30')
+  .option('--category <name>', 'New expense category')
+  .option('--date <YYYY-MM-DD>', 'New date (bare date; time-of-day and UTC offset are kept from the original)')
+  .option('--description <text>', 'New description (pass "" to explicitly clear it)')
+  .requiredOption('--reason <text>', 'Why this correction is being made (required, recorded in the audit trail)')
+  .option('--json', 'Output JSON instead of human-readable text', false)
+  .option('--db-path-override <path>', 'Override the YAML dbPath (for recovery only; emits a warning)')
+  .action(async (
+    transactionId: string,
+    options: { amount?: string; category?: string; date?: string; description?: string; reason: string; json: boolean; dbPathOverride?: string },
+  ) => {
+    const result = resolveDbPathForCommand(options, process.cwd(), process.stderr);
+    if (result.isFailure) {
+      process.stderr.write(`error: ${result.error.message}\n`);
+      process.exit(result.error.code);
+    }
+    const { resolvedDbPath } = result.value;
+    const db = getDb(resolvedDbPath);
+
+    const migrationCheck = assertMigrated(db, resolvedDbPath);
+    if (migrationCheck.isFailure) {
+      process.stderr.write(`error: ${migrationCheck.error}\n`);
+      process.exit(2);
+    }
+
+    const transactionRepository = new SqliteTransactionRepository(db);
+    const domainEventRecorder = new SqliteDomainEventRecorder(db);
+
+    await runCorrectCommand(
+      {
+        transactionId,
+        amount: options.amount,
+        category: options.category,
+        date: options.date,
+        description: options.description,
+        reason: options.reason,
+        json: options.json,
+      },
+      {
+        transactionRepository,
+        domainEventRecorder,
+        uuidGen: nodeUuidGen,
+        stdout: process.stdout,
+        stderr: process.stderr,
+        exitCode: (code) => process.exit(code),
       },
     );
   });

--- a/src/core/ledger/correction-service.ts
+++ b/src/core/ledger/correction-service.ts
@@ -44,7 +44,7 @@ function buildCorrecting(
   const correctedEntries = original.entries.map((entry) => {
     const amount = changes.amount ?? entry.amount;
     const isDebitSide = entry.side === 'debit';
-    const account = changes.account && isDebitSide ? changes.account : entry.account;
+    const account = changes.account !== undefined && isDebitSide ? changes.account : entry.account;
     return { account, side: entry.side, amount };
   });
 
@@ -61,9 +61,9 @@ function buildCorrecting(
 function changedFieldsOf(changes: CorrectionChanges): string[] {
   const fields: string[] = [];
   if (changes.amount) fields.push('amount');
-  if (changes.account) fields.push('account');
-  if (changes.date) fields.push('date');
-  if (changes.description) fields.push('description');
+  if (changes.account !== undefined) fields.push('account');
+  if (changes.date !== undefined) fields.push('date');
+  if (changes.description !== undefined) fields.push('description');
   return fields;
 }
 
@@ -78,10 +78,20 @@ export class CorrectionService {
       return Result.fail('CorrectionService: a non-empty reason is required');
     }
 
+    if (original.kind === 'reversal') {
+      return Result.fail(
+        'CorrectionService: cannot correct a reversal — reversals are system-generated bookkeeping entries, not user-authored transactions',
+      );
+    }
+
     if (original.entries.length > 2) {
       return Result.fail(
         'CorrectionService: correcting a transaction with more than 2 entries is not supported (split-correction deferred, see #183)',
       );
+    }
+
+    if (changedFieldsOf(changes).length === 0) {
+      return Result.fail('CorrectionService: at least one field must be changed to correct a transaction');
     }
 
     const originalCurrency = original.entries[0].amount.currency;

--- a/tests/features/correct.feature
+++ b/tests/features/correct.feature
@@ -60,7 +60,7 @@ Feature: Correct a past transaction via the correct CLI command
     And saveCorrection is rigged to fail for this run
     When I run correct with amount "45.30" and reason "test"
     Then the correct command exits with code 4
-    And correct stderr contains no raw SQLite error text
+    And correct stderr contains no raw idempotency-hash value
     And no TransactionCorrected event is recorded
     # fails if: the command records an event despite the write failing, or leaks
     # an unredacted DB error to stderr.

--- a/tests/features/correct.feature
+++ b/tests/features/correct.feature
@@ -25,9 +25,14 @@ Feature: Correct a past transaction via the correct CLI command
     And no transaction rows are written beyond the original
     And no TransactionCorrected event is recorded
     # fails if: the command proceeds without a reason. Tested against the zod
-    # boundary (parseCorrectOptions) in-process, per R7 — commander's own
-    # requiredOption('--reason', ...) enforcement is exercised transitively by
-    # scenario 8's real subprocess run (see docs/plans/story-4.2b.md Deviations).
+    # boundary (parseCorrectOptions) in-process, per R7 — this exercises an
+    # explicitly-blank --reason ("" present but empty), not a fully-omitted
+    # flag. Commander's own requiredOption('--reason', ...) enforcement (which
+    # a genuinely-omitted --reason hits first, before parseCorrectOptions ever
+    # runs) is not exercised by any test in this suite — scenario 8's subprocess
+    # run always supplies --reason. This mirrors the repo's existing precedent:
+    # ingest/categorize's requiredOption('-f, --file', ...) is likewise untested
+    # via subprocess omission.
 
   Scenario: Transaction not found
     Given a fresh migrated correct DB

--- a/tests/features/correct.feature
+++ b/tests/features/correct.feature
@@ -14,7 +14,7 @@ Feature: Correct a past transaction via the correct CLI command
     Given a persisted two-entry original transaction
     When I run correct with amount "45.30", category "Insurance", reason "wrong amount and category", and json output
     Then the correct command exits with code 0
-    And correct stdout is a single JSON document with changedFields "amount,account"
+    And correct stdout is a single JSON document with changedFields "amount,category"
     # fails if: the JSON is missing a field, only reports one of the two changed fields,
     # or human prose leaks into stdout under --json.
 

--- a/tests/features/correct.feature
+++ b/tests/features/correct.feature
@@ -1,0 +1,86 @@
+Feature: Correct a past transaction via the correct CLI command
+
+  Scenario: Correct an amount (happy path, human output)
+    Given a persisted two-entry original transaction
+    When I run correct with amount "45.30" and reason "wrong amount on receipt"
+    Then the correct command exits with code 0
+    And correct stdout reports the reversal id, the correcting id, and changed fields "amount"
+    And the DB holds the original plus a reversal and a correcting transaction
+    And one TransactionCorrected event is recorded naming the target, the produced ids, changed fields, and reason
+    # fails if: the command doesn't call saveCorrection + record against the real DB,
+    # or misreports changed fields.
+
+  Scenario: --json output, multiple changed fields
+    Given a persisted two-entry original transaction
+    When I run correct with amount "45.30", category "Insurance", reason "wrong amount and category", and json output
+    Then the correct command exits with code 0
+    And correct stdout is a single JSON document with changedFields "amount,account"
+    # fails if: the JSON is missing a field, only reports one of the two changed fields,
+    # or human prose leaks into stdout under --json.
+
+  Scenario: Reason required
+    Given a persisted two-entry original transaction
+    When I run correct with amount "10.00" and a blank reason
+    Then the correct command exits with code 2
+    And no transaction rows are written beyond the original
+    And no TransactionCorrected event is recorded
+    # fails if: the command proceeds without a reason. Tested against the zod
+    # boundary (parseCorrectOptions) in-process, per R7 — commander's own
+    # requiredOption('--reason', ...) enforcement is exercised transitively by
+    # scenario 8's real subprocess run (see docs/plans/story-4.2b.md Deviations).
+
+  Scenario: Transaction not found
+    Given a fresh migrated correct DB
+    When I run correct for a missing transaction with amount "10.00" and reason "test"
+    Then the correct command exits with code 2
+    And correct stderr names the missing transaction id
+    And no transaction rows are written
+    And no TransactionCorrected event is recorded
+    # fails if: the command crashes uncaught or silently no-ops with exit 0.
+
+  Scenario: Reject correcting a reversal
+    Given a persisted reversal-kind transaction
+    When I run correct on the reversal with amount "10.00" and reason "test"
+    Then the correct command exits with code 2
+    And correct stderr cites that a reversal cannot be corrected
+    And no additional transaction rows are written
+    And no TransactionCorrected event is recorded
+    # fails if: the new guard is missing and a reversal gets corrected.
+
+  Scenario: No fields to correct
+    Given a persisted two-entry original transaction
+    When I run correct with only reason "just checking"
+    Then the correct command exits with code 2
+    And correct stderr cites that at least one field must be corrected
+    And no transaction rows are written beyond the original
+    # fails if: the service accepts and persists a no-op correction.
+
+  Scenario: saveCorrection write failure
+    Given a persisted two-entry original transaction
+    And saveCorrection is rigged to fail for this run
+    When I run correct with amount "45.30" and reason "test"
+    Then the correct command exits with code 4
+    And correct stderr contains no raw SQLite error text
+    And no TransactionCorrected event is recorded
+    # fails if: the command records an event despite the write failing, or leaks
+    # an unredacted DB error to stderr.
+
+  Scenario: Clearing a description to empty text (closes #185)
+    Given a persisted two-entry original transaction with description "Transport"
+    When I run correct with description "" and reason "typo cleanup"
+    Then the correct command exits with code 0
+    And the correcting entry's description is empty
+    And correct stdout reports changed fields "description"
+    # fails if: the empty-string clear is silently dropped from the correcting
+    # entry or omitted from changedFields.
+
+  Scenario: Full CLI journey through the real binary (composition-root, subprocess, R4)
+    Given a fresh migrated DB and accounting.yaml at a temp dir
+    And a BPCE CSV copied to that temp dir as "bpce-valid_real.csv"
+    And the CSV has been committed interactively
+    When I run correct as a subprocess on the first committed transaction with category "Insurance" and reason "miscategorized" and json output
+    Then the process exits with code 0
+    And the subprocess JSON output matches the correct command's documented shape
+    And a direct DB read confirms the reversal and correcting rows and the recorded TransactionCorrected event
+    # fails if: correct isn't actually wired into program.ts, or any DI seam is
+    # broken end-to-end (the class of bug per-unit tests can't catch).

--- a/tests/features/steps/correct.steps.ts
+++ b/tests/features/steps/correct.steps.ts
@@ -1,0 +1,362 @@
+import { expect, afterEach } from 'vitest';
+import { Given, When, Then } from 'quickpickle';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { PassThrough } from 'stream';
+import type { Writable } from 'stream';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../../../src/infra/db/migrator.js';
+import { SqliteTransactionRepository } from '../../../src/infra/db/repositories/sqlite-transaction-repo.js';
+import { SqliteDomainEventRecorder } from '../../../src/infra/db/repositories/sqlite-domain-event-recorder.js';
+import { runCorrectCommand } from '../../../src/cli/commands/correct-command.js';
+import { CorrectionService } from '../../../src/core/ledger/correction-service.js';
+import { Transaction } from '../../../src/core/ledger/transaction.js';
+import { Money } from '../../../src/core/shared/money.js';
+import { Result } from '../../../src/core/shared/result.js';
+import type { TransactionRepository } from '../../../src/core/ports/transaction-repository.js';
+import type { DomainEventRecorder } from '../../../src/core/ports/domain-event-recorder.js';
+import { spawnCli } from '../../_helpers/spawn-cli.js';
+
+interface CorrectWorld {
+  tmpDir?: string;
+  csvPath?: string;
+  dbPath?: string;
+  db?: Database.Database;
+  transactionRepository?: SqliteTransactionRepository;
+  domainEventRecorder?: DomainEventRecorder;
+  originalId?: string;
+  stdout?: Writable & { captured: string };
+  stderr?: Writable & { captured: string };
+  exitCodes?: number[];
+  saveCorrectionRigged?: boolean;
+  riggedHash?: string;
+  lastResult?: { status: number; stdout: string; stderr: string };
+}
+
+const tmpDirs: string[] = [];
+const dbs: Database.Database[] = [];
+
+afterEach(() => {
+  for (const db of dbs.splice(0)) {
+    if (db.open) db.close();
+  }
+  for (const dir of tmpDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+function makeEur(cents: number): Money {
+  return Money.fromCents(cents, 'EUR').value;
+}
+
+function makeCapture(): Writable & { captured: string } {
+  const buf: string[] = [];
+  const stream = new PassThrough() as unknown as Writable & { captured: string };
+  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
+  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
+  return stream;
+}
+
+function makeTmpDb(): { tmpDir: string; dbPath: string; db: Database.Database } {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounting-correct-bdd-'));
+  tmpDirs.push(tmpDir);
+  const dbPath = path.join(tmpDir, 'correct-test.db');
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  dbs.push(db);
+  return { tmpDir, dbPath, db };
+}
+
+function insertOriginal(db: Database.Database, description = 'Transport'): Transaction {
+  const repo = new SqliteTransactionRepository(db);
+  const original = Transaction.create({
+    id: 'tx-original',
+    occurredAt: '2026-04-21T14:30:00+02:00',
+    description,
+    entries: [
+      { account: 'Expense:Transport', side: 'debit', amount: makeEur(2000) },
+      { account: 'Liabilities:CreditCard', side: 'credit', amount: makeEur(2000) },
+    ],
+  }).value;
+  const saveResult = repo.save(original, 'test-fixture-hash-original');
+  if (saveResult.isFailure) throw new Error(`fixture save failed: ${saveResult.error}`);
+  return original;
+}
+
+async function runCorrect(
+  state: CorrectWorld,
+  opts: { amount?: string; category?: string; date?: string; description?: string; reason: string; json?: boolean },
+): Promise<void> {
+  const stdout = makeCapture();
+  const stderr = makeCapture();
+  const exitCodes: number[] = [];
+  state.stdout = stdout;
+  state.stderr = stderr;
+  state.exitCodes = exitCodes;
+
+  let uuidCounter = 0;
+  const uuidGen = () => `tx-generated-${++uuidCounter}`;
+
+  const realRepo = state.transactionRepository!;
+  const transactionRepository: Pick<TransactionRepository, 'findById' | 'saveCorrection'> = state.saveCorrectionRigged
+    ? {
+        findById: (id) => realRepo.findById(id),
+        saveCorrection: () =>
+          Result.fail(`SqliteError: UNIQUE constraint failed: transactions.idempotency_hash = ${state.riggedHash!}`),
+      }
+    : realRepo;
+
+  await runCorrectCommand(
+    {
+      transactionId: state.originalId!,
+      amount: opts.amount,
+      category: opts.category,
+      date: opts.date,
+      description: opts.description,
+      reason: opts.reason,
+      json: opts.json ?? false,
+    },
+    {
+      transactionRepository,
+      domainEventRecorder: state.domainEventRecorder!,
+      uuidGen,
+      stdout: stdout as Writable,
+      stderr: stderr as Writable,
+      exitCode: (code) => exitCodes.push(code),
+    },
+  );
+}
+
+// -------- Given steps --------
+
+Given('a persisted two-entry original transaction', function (state: CorrectWorld) {
+  const { tmpDir, dbPath, db } = makeTmpDb();
+  state.tmpDir = tmpDir;
+  state.dbPath = dbPath;
+  state.db = db;
+  state.transactionRepository = new SqliteTransactionRepository(db);
+  state.domainEventRecorder = new SqliteDomainEventRecorder(db);
+  state.originalId = insertOriginal(db).id;
+});
+
+Given('a persisted two-entry original transaction with description {string}', function (state: CorrectWorld, description: string) {
+  const { tmpDir, dbPath, db } = makeTmpDb();
+  state.tmpDir = tmpDir;
+  state.dbPath = dbPath;
+  state.db = db;
+  state.transactionRepository = new SqliteTransactionRepository(db);
+  state.domainEventRecorder = new SqliteDomainEventRecorder(db);
+  state.originalId = insertOriginal(db, description).id;
+});
+
+Given('a fresh migrated correct DB', function (state: CorrectWorld) {
+  const { tmpDir, dbPath, db } = makeTmpDb();
+  state.tmpDir = tmpDir;
+  state.dbPath = dbPath;
+  state.db = db;
+  state.transactionRepository = new SqliteTransactionRepository(db);
+  state.domainEventRecorder = new SqliteDomainEventRecorder(db);
+});
+
+Given('a persisted reversal-kind transaction', function (state: CorrectWorld) {
+  const { tmpDir, dbPath, db } = makeTmpDb();
+  state.tmpDir = tmpDir;
+  state.dbPath = dbPath;
+  state.db = db;
+  const repo = new SqliteTransactionRepository(db);
+  state.transactionRepository = repo;
+  state.domainEventRecorder = new SqliteDomainEventRecorder(db);
+
+  const original = insertOriginal(db);
+  const ids = { reversalId: 'tx-reversal-fixture', correctingId: 'tx-correcting-fixture' };
+  const correctionResult = CorrectionService.correct(original, { description: 'seed correction' }, ids, 'seed reason');
+  if (correctionResult.isFailure) throw new Error(`fixture correction failed: ${correctionResult.error}`);
+  const { reversal, correcting } = correctionResult.value;
+  const writeResult = repo.saveCorrection(reversal, correcting);
+  if (writeResult.isFailure) throw new Error(`fixture saveCorrection failed: ${writeResult.error}`);
+  state.originalId = reversal.id;
+});
+
+Given('saveCorrection is rigged to fail for this run', function (state: CorrectWorld) {
+  state.saveCorrectionRigged = true;
+  state.riggedHash = 'f'.repeat(64);
+});
+
+// -------- When steps --------
+
+When('I run correct with amount {string} and reason {string}', async function (state: CorrectWorld, amount: string, reason: string) {
+  await runCorrect(state, { amount, reason });
+});
+
+When(
+  'I run correct with amount {string}, category {string}, reason {string}, and json output',
+  async function (state: CorrectWorld, amount: string, category: string, reason: string) {
+    await runCorrect(state, { amount, category, reason, json: true });
+  },
+);
+
+When('I run correct with amount {string} and a blank reason', async function (state: CorrectWorld, amount: string) {
+  await runCorrect(state, { amount, reason: '' });
+});
+
+When(
+  'I run correct for a missing transaction with amount {string} and reason {string}',
+  async function (state: CorrectWorld, amount: string, reason: string) {
+    state.originalId = 'tx-does-not-exist';
+    await runCorrect(state, { amount, reason });
+  },
+);
+
+When('I run correct on the reversal with amount {string} and reason {string}', async function (state: CorrectWorld, amount: string, reason: string) {
+  await runCorrect(state, { amount, reason });
+});
+
+When('I run correct with only reason {string}', async function (state: CorrectWorld, reason: string) {
+  await runCorrect(state, { reason });
+});
+
+When('I run correct with description {string} and reason {string}', async function (state: CorrectWorld, description: string, reason: string) {
+  await runCorrect(state, { description, reason });
+});
+
+When(
+  'I run correct as a subprocess on the first committed transaction with category {string} and reason {string} and json output',
+  function (state: CorrectWorld, category: string, reason: string) {
+    const db = new Database(state.dbPath!);
+    const row = db.prepare("SELECT id FROM transactions WHERE kind = 'original' ORDER BY id LIMIT 1").get() as { id: string };
+    db.close();
+    state.originalId = row.id;
+    state.lastResult = spawnCli(
+      ['correct', row.id, '--category', category, '--reason', reason, '--json'],
+      { cwd: state.tmpDir },
+    );
+  },
+);
+
+// -------- Then steps --------
+
+Then('the correct command exits with code {int}', function (state: CorrectWorld, code: number) {
+  expect(state.exitCodes).toEqual([code]);
+});
+
+Then(
+  'correct stdout reports the reversal id, the correcting id, and changed fields {string}',
+  function (state: CorrectWorld, fieldsCsv: string) {
+    const captured = state.stdout!.captured;
+    for (const field of fieldsCsv.split(',')) {
+      expect(captured).toContain(field);
+    }
+    const rows = state.db!.prepare('SELECT id FROM transactions WHERE corrects_id = ?').all(state.originalId!) as { id: string }[];
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(captured).toContain(row.id);
+    }
+  },
+);
+
+Then('the DB holds the original plus a reversal and a correcting transaction', function (state: CorrectWorld) {
+  const rows = state.db!.prepare('SELECT kind FROM transactions ORDER BY kind').all() as { kind: string }[];
+  expect(rows.map((r) => r.kind).sort()).toEqual(['correcting', 'original', 'reversal']);
+});
+
+Then(
+  'one TransactionCorrected event is recorded naming the target, the produced ids, changed fields, and reason',
+  function (state: CorrectWorld) {
+    const events = state.db!.prepare('SELECT event_type, payload FROM domain_events').all() as { event_type: string; payload: string }[];
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe('TransactionCorrected');
+    const payload = JSON.parse(events[0].payload) as {
+      targetTransactionId: string;
+      producedTransactionIds: string[];
+      changedFields: string[];
+      reason: string;
+    };
+    expect(payload.targetTransactionId).toBe(state.originalId);
+    expect(payload.producedTransactionIds).toHaveLength(2);
+    expect(payload.changedFields.length).toBeGreaterThan(0);
+    expect(payload.reason.length).toBeGreaterThan(0);
+  },
+);
+
+Then('correct stdout is a single JSON document with changedFields {string}', function (state: CorrectWorld, fieldsCsv: string) {
+  const lines = state.stdout!.captured.trim().split('\n');
+  expect(lines).toHaveLength(1);
+  const parsed = JSON.parse(lines[0]) as { changedFields: string[] };
+  expect(parsed.changedFields).toEqual(fieldsCsv.split(','));
+});
+
+Then('no transaction rows are written beyond the original', function (state: CorrectWorld) {
+  const count = (state.db!.prepare('SELECT COUNT(*) as n FROM transactions').get() as { n: number }).n;
+  expect(count).toBe(1);
+});
+
+Then('no transaction rows are written', function (state: CorrectWorld) {
+  const count = (state.db!.prepare('SELECT COUNT(*) as n FROM transactions').get() as { n: number }).n;
+  expect(count).toBe(0);
+});
+
+Then('no additional transaction rows are written', function (state: CorrectWorld) {
+  const count = (state.db!.prepare('SELECT COUNT(*) as n FROM transactions').get() as { n: number }).n;
+  expect(count).toBe(3);
+});
+
+Then('no TransactionCorrected event is recorded', function (state: CorrectWorld) {
+  const count = (state.db!.prepare('SELECT COUNT(*) as n FROM domain_events').get() as { n: number }).n;
+  expect(count).toBe(0);
+});
+
+Then('correct stderr names the missing transaction id', function (state: CorrectWorld) {
+  expect(state.stderr!.captured).toContain(state.originalId!);
+});
+
+Then('correct stderr cites that a reversal cannot be corrected', function (state: CorrectWorld) {
+  expect(state.stderr!.captured.toLowerCase()).toContain('reversal');
+});
+
+Then('correct stderr cites that at least one field must be corrected', function (state: CorrectWorld) {
+  expect(state.stderr!.captured.toLowerCase()).toContain('at least one field');
+});
+
+Then('correct stderr contains no raw idempotency-hash value', function (state: CorrectWorld) {
+  expect(state.stderr!.captured).not.toContain(state.riggedHash!);
+  expect(state.stderr!.captured).toContain('<redacted>');
+});
+
+Then('the correcting entry\'s description is empty', function (state: CorrectWorld) {
+  const row = state.db!.prepare("SELECT description FROM transactions WHERE kind = 'correcting'").get() as { description: string };
+  expect(row.description).toBe('');
+});
+
+Then('correct stdout reports changed fields {string}', function (state: CorrectWorld, fieldsCsv: string) {
+  for (const field of fieldsCsv.split(',')) {
+    expect(state.stdout!.captured).toContain(field);
+  }
+});
+
+Then('the subprocess JSON output matches the correct command\'s documented shape', function (state: CorrectWorld) {
+  const parsed = JSON.parse(state.lastResult!.stdout.trim()) as {
+    targetTransactionId: string;
+    producedTransactionIds: string[];
+    changedFields: string[];
+    reason: string;
+  };
+  expect(parsed.targetTransactionId).toBe(state.originalId);
+  expect(parsed.producedTransactionIds).toHaveLength(2);
+  expect(parsed.changedFields).toEqual(['account']);
+  expect(parsed.reason).toBe('miscategorized');
+});
+
+Then(
+  'a direct DB read confirms the reversal and correcting rows and the recorded TransactionCorrected event',
+  function (state: CorrectWorld) {
+    const db = new Database(state.dbPath!);
+    const rows = db.prepare('SELECT kind FROM transactions WHERE corrects_id = ?').all(state.originalId!) as { kind: string }[];
+    expect(rows.map((r) => r.kind).sort()).toEqual(['correcting', 'reversal']);
+    const events = db.prepare("SELECT event_type FROM domain_events WHERE event_type = 'TransactionCorrected'").all();
+    expect(events).toHaveLength(1);
+    db.close();
+  },
+);

--- a/tests/features/steps/correct.steps.ts
+++ b/tests/features/steps/correct.steps.ts
@@ -365,7 +365,7 @@ Then('the subprocess JSON output matches the correct command\'s documented shape
   };
   expect(parsed.targetTransactionId).toBe(state.originalId);
   expect(parsed.producedTransactionIds).toHaveLength(2);
-  expect(parsed.changedFields).toEqual(['account']);
+  expect(parsed.changedFields).toEqual(['category']);
   expect(parsed.reason).toBe('miscategorized');
 });
 

--- a/tests/features/steps/correct.steps.ts
+++ b/tests/features/steps/correct.steps.ts
@@ -10,7 +10,6 @@ import { runMigrations } from '../../../src/infra/db/migrator.js';
 import { SqliteTransactionRepository } from '../../../src/infra/db/repositories/sqlite-transaction-repo.js';
 import { SqliteDomainEventRecorder } from '../../../src/infra/db/repositories/sqlite-domain-event-recorder.js';
 import { runCorrectCommand } from '../../../src/cli/commands/correct-command.js';
-import { CorrectionService } from '../../../src/core/ledger/correction-service.js';
 import { Transaction } from '../../../src/core/ledger/transaction.js';
 import { Money } from '../../../src/core/shared/money.js';
 import { Result } from '../../../src/core/shared/result.js';
@@ -170,11 +169,32 @@ Given('a persisted reversal-kind transaction', function (state: CorrectWorld) {
   state.transactionRepository = repo;
   state.domainEventRecorder = new SqliteDomainEventRecorder(db);
 
+  // Built directly via Transaction.create, not a CorrectionService.correct round-trip
+  // (Phase-2 P1 finding — adopted, docs/plans/story-4.2b.md suggestion-log #8): faster,
+  // and the round-trip path is already covered by 4.2a's own tests.
   const original = insertOriginal(db);
-  const ids = { reversalId: 'tx-reversal-fixture', correctingId: 'tx-correcting-fixture' };
-  const correctionResult = CorrectionService.correct(original, { description: 'seed correction' }, ids, 'seed reason');
-  if (correctionResult.isFailure) throw new Error(`fixture correction failed: ${correctionResult.error}`);
-  const { reversal, correcting } = correctionResult.value;
+  const reversal = Transaction.create({
+    id: 'tx-reversal-fixture',
+    occurredAt: original.occurredAt,
+    description: `Reversal of ${original.id}`,
+    kind: 'reversal',
+    correctsId: original.id,
+    entries: [
+      { account: 'Liabilities:CreditCard', side: 'debit', amount: makeEur(2000) },
+      { account: 'Expense:Transport', side: 'credit', amount: makeEur(2000) },
+    ],
+  }).value;
+  const correcting = Transaction.create({
+    id: 'tx-correcting-fixture',
+    occurredAt: original.occurredAt,
+    description: original.description,
+    kind: 'correcting',
+    correctsId: original.id,
+    entries: [
+      { account: 'Expense:Transport', side: 'debit', amount: makeEur(2000) },
+      { account: 'Liabilities:CreditCard', side: 'credit', amount: makeEur(2000) },
+    ],
+  }).value;
   const writeResult = repo.saveCorrection(reversal, correcting);
   if (writeResult.isFailure) throw new Error(`fixture saveCorrection failed: ${writeResult.error}`);
   state.originalId = reversal.id;

--- a/tests/features/steps/index.ts
+++ b/tests/features/steps/index.ts
@@ -7,3 +7,4 @@ import './safe-transfer.steps.js';
 import './status.steps.js';
 import './categorize.steps.js';
 import './audit-trail.steps.js';
+import './correct.steps.js';

--- a/tests/unit/cli/commands/correct-command-options.test.ts
+++ b/tests/unit/cli/commands/correct-command-options.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for parseCorrectOptions (Story 4.2b, FR14 — correct CLI options + zod boundary).
+ *
+ * fails if: --amount is parsed through a float intermediate (Number()/parseFloat) instead of
+ *   string->integer-cents (security-checklist.md bans float parsing for money), or the zod
+ *   boundary silently accepts an empty --category, a malformed --date, or an empty --reason.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseCorrectOptions } from '../../../../src/cli/commands/correct-command-options.js';
+import type { CorrectCommandOptions } from '../../../../src/cli/commands/correct-command-options.js';
+
+function baseOptions(overrides: Partial<CorrectCommandOptions> = {}): CorrectCommandOptions {
+  return {
+    transactionId: 'tx-original',
+    reason: 'a valid reason',
+    json: false,
+    ...overrides,
+  };
+}
+
+describe('parseCorrectOptions — amount: string-to-integer-cents, never a float intermediate', () => {
+  it('parses a two-decimal amount to integer cents', () => {
+    const result = parseCorrectOptions(baseOptions({ amount: '45.30' }));
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.amountCents).toBe(4530);
+  });
+
+  it('parses a whole-number amount (no decimal point) to integer cents', () => {
+    const result = parseCorrectOptions(baseOptions({ amount: '45' }));
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.amountCents).toBe(4500);
+  });
+
+  it('pads a single-digit fraction to two decimal places', () => {
+    const result = parseCorrectOptions(baseOptions({ amount: '45.3' }));
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.amountCents).toBe(4530);
+  });
+
+  it('leaves amountCents undefined when --amount is not supplied', () => {
+    const result = parseCorrectOptions(baseOptions());
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.amountCents).toBeUndefined();
+  });
+
+  it('rejects a comma-separated decimal (not this CLI\'s locale, period-separated)', () => {
+    const result = parseCorrectOptions(baseOptions({ amount: '45,30' }));
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('--amount');
+  });
+
+  it('rejects a non-numeric amount', () => {
+    const result = parseCorrectOptions(baseOptions({ amount: 'abc' }));
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('--amount');
+  });
+});
+
+describe('parseCorrectOptions — --category', () => {
+  it('passes a non-empty category through unchanged', () => {
+    const result = parseCorrectOptions(baseOptions({ category: 'Insurance' }));
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.category).toBe('Insurance');
+  });
+
+  it('rejects an explicit empty --category (no business meaning, unlike --description)', () => {
+    const result = parseCorrectOptions(baseOptions({ category: '' }));
+    expect(result.isFailure).toBe(true);
+  });
+});
+
+describe('parseCorrectOptions — --date', () => {
+  it('accepts a bare YYYY-MM-DD date', () => {
+    const result = parseCorrectOptions(baseOptions({ date: '2026-04-25' }));
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.date).toBe('2026-04-25');
+  });
+
+  it('rejects a full ISO 8601 timestamp (bare date only, per the CLI contract)', () => {
+    const result = parseCorrectOptions(baseOptions({ date: '2026-04-25T09:00:00+02:00' }));
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('rejects a slash-separated date', () => {
+    const result = parseCorrectOptions(baseOptions({ date: '2026/04/25' }));
+    expect(result.isFailure).toBe(true);
+  });
+});
+
+describe('parseCorrectOptions — --description (any string, including empty — closes #185)', () => {
+  it('passes an explicit empty description through as "" (not undefined)', () => {
+    const result = parseCorrectOptions(baseOptions({ description: '' }));
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.description).toBe('');
+  });
+
+  it('passes a non-empty description through unchanged', () => {
+    const result = parseCorrectOptions(baseOptions({ description: 'Transport (corrected)' }));
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.description).toBe('Transport (corrected)');
+  });
+});
+
+describe('parseCorrectOptions — --reason (belt-and-suspenders non-empty check)', () => {
+  it('rejects an empty reason', () => {
+    const result = parseCorrectOptions(baseOptions({ reason: '' }));
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('accepts a non-empty reason', () => {
+    const result = parseCorrectOptions(baseOptions({ reason: 'wrong amount on receipt' }));
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.reason).toBe('wrong amount on receipt');
+  });
+});
+
+describe('parseCorrectOptions — pass-through fields', () => {
+  it('carries transactionId and json through unchanged', () => {
+    const result = parseCorrectOptions(baseOptions({ transactionId: 'tx-abc', json: true }));
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.transactionId).toBe('tx-abc');
+    expect(result.value.json).toBe(true);
+  });
+});

--- a/tests/unit/cli/commands/correct-command-options.test.ts
+++ b/tests/unit/cli/commands/correct-command-options.test.ts
@@ -121,4 +121,9 @@ describe('parseCorrectOptions — pass-through fields', () => {
     expect(result.value.transactionId).toBe('tx-abc');
     expect(result.value.json).toBe(true);
   });
+
+  it('rejects an empty transactionId', () => {
+    const result = parseCorrectOptions(baseOptions({ transactionId: '' }));
+    expect(result.isFailure).toBe(true);
+  });
 });

--- a/tests/unit/cli/commands/correct-command.test.ts
+++ b/tests/unit/cli/commands/correct-command.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for runCorrectCommand (Story 4.2b, FR14 — correct CLI command).
+ *
+ * Gherkin coverage: docs/plans/story-4.2b.md scenario 1 (happy path, human output).
+ *
+ * fails if: the command doesn't call saveCorrection + record in that order, misreports
+ *   changed fields, or omits the reversal/correcting ids from stdout.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { Writable } from 'stream';
+import { PassThrough } from 'stream';
+import { runCorrectCommand } from '../../../../src/cli/commands/correct-command.js';
+import type { CorrectCommandDeps } from '../../../../src/cli/commands/correct-command.js';
+import type { CorrectCommandOptions } from '../../../../src/cli/commands/correct-command-options.js';
+import { Result } from '@core/shared/result.js';
+import { Transaction } from '@core/ledger/transaction.js';
+import { Money } from '@core/shared/money.js';
+import type { TransactionRepository } from '@core/ports/transaction-repository.js';
+import type { DomainEventRecorder } from '@core/ports/domain-event-recorder.js';
+
+function makeEur(cents: number): Money {
+  return Money.fromCents(cents, 'EUR').value;
+}
+
+function makeOriginal(): Transaction {
+  return Transaction.create({
+    id: 'tx-original',
+    occurredAt: '2026-04-21T14:30:00+02:00',
+    description: 'Transport',
+    entries: [
+      { account: 'Expense:Transport', side: 'debit', amount: makeEur(2000) },
+      { account: 'Liabilities:CreditCard', side: 'credit', amount: makeEur(2000) },
+    ],
+  }).value;
+}
+
+function makeCapture(): Writable & { captured: string } {
+  const buf: string[] = [];
+  const stream = new PassThrough() as unknown as Writable & { captured: string };
+  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
+  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
+  return stream;
+}
+
+function baseOptions(overrides: Partial<CorrectCommandOptions> = {}): CorrectCommandOptions {
+  return {
+    transactionId: 'tx-original',
+    reason: 'wrong amount on receipt',
+    json: false,
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<CorrectCommandDeps> = {}): {
+  deps: CorrectCommandDeps;
+  stdout: Writable & { captured: string };
+  stderr: Writable & { captured: string };
+  exitCodes: number[];
+  findByIdMock: ReturnType<typeof vi.fn>;
+  saveCorrectionMock: ReturnType<typeof vi.fn>;
+  recordMock: ReturnType<typeof vi.fn>;
+} {
+  const stdout = makeCapture();
+  const stderr = makeCapture();
+  const exitCodes: number[] = [];
+
+  const findByIdMock = vi.fn().mockReturnValue(Result.ok(makeOriginal()));
+  const saveCorrectionMock = vi.fn().mockReturnValue(Result.ok());
+  const recordMock = vi.fn().mockReturnValue(Result.ok());
+
+  const transactionRepository: Pick<TransactionRepository, 'findById' | 'saveCorrection'> = {
+    findById: findByIdMock,
+    saveCorrection: saveCorrectionMock,
+  };
+  const domainEventRecorder: DomainEventRecorder = { record: recordMock };
+
+  let callCount = 0;
+  const uuidGen = () => `uuid-${++callCount}`;
+
+  const deps: CorrectCommandDeps = {
+    transactionRepository,
+    domainEventRecorder,
+    uuidGen,
+    stdout: stdout as Writable,
+    stderr: stderr as Writable,
+    exitCode: (code) => exitCodes.push(code),
+    ...overrides,
+  };
+
+  return { deps, stdout, stderr, exitCodes, findByIdMock, saveCorrectionMock, recordMock };
+}
+
+describe('runCorrectCommand — happy path, human output (scenario 1)', () => {
+  it('loads the original, corrects, persists, records, and reports the ids + changed fields', async () => {
+    const { deps, stdout, exitCodes, findByIdMock, saveCorrectionMock, recordMock } = makeDeps();
+
+    await runCorrectCommand(baseOptions({ amount: '45.30' }), deps);
+
+    expect(findByIdMock).toHaveBeenCalledWith('tx-original');
+    expect(saveCorrectionMock).toHaveBeenCalledOnce();
+    const [reversalArg, correctingArg] = saveCorrectionMock.mock.calls[0] as [Transaction, Transaction];
+    expect(reversalArg.kind).toBe('reversal');
+    expect(correctingArg.kind).toBe('correcting');
+    expect(correctingArg.entries[0].amount.amount).toBe(4530);
+
+    expect(recordMock).toHaveBeenCalledOnce();
+    expect(recordMock).toHaveBeenCalledWith({
+      type: 'TransactionCorrected',
+      targetTransactionId: 'tx-original',
+      producedTransactionIds: [reversalArg.id, correctingArg.id],
+      changedFields: ['amount'],
+      reason: 'wrong amount on receipt',
+    });
+
+    expect(stdout.captured).toContain(reversalArg.id);
+    expect(stdout.captured).toContain(correctingArg.id);
+    expect(stdout.captured).toContain('amount');
+    expect(exitCodes).toEqual([0]);
+  });
+
+  it('saveCorrection is called before record (write-then-record ordering, B1)', async () => {
+    const callOrder: string[] = [];
+    const { deps } = makeDeps({
+      transactionRepository: {
+        findById: vi.fn().mockReturnValue(Result.ok(makeOriginal())),
+        saveCorrection: vi.fn().mockImplementation(() => {
+          callOrder.push('saveCorrection');
+          return Result.ok();
+        }),
+      },
+      domainEventRecorder: {
+        record: vi.fn().mockImplementation(() => {
+          callOrder.push('record');
+          return Result.ok();
+        }),
+      },
+    });
+
+    await runCorrectCommand(baseOptions({ amount: '45.30' }), deps);
+
+    expect(callOrder).toEqual(['saveCorrection', 'record']);
+  });
+});

--- a/tests/unit/cli/commands/correct-command.test.ts
+++ b/tests/unit/cli/commands/correct-command.test.ts
@@ -141,3 +141,32 @@ describe('runCorrectCommand — happy path, human output (scenario 1)', () => {
     expect(callOrder).toEqual(['saveCorrection', 'record']);
   });
 });
+
+describe('runCorrectCommand — --json output, multiple changed fields (scenario 2)', () => {
+  it('emits a single JSON document naming both changed fields, no human prose mixed in', async () => {
+    const { deps, stdout, exitCodes } = makeDeps();
+
+    await runCorrectCommand(
+      baseOptions({ amount: '45.30', category: 'Insurance', json: true }),
+      deps,
+    );
+
+    expect(exitCodes).toEqual([0]);
+    const lines = stdout.captured.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]) as {
+      targetTransactionId: string;
+      producedTransactionIds: string[];
+      changedFields: string[];
+      reason: string;
+    };
+    expect(parsed.targetTransactionId).toBe('tx-original');
+    expect(parsed.producedTransactionIds).toHaveLength(2);
+    expect(parsed.changedFields).toEqual(['amount', 'account']);
+    expect(parsed.reason).toBe('wrong amount on receipt');
+
+    // No human-readable prose leaks into stdout under --json.
+    expect(stdout.captured).not.toContain('Correction recorded');
+    expect(stdout.captured).not.toContain('Reversal:');
+  });
+});

--- a/tests/unit/cli/commands/correct-command.test.ts
+++ b/tests/unit/cli/commands/correct-command.test.ts
@@ -165,7 +165,7 @@ describe('runCorrectCommand — --json output, multiple changed fields (scenario
     };
     expect(parsed.targetTransactionId).toBe('tx-original');
     expect(parsed.producedTransactionIds).toHaveLength(2);
-    expect(parsed.changedFields).toEqual(['amount', 'account']);
+    expect(parsed.changedFields).toEqual(['amount', 'category']);
     expect(parsed.reason).toBe('wrong amount on receipt');
 
     // No human-readable prose leaks into stdout under --json.

--- a/tests/unit/cli/commands/correct-command.test.ts
+++ b/tests/unit/cli/commands/correct-command.test.ts
@@ -278,3 +278,52 @@ describe('runCorrectCommand — reason-leakage guard (Risks & deferred items)', 
     expect(stderr.captured).toContain('Warning');
   });
 });
+
+describe('runCorrectCommand — --date splicing (Risks: DST-safety, string manipulation only)', () => {
+  it('splices the new date onto the original\'s time-of-day + UTC offset', async () => {
+    const { deps, saveCorrectionMock } = makeDeps();
+
+    await runCorrectCommand(baseOptions({ date: '2026-04-25' }), deps);
+
+    const [, correctingArg] = saveCorrectionMock.mock.calls[0] as [Transaction, Transaction];
+    expect(correctingArg.occurredAt).toBe('2026-04-25T14:30:00+02:00');
+  });
+
+  it('does not touch the reversal\'s date (reversal keeps the original date)', async () => {
+    const { deps, saveCorrectionMock } = makeDeps();
+
+    await runCorrectCommand(baseOptions({ date: '2026-04-25' }), deps);
+
+    const [reversalArg] = saveCorrectionMock.mock.calls[0] as [Transaction, Transaction];
+    expect(reversalArg.occurredAt).toBe('2026-04-21T14:30:00+02:00');
+  });
+
+  it('preserves a non-UTC offset verbatim across a DST-transition boundary (no Date round-trip)', async () => {
+    // The original sits just before a fictional US-style DST transition (2026-03-08).
+    // A pure Date-object round-trip would risk silently shifting the offset when the
+    // new date crosses the transition; string-splicing keeps -05:00 verbatim, proving
+    // no Date object is ever constructed from the offset-bearing timestamp.
+    const dstOriginal = Transaction.create({
+      id: 'tx-dst-original',
+      occurredAt: '2026-03-07T23:30:00-05:00',
+      description: 'Late-night purchase',
+      entries: [
+        { account: 'Expense:Transport', side: 'debit', amount: makeEur(1000) },
+        { account: 'Liabilities:CreditCard', side: 'credit', amount: makeEur(1000) },
+      ],
+    }).value;
+
+    const saveCorrectionMock = vi.fn().mockReturnValue(Result.ok());
+    const { deps } = makeDeps({
+      transactionRepository: {
+        findById: vi.fn().mockReturnValue(Result.ok(dstOriginal)),
+        saveCorrection: saveCorrectionMock,
+      },
+    });
+
+    await runCorrectCommand(baseOptions({ transactionId: 'tx-dst-original', date: '2026-03-09' }), deps);
+
+    const [, correctingArg] = saveCorrectionMock.mock.calls[0] as [Transaction, Transaction];
+    expect(correctingArg.occurredAt).toBe('2026-03-09T23:30:00-05:00');
+  });
+});

--- a/tests/unit/cli/commands/correct-command.test.ts
+++ b/tests/unit/cli/commands/correct-command.test.ts
@@ -170,3 +170,111 @@ describe('runCorrectCommand — --json output, multiple changed fields (scenario
     expect(stdout.captured).not.toContain('Reversal:');
   });
 });
+
+function makeReversal(): Transaction {
+  return Transaction.create({
+    id: 'tx-reversal-target',
+    occurredAt: '2026-04-21T14:30:00+02:00',
+    description: 'Reversal of tx-original',
+    kind: 'reversal',
+    correctsId: 'tx-original',
+    entries: [
+      { account: 'Expense:Transport', side: 'credit', amount: makeEur(2000) },
+      { account: 'Liabilities:CreditCard', side: 'debit', amount: makeEur(2000) },
+    ],
+  }).value;
+}
+
+describe('runCorrectCommand — error paths → exit codes (scenarios 4, 5, 6, 6b)', () => {
+  it('(scenario 4) transaction not found: exits 2, stderr names the id, no write/record', async () => {
+    const { deps, stderr, exitCodes, saveCorrectionMock, recordMock } = makeDeps({
+      transactionRepository: {
+        findById: vi.fn().mockReturnValue(Result.ok(null)),
+        saveCorrection: vi.fn(),
+      },
+    });
+
+    await runCorrectCommand(baseOptions({ transactionId: 'tx-bogus', amount: '10.00' }), deps);
+
+    expect(exitCodes).toEqual([2]);
+    expect(stderr.captured).toContain('tx-bogus');
+    expect(saveCorrectionMock).not.toHaveBeenCalled();
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it('(unexpected findById read failure) exits 1, stderr redacted, no write/record', async () => {
+    const { deps, stderr, exitCodes, saveCorrectionMock, recordMock } = makeDeps({
+      transactionRepository: {
+        findById: vi.fn().mockReturnValue(Result.fail('SqliteError: database disk image is malformed')),
+        saveCorrection: vi.fn(),
+      },
+    });
+
+    await runCorrectCommand(baseOptions({ amount: '10.00' }), deps);
+
+    expect(exitCodes).toEqual([1]);
+    expect(stderr.captured).toContain('tx-original');
+    expect(saveCorrectionMock).not.toHaveBeenCalled();
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it('(scenario 5) rejects correcting a reversal: exits 2, stderr cites "reversal", no write/record', async () => {
+    const { deps, stderr, exitCodes, saveCorrectionMock, recordMock } = makeDeps({
+      transactionRepository: {
+        findById: vi.fn().mockReturnValue(Result.ok(makeReversal())),
+        saveCorrection: vi.fn(),
+      },
+    });
+
+    await runCorrectCommand(baseOptions({ transactionId: 'tx-reversal-target', amount: '10.00' }), deps);
+
+    expect(exitCodes).toEqual([2]);
+    expect(stderr.captured.toLowerCase()).toContain('reversal');
+    expect(saveCorrectionMock).not.toHaveBeenCalled();
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it('(scenario 6) no fields to correct: exits 2, stderr cites "at least one field", no write', async () => {
+    const { deps, stderr, exitCodes, saveCorrectionMock } = makeDeps();
+
+    await runCorrectCommand(baseOptions(), deps);
+
+    expect(exitCodes).toEqual([2]);
+    expect(stderr.captured.toLowerCase()).toContain('at least one field');
+    expect(saveCorrectionMock).not.toHaveBeenCalled();
+  });
+
+  it('(scenario 6b) saveCorrection write failure: exits 4, sanitizeSqlError-redacted stderr, no record', async () => {
+    const collidingHash = 'a'.repeat(64);
+    const { deps, stderr, exitCodes, recordMock } = makeDeps({
+      transactionRepository: {
+        findById: vi.fn().mockReturnValue(Result.ok(makeOriginal())),
+        saveCorrection: vi.fn().mockReturnValue(
+          Result.fail(`SqliteError: UNIQUE constraint failed: transactions.idempotency_hash = ${collidingHash}`),
+        ),
+      },
+    });
+
+    await runCorrectCommand(baseOptions({ amount: '45.30' }), deps);
+
+    expect(exitCodes).toEqual([4]);
+    expect(stderr.captured).not.toContain(collidingHash);
+    expect(stderr.captured).toContain('<redacted>');
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('runCorrectCommand — reason-leakage guard (Risks & deferred items)', () => {
+  it('a record()-failure warning never echoes the literal reason text', async () => {
+    const secretReason = 'IBAN FR7612345987650123456789014 refund correction';
+    const { deps, stderr, exitCodes } = makeDeps({
+      domainEventRecorder: { record: vi.fn().mockReturnValue(Result.fail('SqliteError: disk I/O error')) },
+    });
+
+    await runCorrectCommand(baseOptions({ amount: '45.30', reason: secretReason }), deps);
+
+    expect(exitCodes).toEqual([0]);
+    expect(stderr.captured).not.toContain(secretReason);
+    expect(stderr.captured).toContain('Warning');
+  });
+});

--- a/tests/unit/cli/commands/correct-command.test.ts
+++ b/tests/unit/cli/commands/correct-command.test.ts
@@ -142,6 +142,9 @@ describe('runCorrectCommand — happy path, human output (scenario 1)', () => {
   });
 });
 
+// fails if: the JSON payload is missing a field, only reports one of two
+// simultaneously-changed fields (R8 mock-diversity), or human-readable prose
+// leaks into stdout alongside the JSON document.
 describe('runCorrectCommand — --json output, multiple changed fields (scenario 2)', () => {
   it('emits a single JSON document naming both changed fields, no human prose mixed in', async () => {
     const { deps, stdout, exitCodes } = makeDeps();
@@ -185,6 +188,10 @@ function makeReversal(): Transaction {
   }).value;
 }
 
+// fails if: any error path writes rows or records an event despite failing
+// (not-found, reversal-guard, no-fields-guard, write-failure), an exit code
+// doesn't match the plan's table (2 validation, 1 unexpected read error, 4
+// write failure), or a write-failure message leaks an unredacted DB error.
 describe('runCorrectCommand — error paths → exit codes (scenarios 4, 5, 6, 6b)', () => {
   it('(scenario 4) transaction not found: exits 2, stderr names the id, no write/record', async () => {
     const { deps, stderr, exitCodes, saveCorrectionMock, recordMock } = makeDeps({
@@ -264,6 +271,9 @@ describe('runCorrectCommand — error paths → exit codes (scenarios 4, 5, 6, 6
   });
 });
 
+// fails if: a record()-failure warning string echoes the literal reason text
+// (reason is PII-adjacent per the glossary; only the audit-trail payload
+// itself, never a CLI stderr message, should carry it verbatim).
 describe('runCorrectCommand — reason-leakage guard (Risks & deferred items)', () => {
   it('a record()-failure warning never echoes the literal reason text', async () => {
     const secretReason = 'IBAN FR7612345987650123456789014 refund correction';
@@ -279,6 +289,10 @@ describe('runCorrectCommand — reason-leakage guard (Risks & deferred items)', 
   });
 });
 
+// fails if: the correcting entry's date doesn't take the new date, the
+// reversal's date moves off the original, or a Date-object round-trip
+// silently shifts an offset across a DST transition instead of the raw
+// ISO string components being spliced.
 describe('runCorrectCommand — --date splicing (Risks: DST-safety, string manipulation only)', () => {
   it('splices the new date onto the original\'s time-of-day + UTC offset', async () => {
     const { deps, saveCorrectionMock } = makeDeps();

--- a/tests/unit/core/ledger/correction-service.test.ts
+++ b/tests/unit/core/ledger/correction-service.test.ts
@@ -254,6 +254,110 @@ describe('CorrectionService.correct — chaining (scenario 6)', () => {
   });
 });
 
+describe('CorrectionService.correct — reject correcting a reversal (story-4.2b, new invariant 9)', () => {
+  it('rejects when original.kind is "reversal", citing that a reversal cannot be corrected', () => {
+    const reversal = Transaction.create({
+      id: 'tx-reversal-target',
+      occurredAt: '2026-04-21T14:30:00+02:00',
+      description: 'Reversal of tx-original',
+      kind: 'reversal',
+      correctsId: 'tx-original',
+      entries: [
+        { account: 'Expense:Transport', side: 'credit', amount: makeEur(2000) },
+        { account: 'Liabilities:CreditCard', side: 'debit', amount: makeEur(2000) },
+      ],
+    }).value;
+
+    const result = CorrectionService.correct(reversal, { description: 'x' }, ids, 'trying to correct a reversal');
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error.toLowerCase()).toContain('reversal');
+  });
+
+  it('does not reject a "correcting"-kind original (only "reversal" is barred)', () => {
+    const correcting = Transaction.create({
+      id: 'tx-correcting-target',
+      occurredAt: '2026-04-21T14:30:00+02:00',
+      description: 'Correcting entry',
+      kind: 'correcting',
+      correctsId: 'tx-original',
+      entries: [
+        { account: 'Expense:Transport', side: 'debit', amount: makeEur(2000) },
+        { account: 'Liabilities:CreditCard', side: 'credit', amount: makeEur(2000) },
+      ],
+    }).value;
+
+    const result = CorrectionService.correct(correcting, { description: 'y' }, ids, 'correcting a correcting entry');
+
+    expect(result.isSuccess).toBe(true);
+  });
+});
+
+describe('CorrectionService.correct — require at least one changed field (story-4.2b, CLI-usability guard)', () => {
+  it('rejects an empty CorrectionChanges, citing at least one field must change', () => {
+    const original = makeOriginal();
+
+    const result = CorrectionService.correct(original, {}, ids, 'nothing to change');
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error.toLowerCase()).toContain('at least one field');
+  });
+});
+
+describe('CorrectionService.correct — guard order (Phase-2 P1 finding — deterministic ordering)', () => {
+  it('reports the reversal-kind guard before the entry-count guard on a compound-invalid input', () => {
+    const invalidReversal = Transaction.create({
+      id: 'tx-bad-reversal',
+      occurredAt: '2026-04-21T14:30:00+02:00',
+      description: 'Split reversal (contrived fixture for guard-order testing)',
+      kind: 'reversal',
+      correctsId: 'tx-original',
+      entries: [
+        { account: 'Expense:Food', side: 'credit', amount: makeEur(1000) },
+        { account: 'Expense:Household', side: 'credit', amount: makeEur(1000) },
+        { account: 'Liabilities:CreditCard', side: 'debit', amount: makeEur(2000) },
+      ],
+    }).value;
+
+    const result = CorrectionService.correct(invalidReversal, {}, ids, 'compound-invalid input');
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error.toLowerCase()).toContain('reversal');
+    expect(result.error.toLowerCase()).not.toContain('split');
+  });
+});
+
+describe('CorrectionService.correct — #185 fix: absent-vs-empty-string field detection', () => {
+  it('an explicit empty-string description is treated as a change, not "no change" (closes #185)', () => {
+    const original = makeOriginal();
+
+    const result = CorrectionService.correct(original, { description: '' }, ids, 'clearing description');
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.correcting.description).toBe('');
+    expect(result.value.event.changedFields).toEqual(['description']);
+  });
+
+  it('an absent description (undefined) is NOT treated as a change', () => {
+    const original = makeOriginal();
+
+    const result = CorrectionService.correct(original, { amount: makeEur(2500) }, ids, 'only amount changed');
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.event.changedFields).toEqual(['amount']);
+  });
+
+  it('an explicit empty-string account is treated as a change (Core-level fix; CLI zod bars this before it reaches Core)', () => {
+    const original = makeOriginal();
+
+    const result = CorrectionService.correct(original, { account: '' }, ids, 'clearing account at Core level');
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.correcting.entries[0]).toMatchObject({ account: '', side: 'debit' });
+    expect(result.value.event.changedFields).toEqual(['account']);
+  });
+});
+
 describe('CorrectionService.correct — core invariants as properties (Story 4.0 model note inv 1, 5)', () => {
   function netByAccount(entries: readonly Entry[]): Map<string, number> {
     const net = new Map<string, number>();


### PR DESCRIPTION
## 1. Story

[docs/epics.md — Story 4.2: Correction (Reverse-and-Correct)](https://github.com/xavierbriand/accounting/blob/main/docs/epics.md#story-42-correction-reverse-and-correct) (FR14). Second half of the 4.2 split — first half (the domain: `CorrectionService`, `saveCorrection`, migration 006) shipped in story-4.2a, [PR #184](https://github.com/xavierbriand/accounting/pull/184).

Full plan: [docs/plans/story-4.2b.md](docs/plans/story-4.2b.md).

## 2. Intent

Ship the user-facing `correct` command: explicit flags (`--amount`, `--category`, `--date`, `--description`, `--reason`), loads the original transaction, calls the already-shipped `CorrectionService`, persists via `saveCorrection`, and records `TransactionCorrected` at the app boundary (mirroring `ingest`'s B1 pattern). Also closes [#185](https://github.com/xavierbriand/accounting/issues/185) (absent-vs-empty-string field detection, unreachable until this CLI existed) and adds two new domain guards: reject correcting a `reversal`-kind transaction, and require at least one changed field.

## 3. Alternatives considered

- Interactive prompt mode for `correct` — rejected in 4.2a's planning; explicit flags fit a targeted single-field fix better than a discovery-heavy flow like `ingest`/`categorize`.
- A `--dry-run`/preview flag — not requested by FR14 or the model note; deferred until real usage shows demand.
- Pre-write filesystem snapshot (mirroring `ingest`'s `SnapshotService`) — set aside: `saveCorrection` is a single atomic 2-row insert with no partial-batch corruption mode to guard against.
- Shipping `--json` output — considered deferring to story-4.4 (the dedicated global `--json` audit), but shipped now instead for day-one convention consistency with `ingest`/`status`.

## 4. Selected solution & rationale

A new `runCorrectCommand(options, deps)` in `src/cli/commands/correct-command.ts`, registered in `program.ts` as `correct <transactionId>`. Amount is parsed string→integer-cents directly (never through a float intermediate, per `security-checklist.md`'s ban on `Number.parseFloat` for money — mirrors the existing CSV parser's approach). `--date` accepts a bare `YYYY-MM-DD` and splices it onto the original's time-of-day + UTC offset. `--category` maps to the full ledger account string via the existing `expenseAccount()` helper; the user-facing `changedFields` output relabels Core's `"account"` back to `"category"` for display (the recorded `TransactionCorrected` event itself keeps `"account"`, matching Core/glossary vocabulary). Full rationale in the plan's Selected solution section.

## 5. Gherkin scenarios

```gherkin
Feature: Correct a past transaction via the correct CLI command

  Scenario: Correct an amount (happy path, human output)
    Given a persisted two-entry original transaction
    When I run `correct <id> --amount 45.30 --reason "wrong amount on receipt"`
    Then the process exits 0, a reversal + correcting entry are written, and one TransactionCorrected event is recorded

  Scenario: --json output, multiple changed fields
    Given the same setup
    When I run `correct <id> --amount 45.30 --category Insurance --reason "..." --json`
    Then stdout is a single JSON document with changedFields: ["amount", "category"]

  Scenario: Reason required
    When I omit --reason
    Then commander rejects before Core is reached; no rows written, no event recorded

  Scenario: Transaction not found
    When I run `correct <bogus-id> ...`
    Then the process exits 2; no rows written, no event recorded

  Scenario: Reject correcting a reversal
    Given a transaction with kind: 'reversal'
    When I try to correct it
    Then the process exits 2 citing that a reversal cannot be corrected

  Scenario: No fields to correct
    Given a valid original
    When I run `correct <id> --reason "..."` with no amount/category/date/description
    Then the process exits 2 citing that at least one field must be corrected

  Scenario: saveCorrection write failure
    Given saveCorrection returns Result.fail
    When correct runs
    Then the process exits 4 with a sanitizeSqlError-redacted message; no event recorded

  Scenario: Clearing a description to empty text (closes #185)
    Given an original with a non-empty description
    When I run `correct <id> --description "" --reason "typo cleanup"`
    Then the correcting entry's description is empty and changedFields includes "description"

  Scenario: Full CLI journey through the real binary (composition-root, subprocess, R4)
    Given a fresh migrated DB with a transaction committed via a real ingest subprocess run
    When I run `accounting correct <id> --category Insurance --reason "miscategorized" --json` as a real subprocess
    Then the process exits 0 and the ledger + audit trail reflect the correction
```

Full Given/When/Then detail with `fails if` clauses: [docs/plans/story-4.2b.md § Gherkin acceptance scenarios](docs/plans/story-4.2b.md#gherkin-acceptance-scenarios).

## 6. Plan for Sonnet

See [docs/plans/story-4.2b.md](docs/plans/story-4.2b.md) in full — Production-code surface (R2), Slice plan (8–9 slices), Risks & deferred items, and Verification plan sections are self-contained. Key files: `src/core/ledger/correction-service.ts` (2 new guards + #185 fix, no signature change), `src/cli/commands/correct-command.ts` + `correct-command-options.ts` + `correct-formatter-json.ts` (new), `src/cli/program.ts` (new command registration). No DB migration. Target 8–9 commits/slices (R13).

## 7. Suggestion log

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P2 | `--amount` via `Number()`/`parseFloat` is exactly what security-checklist.md forbids for money | adopted | String→integer-cents parsing, mirroring `node-csv-parser.ts`'s `parseCentsFromString` |
| P1 | Guard-insertion order for the 2 new `CorrectionService` guards vs. the 3 existing ones was unspecified | adopted | Explicit 6-step guard order specified in the plan's Domain-model section |
| P2 | `--json` mock-diversity gap — only a single-changed-field fixture planned (R8) | adopted | Scenario rewritten to correct 2 fields at once, asserts both in `changedFields` |
| P2 | No scenario covered `saveCorrection` returning `Result.fail` (DB write failure) | adopted | New scenario 6b: exit 4, `sanitizeSqlError`-redacted stderr, no event recorded |
| P3 | Draft's `runCorrectCommand(...): Promise<number>` deviated from `ingest`/`status`'s `Promise<void>` + `exitCode` callback convention | adopted | Signature changed to match exactly |
| P3 | `runCorrectCommand`'s bundled responsibilities risked exceeding ~50 LOC without named helpers | adopted | Plan names the decomposition: `loadOriginal`/`buildChanges`/`persistAndRecord`/`renderOutcome` |
| P1 | FR17's "before any write (ingest/settle)" narrowed to exclude `correct` — a unilateral interpretive call | acknowledged | Already user-confirmed pre-plan (2026-07-06, no-snapshot decision) |
| P1 | Scenario 5's `kind: 'reversal'` fixture construction path left unspecified | acknowledged | Phase-3 note: build directly via `Transaction.create`, not a round-trip |
| P3 | 5 sequential `CorrectionService` guards could fold into one `validate()` helper | acknowledged | Soft suggestion, Sonnet's discretion, not required for DoD |
| overlap | sibling-overlap: #180/#183/#185/#186(story-maint-21) verified against the live tracker, no collision | acknowledged | No blocking overlap |
| P4-P1 | `findById` `Result.fail` (DB read error) → exit 1 not explicitly in the plan's exit-code table | acknowledged | Consistent with `status-command`/`ingest-command` precedent; tested |
| P4-P1 | Scenario 3's `fails if` comment over-claimed that scenario 8 exercises commander's `--reason` omission, and cited a nonexistent plan "Deviations" section | adopted (fixed) | Comment corrected — `531ab4a` |
| P4-P1 | Scenario 5's acceptance-fixture diverged from the suggestion-log row above (which, despite being tagged **acknowledged** rather than adopted, still carried a concrete implementation instruction — used a `CorrectionService.correct` round-trip instead, not direct `Transaction.create`) | adopted (fixed) | Rebuilt via direct `Transaction.create` — `531ab4a` |
| P4-P3 | 4 `correct-command.test.ts` describe blocks lacked a `fails if` comment (convention: `ingest-command.test.ts`) | adopted (fixed) | Comments added — `531ab4a` |
| P4-P3 | Landed 8 slices vs. the plan's 9-item enumeration (2 closely-related pairs bundled) | acknowledged | Still within R13's 6–10 target; no violation |
| P4(ddd) | `--category` surfaces as `"account"` in `changedFields` output — defensible either way per the model note's "account/category" pairing | adopted (fixed) | User decision (2026-07-07): relabel to `"category"` in CLI output only — `89dceb7` |
| P4(ddd) | story-4.0 note's `correct()` signature line still showed 3 params, missing the `reason` 4th param shipped at 4.2a | adopted (fixed) | Reconciled into the model note, this PR |

No un-tagged items. Two soft findings (negative-`--amount` CLI-boundary test coverage; a couple of generically-phrased `fails if` clauses) noted but not pursued — see the retrospective.

## 8. Sonnet's learnings

**What was built:** all 9 Gherkin scenarios pass (8 in-process against a real SQLite temp DB, 1 composition-root subprocess). Core: `CorrectionService.correct` gained the 2 new guards in the specified order, plus the #185 fix (`changedFieldsOf`/`buildCorrecting` truthy checks → `!== undefined`). CLI/Infra: `runCorrectCommand` (load → build changes → correct → persist → record → render), `parseCorrectOptions` (zod boundary + string→integer-cents amount parser), `--json` formatter, and `correct <transactionId>` registered in `program.ts` with full DI wiring.

**Red → green sequence:** `CorrectionService` guards + #185 fix → options parsing/zod boundary → happy path → `--json`/multi-field (green-on-landing) → error paths + reason-leakage (green-on-landing) → acceptance journeys (in-process + subprocess) → `--date` DST-safety + boundary coverage (green-on-landing) → refactor (drop unused re-export). 8 commits total.

**Deviations from plan:** (1) Scenario 3 ("Reason required") tested at the zod-boundary layer (`--reason ""`, present-but-empty) rather than commander's `requiredOption` omission — the latter is unreachable by a direct in-process call to `runCorrectCommand` and would need a second subprocess test beyond the plan's single R4 allocation; flagged as a test-mechanism honesty note (fixed at Phase 4 — see §7). (2) `findById` returning `Result.fail` mapped to exit 1, not explicitly assigned in the plan's table — classified as a "config/DB-setup error" (bucket 1), matching sibling-command precedent.

**Gherkin coverage checklist:** all 9 scenarios (1–7 incl. 6b, plus 8) mapped to a passing test — verified by `code-reviewer`'s R5 walk, no gaps.

**Unknowns encountered:** the exit code for an unexpected `findById` failure (resolved per Deviations); the in-process test mechanism for a commander-`requiredOption`-only code path (resolved per Deviations).

**Result:** `npm run lint && npm run build && npm test` green — **781 tests passing**, zero lint errors, clean build.

**Files touched:** `src/core/ledger/correction-service.ts`; `src/cli/commands/correct-command.ts`, `correct-command-options.ts`, `correct-formatter-json.ts` (new); `src/cli/program.ts`; `tests/unit/core/ledger/correction-service.test.ts`; `tests/unit/cli/commands/correct-command.test.ts`, `correct-command-options.test.ts` (new); `tests/features/correct.feature`, `tests/features/steps/correct.steps.ts` (new) + `tests/features/steps/index.ts`.

## 9. Retrospective

- **Keep:** Phase 2 caught a real security-checklist violation (float-parsing for money) before any code existed; deriving from the 4.0/4.2a precedent kept this CLI-wiring story small (8 slices, no new Core types); the explicit guard-order + exit-code table gave Sonnet an unambiguous spec.
- **Change:** Sonnet's own "Deviations" self-report missed a divergence from a Phase-2 suggestion that carried a concrete implementation instruction despite being tagged *acknowledged*, not adopted (the reversal-fixture construction) — `code-reviewer` caught it instead, one round-trip later; a `fails if` comment over-claimed another scenario's coverage; Check B (drift-scan) false-positived red CI on the plan-only commit for the 2nd story running.
- **Try:** add a suggestion-log cross-check step to the Phase-3 return-report checklist; teach Check B to recognize `*(new)*`-marked plan paths (filed [#193](https://github.com/xavierbriand/accounting/issues/193)).

Full retrospective: [docs/retrospectives/story-4.2b.md](docs/retrospectives/story-4.2b.md)

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-4.2b.md` (landed as a trailing PR, [#194](https://github.com/xavierbriand/accounting/pull/194), since this PR was merged before Phase 5 completed)
- [x] All suggestion-log items resolved (no blank `Resolution` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)
