### PR TITLE
story-maint-23: extract capturing-stream helper to tests/_helpers/streams.ts (closes #43)

### DIFF
--- a/docs/plans/story-maint-23.md
+++ b/docs/plans/story-maint-23.md
@@ -73,7 +73,7 @@ None. Test-only change:
 
 No new scenario — this is a zero-behaviour-change mechanical extraction (R6/R7 honesty: the guard is the existing suite, not a new test).
 
-`fails if`: the relocated `makeCapturingStream` diverges from the original 7 declarations (wrong `Object.defineProperty` getter, wrong chunk-join order, wrong `Buffer`/`string` handling) — any of the 7 consuming suites' assertions on stdout/stderr/`captured` content fail immediately, across unit, integration, perf, and BDD-step tiers (in-process for unit/BDD-step, subprocess-adjacent for perf/integration per their existing mechanism — unchanged by this story).
+`fails if`: the relocated `makeCapturingStream` diverges from the original 7 declarations (wrong `Object.defineProperty` getter, wrong chunk-join order, wrong `Buffer`/`string` handling) — any of the 7 consuming suites' assertions on stdout/stderr/`captured` content fail immediately, across unit, integration, perf, and BDD-step tiers. **Correction (Phase 4 finding, fix-now):** integration (`ingest-commit.test.ts`) and perf (`ingest-throughput.test.ts`) run `runIngestCommand` in-process against a real temp-file SQLite DB — real-infra "integration" tier per `docs/engineering-standards.md`'s testing-tiers table, not subprocess execution; only one step in `correct.steps.ts` uses `spawnCli` (subprocess). All mechanisms are unchanged by this extraction either way.
 
 ## Slice plan
 
@@ -110,9 +110,20 @@ No deferred follow-ups — this story fully closes issue #43.
 | 2 | Issue #117 (story-maint-17 Phase-4 deferred) touches a sibling `tests/features/steps/ingest.steps.ts` (YAML fixture injection), not this story's `correct.steps.ts` (stream-capture dedup). | ACKNOWLEDGE | No action — different file, different concern, no open PR. |
 | 3 | No other open issue references the 7 touched files or the `makeCapture`/`makeStdout`/`PassThrough`/`.captured` pattern. | ACKNOWLEDGE | No action — confirms proceed-to-implementation. |
 
+**Phase 4 (`code-reviewer` + `sibling-overlap`, Reduced lane) — run 2026-07-08 against PR #201, commit `4c7da51`.** `sibling-overlap` re-check: still exactly one open PR (#201 itself), no new issue overlaps since Phase 2 — nothing new. `code-reviewer`: 1 P1 finding, 0 P2, 5 P3 findings (2 soft); no code defect found (extraction verified byte-identical to all 7 originals; import paths, unused-import cleanup, and out-of-scope-file untouched-ness all verified independently).
+
+| # | Finding | Tag | Resolution |
+|---|---------|-----|------------|
+| 4 | [R5] The plan's "no new Gherkin scenario" declaration doesn't literally match any documented carve-out wording — R5's audit assumes either new scenarios exist to map, or a docs/process story with zero test files; this story is a third shape (test-code-only mechanical extraction, existing suite as guard) the rule text doesn't explicitly enumerate. | ACKNOWLEDGE | No action on the story — the chosen approach (rely on the 7 consuming suites) is sound and explicitly reasoned. Rule-coverage gap, not an execution defect; see also findings 5–6 below (same theme). First occurrence of this specific shape — watch for reproduction before codifying (repo's own "codify on reproduction" convention, precedent: [story-maint-05](../retrospectives/story-maint-05.md)→[story-maint-06](../retrospectives/story-maint-06.md), [issue #200](https://github.com/xavierbriand/accounting/issues/200)). |
+| 5 | [R26] CLAUDE.md § 6's lane table doesn't literally enumerate "tests/-only change" under any of the three trigger definitions; this plan's Reduced-lane choice is by analogy to `story-maint-21`/`22` (which were dependency-bump stories, not test-code stories). | ACKNOWLEDGE | No action — same rule-coverage-gap theme as finding 4 and [issue #200](https://github.com/xavierbriand/accounting/issues/200) (which covers the R15/dependency-bump angle specifically). This is a distinct angle (test-infra-only stories); first occurrence, not yet at the two-data-point codify threshold. |
+| 6 | [R16] The 3-commit slice-envelope collapse borrows R16's shape by analogy; R16's own trigger list (§ 8 row) names "process refresh, agent spec, doc refresh, parallel-safety," not test-code refactors. | ACKNOWLEDGE | No action — same theme as findings 4–5; first occurrence for this angle. |
+| 7 | PR #201 §7/§8 read stale ("pending") despite Phase 3 (commit `4c7da51`) and this Phase 4 review already landing. | FIX-NOW | PR body updated in the same pass as this commit: §7 appended with this Phase 4 table, §8 filled with Sonnet's verbatim implementation report. |
+| 8 | (soft) `fails if` wording mischaracterized integration/perf tests as "subprocess-adjacent" when both actually run in-process against real SQLite/FS. | FIX-NOW | Corrected above in this document's Gherkin acceptance scenarios section. |
+| 9 | (soft) The extracted helper is imported under 3 different local names (`makeCapturingStream` canonical, `as makeCapture` ×5, `as makeStdout` ×1) — a discoverability tradeoff for a reader grepping the canonical name. | ACKNOWLEDGE | No action — explicitly reasoned and accepted in this plan's Selected solution / Alternative-considered section; diff-churn-minimization was the deliberate goal. |
+
 ## DoR checklist
 
-- [ ] Phase 0 (Model): `No model impact — test-infra maintenance` (R24).
+- [x] Phase 0 (Model): `No model impact — test-infra maintenance` (R24).
 - [x] Phase 1 (Plan): complete in this document.
 - [x] Phase 2 (Critical review — `sibling-overlap` only, Reduced lane): findings triaged above — no overlap detected.
-- [ ] Draft PR with template sections 1–6 filled.
+- [x] Draft PR with template sections 1–6 filled.

--- a/docs/plans/story-maint-23.md
+++ b/docs/plans/story-maint-23.md
@@ -1,0 +1,118 @@
+# Story maint-23 — Extract capturing-stream helper to tests/_helpers/streams.ts
+
+## Context
+
+Issue [#43](https://github.com/xavierbriand/accounting/issues/43) was filed at story-maint-01 Phase-4 review (PR #41): a `PassThrough`-wrapped stream with a `captured: string` getter (`makeCapture`/`makeStdout`) was duplicated across 4 test files, past the repo's ≥3-caller extraction threshold. Deferred at the time to stay within that story's slice budget.
+
+Re-verified 2026-07-08: the issue is still open, never implemented, and the duplication has **grown to 7 files** (byte-identical logic, only the function name/indentation differs):
+
+- `tests/unit/cli/commands/ingest-command.test.ts` (`makeStdout`, 11 call sites)
+- `tests/unit/cli/commands/ingest-command-flags.test.ts` (`makeCapture`, 2 call sites)
+- `tests/integration/cli/ingest-commit.test.ts` (`makeCapture`, 3 call sites)
+- `tests/perf/ingest-throughput.test.ts` (`makeCapture`, 3 call sites)
+- `tests/unit/cli/commands/categorize-command.test.ts` (`makeCapture`, 9 call sites)
+- `tests/unit/cli/commands/correct-command.test.ts` (`makeCapture`, 3 call sites)
+- `tests/features/steps/correct.steps.ts` (`makeCapture`, 3 call sites)
+
+Two more files (`tests/features/steps/commit.steps.ts`, `tests/features/steps/ingest.steps.ts`) use `PassThrough` too, but as a fire-and-forget `.resume()` sink with no `.captured` getter — a different pattern, out of scope.
+
+`tests/_helpers/` already exists with sibling helpers `spawn-cli.ts` and `inline-config.ts` (same "test I/O helper, no dedicated unit test, exercised via consumers" shape) — this story adds a third file following that exact convention.
+
+No FR/NFR coverage — test-infra maintenance only.
+
+**Maintenance sub-loop (§ 6.7) run 2026-07-08 pre-planning:**
+- [x] **Sibling work check.** `gh pr list --state open --draft --base main` → `[]`. `gh issue list --state open --limit 50` → 38 open issues reviewed; none overlaps this story's scope.
+- [x] **Story-id uniqueness.** `git ls-tree -r origin/main --name-only -- docs/plans/ docs/retrospectives/ docs/status.d/ | grep -i "story-maint-23"` → no hits. Highest existing is `story-maint-22`; `story-maint-23` is free. No open PR branch uses it either.
+- [x] **Working tree clean.** `git status` clean; branch `claude/issue-43-relevance-955060` up to date with `origin/main` (`c94db32`).
+- [x] **Open issues.** Reviewed above; #43 (this story) is the only issue in scope.
+- [x] **Open PRs.** None open.
+- [x] **`npm audit --audit-level=high`** — 0 vulnerabilities.
+- [x] **Proceed-to-planning.**
+
+## Story
+
+> As a developer maintaining the CLI test suite, I want the duplicated capturing-stream helper collapsed into one shared `tests/_helpers/streams.ts` module, so that the 7 identical `makeCapture`/`makeStdout` declarations become a single source of truth and new test files reuse it instead of growing an 8th copy.
+
+## Lane (R26)
+
+**Reduced** — test-infra-only change (no `src/core`, `src/infra`, `src/cli`, DB schema, or migration touched). No Core domain concept changes → Phase 0 skipped. Phase 2 review: `sibling-overlap` only (`plan-reviewer` dropped — same reasoning `story-maint-21`/`story-maint-22` used for infra-only changes, applied here by analogy to test-infra). Phase 4: `code-reviewer` + `sibling-overlap`. Envelope: below R13's 6–10 band by design (see Slice plan).
+
+## Domain model
+
+No model impact — test-infra maintenance, not product Core domain (R24 default for maint/process stories).
+
+## Selected solution
+
+Add `tests/_helpers/streams.ts` exporting:
+
+```ts
+export function makeCapturingStream(): Writable & { captured: string } {
+  const buf: string[] = [];
+  const stream = new PassThrough() as unknown as Writable & { captured: string };
+  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
+  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
+  return stream;
+}
+```
+
+(Verbatim body from the 7 existing declarations — confirmed byte-identical via diff before drafting this plan.)
+
+In each of the 7 files: delete the local function declaration, add `import { makeCapturingStream } from '<relative path>/_helpers/streams.js';`. **Keep each file's existing local call-site name** via aliased import (`import { makeCapturingStream as makeCapture } from ...` or `as makeStdout`) — call sites (`makeCapture()`/`makeStdout()`, 34 occurrences total) are left untouched. This keeps each diff to a 6-line deletion + 1-line import addition, rather than also renaming ~34 call sites for a cosmetic-only reason the issue never asked for.
+
+**Alternative considered and rejected:** renaming all call sites to the canonical `makeCapturingStream()` name — adds diff churn across 7 files for no functional benefit; the issue's goal is deduplicating *logic*, not unifying *naming*.
+
+**No new dedicated unit test.** Follows the existing convention set by `spawn-cli.ts`/`inline-config.ts` (both test I/O helpers with no colocated unit test) rather than the `findDuplicateIndices`-style "add one direct unit test" precedent from story-maint-11 (that was a new pure-logic helper; this is a verbatim relocation of already-covered code). The 7 consuming suites already assert on `.captured` content — if the relocated helper behaves differently from the original, those suites fail immediately (this **is** the regression guard, per R6/R7).
+
+## Production-code surface (R2)
+
+None. Test-only change:
+- New: `tests/_helpers/streams.ts`
+- Modified (delete local fn + add import, call sites untouched): the 7 files listed in Context.
+
+## Gherkin acceptance scenarios
+
+No new scenario — this is a zero-behaviour-change mechanical extraction (R6/R7 honesty: the guard is the existing suite, not a new test).
+
+`fails if`: the relocated `makeCapturingStream` diverges from the original 7 declarations (wrong `Object.defineProperty` getter, wrong chunk-join order, wrong `Buffer`/`string` handling) — any of the 7 consuming suites' assertions on stdout/stderr/`captured` content fail immediately, across unit, integration, perf, and BDD-step tiers (in-process for unit/BDD-step, subprocess-adjacent for perf/integration per their existing mechanism — unchanged by this story).
+
+## Slice plan
+
+Small mechanical extraction — below R13's 6–10 band by design, reasoning borrowed from R16's zero-behaviour-change collapse shape (that rule's listed triggers are docs/agent-spec, not test code, so this is an analogous application for Phase 2/4 review to confirm, not a literal R16 invocation):
+
+Preparatory (before Phase 3; not counted per R16 convention):
+- **P0:** `chore(docs): story-maint-23 plan + P1/P2/P3 review`
+
+Change-body commits:
+1. **C1** `refactor(tests): extract makeCapturingStream to tests/_helpers/streams.ts, replace 7 duplicated declarations (story-maint-23)` — add the helper, delete + import in all 7 files, run `npm run lint && npm run build && npm test` green.
+2. **C2** `refactor: — empty slice — TDD rhythm note: pure mechanical extraction needs no follow-up (story-maint-23)` (R11 empty-refactor carve-out; also the Phase-4 output if code-reviewer finds nothing to fix-now).
+3. **C3** `chore(retro): story-maint-23 retrospective (story-maint-23)`
+
+## Risks & deferred items
+
+| Risk | Mitigation |
+|---|---|
+| `commit.steps.ts`/`ingest.steps.ts`'s different `PassThrough` sink pattern gets swept in by mistake | Explicitly out of scope; left untouched; verified by final diff review. |
+| Relative import path errors (7 files at 3 different nesting depths: `tests/unit/cli/commands/` = 3 deep, `tests/integration/cli/` and `tests/features/steps/` = 2 deep, `tests/perf/` = 1 deep) | Verified each path against existing sibling imports (`_helpers/spawn-cli.js` et al.) in the same files before drafting this plan; `npm run build` (tsc) catches any wrong path immediately. |
+
+No deferred follow-ups — this story fully closes issue #43.
+
+## Verification plan
+
+`npm run lint && npm run build && npm test` green, covering all 4 tiers (unit, integration, perf, acceptance/BDD) — the 7 touched files' suites are the direct regression guard. Manual diff review confirms the 2 out-of-scope `.steps.ts` files are untouched. Closes issue #43 on merge.
+
+## Suggestion log
+
+**Phase 2 (`sibling-overlap`, Reduced lane — `plan-reviewer` dropped) — run 2026-07-08.** Zero open PRs (`gh pr list --state open` → `[]`); 38 open issues scanned by keyword (`makeCapture`, `makeStdout`, `PassThrough`, `.captured`) and by directory (`tests/_helpers/`, `tests/features/steps/`). No collision with this story's 7 touched files.
+
+| # | Finding | Tag | Resolution |
+|---|---------|-----|------------|
+| 1 | Issue #186 (e2e journey tests) reuses sibling helper `tests/_helpers/spawn-cli.ts` for a new `tests/e2e/` tier — same directory, different file/tier, no open PR. | ACKNOWLEDGE | No action — no file/branch overlap with this story's `streams.ts` addition. |
+| 2 | Issue #117 (story-maint-17 Phase-4 deferred) touches a sibling `tests/features/steps/ingest.steps.ts` (YAML fixture injection), not this story's `correct.steps.ts` (stream-capture dedup). | ACKNOWLEDGE | No action — different file, different concern, no open PR. |
+| 3 | No other open issue references the 7 touched files or the `makeCapture`/`makeStdout`/`PassThrough`/`.captured` pattern. | ACKNOWLEDGE | No action — confirms proceed-to-implementation. |
+
+## DoR checklist
+
+- [ ] Phase 0 (Model): `No model impact — test-infra maintenance` (R24).
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review — `sibling-overlap` only, Reduced lane): findings triaged above — no overlap detected.
+- [ ] Draft PR with template sections 1–6 filled.

--- a/docs/retrospectives/story-maint-23.md
+++ b/docs/retrospectives/story-maint-23.md
@@ -1,0 +1,49 @@
+# Story maint-23 retrospective
+
+**PR:** [#201](https://github.com/xavierbriand/accounting/pull/201)  **Closed:** pending merge  **Closes issue:** [#43](https://github.com/xavierbriand/accounting/issues/43)
+
+Smallest-scope maintenance story in recent memory: a pure test-infra mechanical extraction with zero production code touched and zero new tests. Collapses a `PassThrough`-wrapped capturing-stream helper (`makeCapture`/`makeStdout`, a `.captured` getter) duplicated across 7 test files (grown from 4 at the issue's filing during story-maint-01) into one shared `tests/_helpers/streams.ts` module. Diff: 8 files, 17 insertions, 62 deletions — net negative LOC.
+
+## Keep
+
+- **Re-verifying issue relevance before planning caught real drift.** The user asked to "check if #43 is still relevant" before committing to a story. It was not only still relevant but *more* relevant than at filing — duplication had grown from 4 files to 7. Confirming the actual current state (via `md5` diff of all 7 declarations) rather than trusting the issue body's 2026-04-24 snapshot avoided under-scoping the plan.
+- **The aliased-import approach (keep each file's local call-site name, don't rename ~34 call sites) held up under Phase 4 review.** It was flagged only as a soft, already-reasoned tradeoff (discoverability of the canonical name vs diff-churn minimization), not a defect — confirms the "don't add churn beyond what the task requires" judgment call was sound.
+- **Following the existing `spawn-cli.ts`/`inline-config.ts` convention (no dedicated unit test for the extracted helper) was validated, not just assumed.** Phase 4 review explicitly checked whether a new unit test was warranted (comparing against the `findDuplicateIndices` precedent from story-maint-11, which *did* get one) and agreed the "verbatim relocation of already-covered code, exercised by 7 consuming suites" framing was the right call, not the "new pure-logic helper" framing.
+- **The Phase-4-findings-as-a-separate-commit pattern (established by story-maint-21/22) transferred cleanly to a non-dependency-bump story.** `chore(docs): story-<id> — Phase 4 findings (...)` after the empty refactor slice, before the retro commit, kept the plan's Suggestion log and the PR body in sync without conflating "no code fix needed" (R11 empty refactor) with "the review still produced findings worth recording."
+
+## Change
+
+- **This story surfaced the same rule-coverage-gap theme as [issue #200](https://github.com/xavierbriand/accounting/issues/200) from a third angle, and it's tempting to over-generalize.** Issue #200 covers "the § 6 lane table doesn't list R15 as a selectable Envelope value" for *dependency-bump* stories. This story's Phase 4 review found three *related but distinct* gaps for *test-infra-only* stories: the lane table's Reduced trigger doesn't literally say "tests/-only," R5's Gherkin-audit carve-out doesn't literally cover "zero-scenario mechanical extraction with existing tests as guard," and R16's trigger list doesn't literally say "test-code refactor." All three got ACKNOWLEDGE (first occurrence, not yet at the repo's own "codify on reproduction" bar) rather than being folded into #200 or spawning three new issues. That was the right call for *this* story, but it means the underlying pattern — "the § 6 lane table's literal wording keeps failing to anticipate new story shapes, and every story just reasons by analogy and moves on" — is now visible from two independent angles (dependency-bumps via #200, test-infra via this retro) without a tracking mechanism connecting them. Left as an observation, not an issue, per this repo's own convention of waiting for a second data point on *this specific angle* before codifying — but worth deliberately checking whether a *fourth* story (any lane, any angle) reproduces "the literal trigger table doesn't cover my story's shape" before treating each new angle as independently below-threshold forever.
+- **The `fails if` mechanism-classification error (integration/perf tests are in-process against real SQLite/FS, not "subprocess-adjacent") was a planning-time guess that went unverified until Phase 4.** The plan's original wording hedged with "-adjacent" rather than checking the actual test file for `spawnCli`/`execFileSync` calls — a two-minute grep that would have caught it before Phase 4 review had to. Small, but it's the second time in this session's visible history (after story-maint-22's changelog-completeness gap) that a hedge-word in a plan substituted for an actual verification step.
+
+## Try
+
+- **When a plan describes a test file's execution mechanism (in-process vs subprocess vs "-adjacent"), grep the file for the actual subprocess-invoking call (`spawnCli`, `execFileSync`, `spawnSync`) before writing the classification, rather than describing it from memory of the test's tier name.** Cheap, and this is now two stories in a row (maint-22's changelog claim, this story's mechanism claim) where a to-be-verified planning claim shipped unverified until Phase 4 caught it.
+- **Watch for a fourth "lane table doesn't literally cover this story's shape" data point (any angle, not just R15/dependency-bumps or R16/test-infra) before deciding whether the fix belongs in the table's trigger wording itself (broaden each row) versus a per-angle footnote (append a new row per story-shape indefinitely, which doesn't scale).**
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| A. Grep-verify test-mechanism classification (in-process vs subprocess) before writing a plan's `fails if` note, rather than describing from memory. | Next story whose plan classifies a test's execution mechanism. | open, passive |
+| B. Watch whether a fourth lane-table-coverage-gap angle appears (beyond #200's dependency-bump angle and this story's test-infra angle) before deciding on a structural fix to CLAUDE.md § 6's trigger wording. | Retro of the next story that hits this gap, any angle. | open, passive |
+
+## Loop metrics (this run)
+
+- **Plan phase:** 1 maintenance sub-loop check + Phase 2 `sibling-overlap` review (3 findings, all acknowledge, 0 deferred).
+- **Implementation:** 1 `sonnet-implementer` invocation, single commit, no red/green cycle (pure refactor, no new tests) — 8 files touched, ~5.5 minutes agent time.
+- **Phase 4 review:** `code-reviewer` (1 P1 + 5 P3 findings, 2 soft; 2 fix-now, 4 acknowledge) + `sibling-overlap` (0 new findings, reconfirmed Phase 2) — run in parallel, ~6 minutes agent time.
+- **Issues closed by this story:** [#43](https://github.com/xavierbriand/accounting/issues/43) (via merge).
+- **Issues opened:** 0.
+- **Total commits on branch:** 5 (plan+P2 review / implementation / empty refactor / Phase-4-findings / this retro) — below R13's 6–10 band by design (see plan § Slice plan), consistent with the story's genuinely small scope.
+- **Test count:** 781 product tests, unchanged (same suite, relocated helper — 0 net new/removed tests).
+- **Diff stats:** 8 files, +17/-62 LOC (net −45; the extraction itself is negative-LOC since 7 duplicated ~6-line functions collapse to 1 shared 6-line function + 7 one-line imports).
+- **Bugs squashed:** 0 (test-infra dedup, not a bug fix). **Process observations surfaced:** 3 rule-coverage-gap acknowledgments (§ Change) + 1 planning-verification gap (§ Change).
+- **`npm audit --audit-level=high`:** 0 findings, unchanged.
+- **New runtime deps:** 0. **New dev deps:** 0.
+- **Time-to-DoD:** maintenance sub-loop + plan drafting ~15 min; Phase 2 review ~45s agent time; implementation ~5.5 min agent time + local build/lint/test re-verification; Phase 4 review ~6 min (2 concurrent agents); this retro ~10 min.
+
+## Carryovers resolved
+
+- **[#43](https://github.com/xavierbriand/accounting/issues/43) (capturing-stream helper duplication)** → **CLOSED by this story** (via PR #201 merge). Filed at story-maint-01, deferred for ~2.5 months of repo history; duplication grew from 4 to 7 files in that window before being addressed.
+- **[Issue #200](https://github.com/xavierbriand/accounting/issues/200) (R15/§6-lane-table reconciliation)** → not touched by this story; a related-but-distinct angle of the same underlying "lane table literal wording lags story-shape variety" pattern surfaced here (§ Change) and was left as a separate observation rather than folded in.

--- a/docs/status.d/2026-07-08-story-maint-23.md
+++ b/docs/status.d/2026-07-08-story-maint-23.md
@@ -1,0 +1,8 @@
+---
+date: 2026-07-08
+story: maint-23
+pr: 201
+epic: maintenance
+---
+
+story-maint-23 (pending merge): extracted the duplicated `makeCapture`/`makeStdout` capturing-stream test helper (a `PassThrough`-wrapped `Writable` exposing a `.captured` getter) into a shared `tests/_helpers/streams.ts` module (`makeCapturingStream()`), closing [issue #43](https://github.com/xavierbriand/accounting/issues/43). Duplication had grown from 4 files at the issue's filing (story-maint-01, ~2.5 months earlier) to 7 by the time this story ran. Pure test-infra mechanical extraction — zero production `src/` code touched, zero new tests (follows the existing `spawn-cli.ts`/`inline-config.ts` no-dedicated-test convention), each file keeps its local call-site name via an aliased import to minimize diff churn. Net diff is negative LOC (+17/−62 across 8 files). Reduced lane; Phase 4 review found no code defect, only rule-coverage-gap observations (the § 6 lane table's literal wording doesn't yet anticipate "tests/-only" story shapes — related to but distinct from [issue #200](https://github.com/xavierbriand/accounting/issues/200)'s dependency-bump angle) and one planning-wording correction, both acknowledged/fixed in the plan.

--- a/tests/_helpers/streams.ts
+++ b/tests/_helpers/streams.ts
@@ -1,0 +1,10 @@
+import { PassThrough } from 'stream';
+import type { Writable } from 'stream';
+
+export function makeCapturingStream(): Writable & { captured: string } {
+  const buf: string[] = [];
+  const stream = new PassThrough() as unknown as Writable & { captured: string };
+  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
+  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
+  return stream;
+}

--- a/tests/features/steps/correct.steps.ts
+++ b/tests/features/steps/correct.steps.ts
@@ -3,7 +3,6 @@ import { Given, When, Then } from 'quickpickle';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { PassThrough } from 'stream';
 import type { Writable } from 'stream';
 import Database from 'better-sqlite3';
 import { runMigrations } from '../../../src/infra/db/migrator.js';
@@ -16,6 +15,7 @@ import { Result } from '../../../src/core/shared/result.js';
 import type { TransactionRepository } from '../../../src/core/ports/transaction-repository.js';
 import type { DomainEventRecorder } from '../../../src/core/ports/domain-event-recorder.js';
 import { spawnCli } from '../../_helpers/spawn-cli.js';
+import { makeCapturingStream as makeCapture } from '../../_helpers/streams.js';
 
 interface CorrectWorld {
   tmpDir?: string;
@@ -47,14 +47,6 @@ afterEach(() => {
 
 function makeEur(cents: number): Money {
   return Money.fromCents(cents, 'EUR').value;
-}
-
-function makeCapture(): Writable & { captured: string } {
-  const buf: string[] = [];
-  const stream = new PassThrough() as unknown as Writable & { captured: string };
-  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
-  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
-  return stream;
 }
 
 function makeTmpDb(): { tmpDir: string; dbPath: string; db: Database.Database } {

--- a/tests/integration/cli/ingest-commit.test.ts
+++ b/tests/integration/cli/ingest-commit.test.ts
@@ -16,8 +16,8 @@ import Database from 'better-sqlite3';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { PassThrough } from 'stream';
 import type { Writable } from 'stream';
+import { makeCapturingStream as makeCapture } from '../../_helpers/streams.js';
 import { runIngestCommand } from '../../../src/cli/commands/ingest-command.js';
 import type { IngestCommandDeps } from '../../../src/cli/commands/ingest-command.js';
 import { runMigrations } from '../../../src/infra/db/migrator.js';
@@ -61,14 +61,6 @@ afterEach(() => {
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
   }
 });
-
-function makeCapture(): Writable & { captured: string } {
-  const buf: string[] = [];
-  const stream = new PassThrough() as unknown as Writable & { captured: string };
-  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
-  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
-  return stream;
-}
 
 function makeRealDeps(
   db: Database.Database,

--- a/tests/perf/ingest-throughput.test.ts
+++ b/tests/perf/ingest-throughput.test.ts
@@ -25,7 +25,7 @@ import os from 'os';
 import path from 'path';
 import fc from 'fast-check';
 import type { Writable } from 'stream';
-import { PassThrough } from 'stream';
+import { makeCapturingStream as makeCapture } from '../_helpers/streams.js';
 import { runIngestCommand } from '../../src/cli/commands/ingest-command.js';
 import type { IngestCommandDeps } from '../../src/cli/commands/ingest-command.js';
 import { runMigrations } from '../../src/infra/db/migrator.js';
@@ -99,14 +99,6 @@ function generateBpceCsv(n: number): string {
   }
 
   return rows.join('\n') + '\n';
-}
-
-function makeCapture(): Writable & { captured: string } {
-  const buf: string[] = [];
-  const stream = new PassThrough() as unknown as Writable & { captured: string };
-  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
-  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
-  return stream;
 }
 
 describe('ingest-throughput (perf)', () => {

--- a/tests/unit/cli/commands/categorize-command.test.ts
+++ b/tests/unit/cli/commands/categorize-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Writable } from 'stream';
-import { PassThrough } from 'stream';
+import { makeCapturingStream as makeCapture } from '../../../_helpers/streams.js';
 import { runCategorizeCommand } from '../../../../src/cli/commands/categorize-command.js';
 import type { CategorizeCommandOptions, CategorizeCommandDeps } from '../../../../src/cli/commands/categorize-command.js';
 import type { InteractivePrompter } from '../../../../src/cli/utils/interactive.js';
@@ -29,14 +29,6 @@ const baseConfig: AppConfig = {
   recurring: [],
   autoTagRules: [],
 };
-
-function makeCapture(): Writable & { captured: string } {
-  const buf: string[] = [];
-  const stream = new PassThrough() as unknown as Writable & { captured: string };
-  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
-  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
-  return stream;
-}
 
 const CSV_HEADER = 'Date de comptabilisation;Libelle simplifie;Libelle operation;Reference;Informations complementaires;Type operation;Categorie;Sous categorie;Debit;Credit;Date operation;Date de valeur;Pointage operation';
 

--- a/tests/unit/cli/commands/correct-command.test.ts
+++ b/tests/unit/cli/commands/correct-command.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import type { Writable } from 'stream';
-import { PassThrough } from 'stream';
+import { makeCapturingStream as makeCapture } from '../../../_helpers/streams.js';
 import { runCorrectCommand } from '../../../../src/cli/commands/correct-command.js';
 import type { CorrectCommandDeps } from '../../../../src/cli/commands/correct-command.js';
 import type { CorrectCommandOptions } from '../../../../src/cli/commands/correct-command-options.js';
@@ -32,14 +32,6 @@ function makeOriginal(): Transaction {
       { account: 'Liabilities:CreditCard', side: 'credit', amount: makeEur(2000) },
     ],
   }).value;
-}
-
-function makeCapture(): Writable & { captured: string } {
-  const buf: string[] = [];
-  const stream = new PassThrough() as unknown as Writable & { captured: string };
-  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
-  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
-  return stream;
 }
 
 function baseOptions(overrides: Partial<CorrectCommandOptions> = {}): CorrectCommandOptions {

--- a/tests/unit/cli/commands/ingest-command-flags.test.ts
+++ b/tests/unit/cli/commands/ingest-command-flags.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Writable } from 'stream';
-import { PassThrough } from 'stream';
+import { makeCapturingStream as makeCapture } from '../../../_helpers/streams.js';
 import { runIngestCommand } from '../../../../src/cli/commands/ingest-command.js';
 import type { IngestCommandDeps } from '../../../../src/cli/commands/ingest-command.js';
 import { Result } from '@core/shared/result.js';
@@ -83,13 +83,6 @@ function makeNoOpDomainEventRecorder(): DomainEventRecorder {
 const noOpConfirmRememberRule = vi.fn().mockResolvedValue({ action: 'skip' as const });
 
 function makeStreams(): { stdout: Writable & { captured: string }; stderr: Writable & { captured: string } } {
-  function makeCapture(): Writable & { captured: string } {
-    const buf: string[] = [];
-    const stream = new PassThrough() as unknown as Writable & { captured: string };
-    stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
-    Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
-    return stream;
-  }
   return { stdout: makeCapture(), stderr: makeCapture() };
 }
 

--- a/tests/unit/cli/commands/ingest-command.test.ts
+++ b/tests/unit/cli/commands/ingest-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Writable } from 'stream';
-import { PassThrough } from 'stream';
+import { makeCapturingStream as makeStdout } from '../../../_helpers/streams.js';
 import { runIngestCommand } from '../../../../src/cli/commands/ingest-command.js';
 import type { IngestCommandDeps, IngestCommandOptions } from '../../../../src/cli/commands/ingest-command.js';
 import type { InteractivePrompter } from '../../../../src/cli/utils/interactive.js';
@@ -58,14 +58,6 @@ function makeLowOutcome(description: string, category: string): BuildOutcome {
   return { ...makeHighOutcome(description, category), confidence: 'low' };
 }
 
-
-function makeStdout(): Writable & { captured: string } {
-  const buf: string[] = [];
-  const stream = new PassThrough() as unknown as Writable & { captured: string };
-  stream.on('data', (chunk: Buffer | string) => buf.push(chunk.toString()));
-  Object.defineProperty(stream, 'captured', { get: () => buf.join('') });
-  return stream;
-}
 
 function makeStderr(): Writable & { captured: string } {
   return makeStdout();


### PR DESCRIPTION
## 1. Story

[Issue #43](https://github.com/xavierbriand/accounting/issues/43) — a `PassThrough`-wrapped capturing-stream helper (`makeCapture`/`makeStdout`, exposing a `.captured` getter) was flagged as duplicated across 4 test files at story-maint-01's Phase-4 review, past the repo's ≥3-caller extraction threshold, and deferred to a follow-up. Re-verified 2026-07-08 during the maintenance sub-loop: still open, never implemented, and the duplication has grown to 7 files.

## 2. Intent

Collapse the 7 byte-identical `makeCapture`/`makeStdout` declarations into one shared `tests/_helpers/streams.ts` module (`makeCapturingStream()`), so future test files reuse it instead of growing an 8th copy. Test-infra-only; no production `src/` code touched.

## 3. Alternatives considered

- Renaming all ~34 call sites to a single canonical `makeCapturingStream()` name — rejected: adds diff churn across 7 files for a cosmetic-only reason the issue never asked for. Local names are kept via aliased imports instead.

## 4. Selected solution & rationale

Add `tests/_helpers/streams.ts` exporting `makeCapturingStream(): Writable & { captured: string }` — the verbatim body shared by all 7 existing declarations (confirmed byte-identical via diff before planning). Each of the 7 files drops its local function and imports the shared one under its existing local name (`as makeCapture` / `as makeStdout`), keeping each diff to a 6-line deletion + 1-line import. Follows the same "test I/O helper, no dedicated unit test, exercised via consumers" convention already set by sibling helpers `tests/_helpers/spawn-cli.ts` and `tests/_helpers/inline-config.ts`. Full rationale: [docs/plans/story-maint-23.md § Selected solution](../blob/main/docs/plans/story-maint-23.md).

## 5. Gherkin scenarios

No new scenarios — this is a zero-behaviour-change mechanical extraction (R6/R7 honesty). The regression guard is the existing suite: any of the 7 consuming files' assertions on `.captured`/stdout/stderr content will fail immediately if the relocated helper diverges from the original 7 declarations. Full `fails if` reasoning (corrected at Phase 4 — integration/perf tests run in-process against real SQLite/FS, not subprocess): [docs/plans/story-maint-23.md § Gherkin acceptance scenarios](../blob/main/docs/plans/story-maint-23.md).

## 6. Plan for Sonnet

Files to touch: new `tests/_helpers/streams.ts`; edit (delete local fn + add aliased import, call sites untouched) the 7 files listed in the plan's Context section. No test-first step — no new behavior to characterize; this is a verbatim relocation of already-covered code. DoD: `npm run lint && npm run build && npm test` green across all 4 tiers (unit, integration, perf, acceptance/BDD); the 2 out-of-scope `.steps.ts` files (`commit.steps.ts`, `ingest.steps.ts` — different `PassThrough` sink pattern) left untouched. Full plan: [docs/plans/story-maint-23.md](../blob/main/docs/plans/story-maint-23.md).

## 7. Suggestion log

**Phase 2** (`sibling-overlap`, Reduced lane — `plan-reviewer` dropped) run 2026-07-08. 3 entries, all acknowledge, 0 deferred, 0 rejected — zero open PRs, no issue overlaps this story's 7 touched files or the `makeCapture`/`makeStdout`/`PassThrough`/`.captured` pattern.

**Phase 4** (`code-reviewer` + `sibling-overlap`, Reduced lane) run 2026-07-08 against commit `4c7da51`. 6 entries: 4 acknowledge (R5/R26/R16 rule-coverage-gap findings — the lane table and R5/R16 carve-out wording don't literally enumerate "tests/-only mechanical extraction" as a story shape; related in theme to [issue #200](https://github.com/xavierbriand/accounting/issues/200) but a distinct angle, first occurrence, not yet at the codify-on-reproduction threshold; plus one soft naming-tradeoff finding already explicitly reasoned in the plan), 2 fix-now (corrected a `fails if` mischaracterization of integration/perf test mechanism; this PR's own §7/§8 staleness — fixed same-day). 0 deferred, 0 rejected. `sibling-overlap` re-check found nothing new since Phase 2. Full tables: [docs/plans/story-maint-23.md § Suggestion log](../blob/main/docs/plans/story-maint-23.md).

## 8. Sonnet's learnings

## What was built

A single mechanical refactor commit that collapses the byte-identical capturing-stream helper (`makeCapture`/`makeStdout`, a `PassThrough`-wrapped `Writable` with a `.captured` getter) from 7 test files into one shared `tests/_helpers/streams.ts` module, following the existing `spawn-cli.ts`/`inline-config.ts` convention (no colocated unit test). Each file keeps its local call-site name via an aliased import (`makeCapturingStream as makeCapture` / `as makeStdout`), so all 34 call sites are untouched. Zero behavior change — this is a pure test-infra dedup closing issue #43.

## Red → green sequence

N/A — pure refactor, no new tests. Per the plan, this story does not follow the Red→Green→Refactor rhythm; the 7 consuming suites (unit/integration/perf/BDD tiers) are the regression guard, and they all passed unmodified against the relocated helper.

## Deviations from plan

- `ingest-command-flags.test.ts`: the plan described the local `makeCapture` as nested inside a "describe block" that "was never load-bearing." It was actually nested inside a helper function (`makeStreams()`), not a describe block. Hoisted the import to top-level as directed (same net effect — the plan's described mechanism was slightly off, but the instructed outcome was unambiguous and correctly executed).
- Ran `npm install` in this worktree before the final `npm test` pass — the worktree's own `node_modules/` was present but effectively empty (only vitest cache dirs, no `.bin/`), which failed 2 pre-existing subprocess-path tests in `tests/integration/cli/symlink-dbpath-refuse.test.ts` unrelated to any of the 7 touched files (confirmed identical failure on the unmodified base commit via `git stash`). `npm install` (no `--force`, no lockfile drift) resolved it. Environment-setup action, not a code change.

## Gherkin coverage checklist

N/A — no new Gherkin scenarios per plan (zero-behaviour-change mechanical extraction; the plan's own "Gherkin acceptance scenarios" section states this explicitly).

## Unknowns encountered

The worktree's local `node_modules` was essentially uninitialized (no `.bin/`) at task start, only discovered while diagnosing the 2 pre-existing `symlink-dbpath-refuse.test.ts` failures. Resolved via `npm install`, no lockfile/package.json drift.

## Proposed follow-ups

None — issue #43 is fully closed by this story per the plan's "Risks & deferred items" (no deferred follow-ups).

## Files touched

- `tests/_helpers/streams.ts` — new shared helper, `makeCapturingStream()`.
- `tests/unit/cli/commands/ingest-command.test.ts` — removed local `makeStdout`, added aliased import.
- `tests/unit/cli/commands/ingest-command-flags.test.ts` — removed nested `makeCapture`, added aliased top-level import.
- `tests/integration/cli/ingest-commit.test.ts` — removed local `makeCapture`, added aliased import.
- `tests/perf/ingest-throughput.test.ts` — removed local `makeCapture`, added aliased import.
- `tests/unit/cli/commands/categorize-command.test.ts` — removed local `makeCapture`, added aliased import.
- `tests/unit/cli/commands/correct-command.test.ts` — removed local `makeCapture`, added aliased import.
- `tests/features/steps/correct.steps.ts` — removed local `makeCapture`, added aliased import.

Commit: `4c7da51` — `refactor(tests): extract makeCapturingStream to tests/_helpers/streams.ts, replace 7 duplicated declarations (story-maint-23)`. `npm run lint && npm run build && npm test` green (71 test files, 781 tests).

## 9. Retrospective

- **Keep:** re-verifying issue relevance before planning caught real drift (duplication had grown 4→7 files); the aliased-import diff-minimization tradeoff held up under Phase 4 review; the no-dedicated-unit-test convention was validated against the `findDuplicateIndices` counter-precedent, not just assumed.
- **Change:** Phase 4 surfaced 3 rule-coverage-gap findings (R5/R26/R16 wording doesn't literally cover "tests/-only" stories) — related to but distinct from issue #200's dependency-bump angle; a `fails if` mechanism-classification error (planning-time hedge, unverified until Phase 4) is the second such gap this session, after story-maint-22's changelog-completeness gap.
- **Try:** grep-verify a test's actual execution mechanism (in-process vs subprocess) before writing a plan's `fails if` classification, rather than describing from memory.

Full retrospective: [docs/retrospectives/story-maint-23.md](../blob/main/docs/retrospectives/story-maint-23.md)

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-maint-23.md`
- [x] All suggestion-log items resolved (no blank `Resolution` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval