### PR TITLE
story-maint-29: Mechanize the two convention-only claims — core coverage gate + layer-boundary lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: npm run build
       
     - name: Run Tests
-      run: npm test
+      run: npm run test:coverage
 
     - name: Run Harness Tests
       run: npm run test:harness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Current position: see [docs/status.md](docs/status.md). Refreshed by the retro o
 
 Full decisions in [docs/architecture.md](docs/architecture.md). Quick reference:
 
-- Three layers, strict dependency rule. `src/core/` depends on nothing (no Node APIs, no `better-sqlite3`, no `commander`, no `process.exit`); `src/infra/` talks to the outside world via ports in `src/core/ports/`; `src/cli/` wires them together.
+- Three layers, strict dependency rule. `src/core/` depends on nothing (no Node APIs, no `better-sqlite3`, no `commander`, no `process.exit`); `src/infra/` talks to the outside world via ports in `src/core/ports/`; `src/cli/` wires them together. Mechanically enforced by `no-restricted-imports` (`eslint.config.js` / `eslint-rules/boundary/`) — story-maint-29.
 - **Constructor DI only.** No `new SomeRepo()` inside Core.
 - **`Result<T, E>` in Core** — domain methods return `Result` values, never throw. CLI is the only place that inspects `result.isFailure`.
 - **Append-only ledger.** No `UPDATE`/`DELETE` on ledger rows — corrections are new balancing entries.
@@ -62,7 +62,7 @@ Full checklist in [docs/security-checklist.md](docs/security-checklist.md); prod
 | Property | colocated with unit | `fast-check` for financial invariants |
 | Integration | `tests/integration/` | Real SQLite/FS |
 
-- **100% branch coverage** on `src/core/`. Infra/CLI lower. Coverage targets apply to `src/`; `harness/` is exempt — the Dev Harness is its own bounded context (§ 2). Harness code is exercised by focused unit tests + one integration test per tool.
+- **100% branch coverage** on `src/core/`. Infra/CLI lower. Coverage targets apply to `src/`; `harness/` is exempt — the Dev Harness is its own bounded context (§ 2). Harness code is exercised by focused unit tests + one integration test per tool. The `src/core/` figure is CI-gated via `@vitest/coverage-v8` (`npm run test:coverage`, `vitest.config.ts` `coverage.thresholds`) — story-maint-29.
 - **TDD rhythm (outside-in):** failing acceptance → failing unit → minimal green → acceptance green → refactor. See § 6.4 for commits.
 - **Batch ingestion — two stages.** *Parse:* malformed rows skipped, reported individually; valid siblings proceed. *Commit:* valid rows in one SQL transaction — all-or-nothing. Authoritative policy in [docs/prd.md](docs/prd.md) and [docs/quality-assurance.md](docs/quality-assurance.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,6 +143,8 @@ accounting/
 - **Infra** depends on **Core** (via Ports).
 - **Core** depends on **nothing** (pure TypeScript + Dinero).
 
+Mechanically enforced by `no-restricted-imports` (`eslint.config.js` / `eslint-rules/boundary/`), not just grep — story-maint-29.
+
 ### Data boundaries
 
 - **SQL boundary:** `Infra/Repositories` map SQL rows (snake_case) to domain entities (camelCase).

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -57,9 +57,12 @@ Every new external input, file path, SQL statement, or dependency is scrutinized
 
 ## Coverage
 
-- **100% branch coverage** on everything under `src/core/`. Non-negotiable.
-- Infra and CLI lower, but every branch (happy path, error path) is still exercised with intent. No "covered by accident" lines.
-- Coverage reports are advisory; the review looks at *which branches aren't covered*, not just the percentage.
+- **100% branch coverage** on everything under `src/core/`. Non-negotiable — CI-gated
+  via `@vitest/coverage-v8` (`npm run test:coverage`; `vitest.config.ts`
+  `coverage.thresholds['src/core/**'].branches`) since story-maint-29. A regression
+  now fails the build instead of drifting silently.
+- Infra and CLI lower, but every branch (happy path, error path) is still exercised with intent. No "covered by accident" lines. Infra/CLI are measured (not thresholded) by the same run — see #242 for the planned ratchet.
+- Coverage reports are advisory for *which branches* a human reviews — the CI gate gives a hard percentage floor for `src/core/`, but "why is this branch uncovered" and "is this test honest" remain a Phase-4 code-review judgment call, not a mechanical one.
 
 ## TDD rhythm
 

--- a/docs/plans/story-maint-29.md
+++ b/docs/plans/story-maint-29.md
@@ -1,0 +1,269 @@
+# Story maint-29 — Mechanize the two convention-only claims: core branch-coverage gate + layer-boundary lint
+
+## Context
+
+The [2026-07-20 critical project review](../reviews/2026-07-20-critical-project-review.md)
+(§ 4) found that the repo's two most load-bearing trust claims are enforced by convention
+only, and the user picked both for this story:
+
+- **#209** — CLAUDE.md § 5 claims 100% branch coverage on `src/core/`, but no coverage
+  tooling is installed, configured, or run in CI. **Pre-planning probe (2026-07-20,
+  full suite, `@vitest/coverage-v8` scoped to `src/core/**`): actual branch coverage is
+  88.44% (329/372) — 43 uncovered branches across 9 files.** The claim does not survive
+  its first mechanical measurement. Probe breakdown:
+  `safe-transfer-calculator.ts` 16, `settlement-variance-service.ts` 14, `result.ts` 4,
+  `money.ts` 3, `transaction.ts` 2, and 1 each in `buffer-state-service.ts`,
+  `config-canonical-form.ts`, `config-change-detector.ts`, `line-item-key.ts`.
+- **#241** — the layer rule (core imports nothing but `dinero.js`) holds today by grep
+  but has no ESLint enforcement, despite 10 custom test-smell rules in
+  `eslint.config.js`. Absorbs **#228** (categorize-specific no-DB import restriction —
+  same file, same mechanism).
+
+No FR coverage — engineering-standards/QA enforcement story (DoD item 1 surface).
+
+### Maintenance sub-loop (§ 6.7) run 2026-07-20 pre-planning
+
+- **Sibling work:** 1 open PR — #238 `story-h14` (thesis refresh, Light, draft). No
+  overlap with coverage/lint tooling. Open issues reviewed via tracker search; #209,
+  #241, #228 are the targets of this story; no other issue addresses them.
+- **Story-id uniqueness (R23):** `git ls-tree origin/main` shows no
+  `story-maint-29` in `docs/plans/`, `docs/retrospectives/`, `docs/status.d/`; only
+  open PR branch is `story-h14`. Id free.
+- **Working tree:** clean; session branch `claude/project-review-critical-3stjy0`
+  reset onto `origin/main` (0b36272) after PR #240 merged (session-branch precedent:
+  story-ddd-1).
+- **Open PRs / Dependabot:** only #238 (see above). No pending bumps.
+- **`npm audit --audit-level=high`:** 0 vulnerabilities.
+- **Drain (story-h13, #164):** this story closes **#228** (aging since 2026-07-17) by
+  absorption, plus #209 (2026-07-08) and #241 — net −3 open items.
+- **Proceed-to-planning:** yes — combined story confirmed with the user
+  (one story vs two: one; #228 absorption: yes).
+
+**Lane: Full** (R26) — closing the coverage gaps requires edits inside `src/core/`
+(new tests are `tests/`-only, but structurally-unreachable guards need
+`/* v8 ignore */` annotations in core files; comment-only, zero behaviour). Phase 0
+skipped via No-model-impact declaration below. Phase 2 = `plan-reviewer` +
+`sibling-overlap` in parallel; Phase 4 = `code-reviewer` (no model note → no
+ddd-modeler).
+
+## Story
+
+> As the project's maintainers (human + agents), I want the core branch-coverage claim
+> and the layer-dependency rule enforced by CI-run tooling instead of prose and grep,
+> so that a regression in either becomes a red build instead of a silent drift.
+
+## Domain model
+
+No model impact — tooling/enforcement story: no domain concept, port, schema, or
+behaviour changes. New tests exercise existing documented failure contracts
+(`Result.fail` on currency mismatch, `Result` misuse throws); `/* v8 ignore */`
+annotations are comments.
+
+## Selected solution
+
+Three legs, one PR:
+
+1. **Coverage gate.** Add `@vitest/coverage-v8` as a devDependency (**R3 audit,
+   run 2026-07-20 against the probe install of 4.1.10:** its `package.json`
+   declares all 10 runtime deps — `@bcoe/v8-coverage`, `ast-v8-to-istanbul`,
+   `istanbul-lib-coverage/-report/-reports`, `magicast`, `obug`, `std-env`,
+   `tinyrainbow`, `@vitest/utils` — plus a satisfied `vitest@4.1.10` peer; dev-only
+   tool, never bundled into product code; no undeclared-transitive smell of the
+   story-3.1 kind). In
+   `vitest.config.ts`, add a `coverage` block: `include: ['src/**']`,
+   `thresholds: { 'src/core/**': { branches: 100 } }` (no thresholds for infra/cli
+   yet — CLAUDE.md § 5 allows lower; a follow-up can ratchet). Add script
+   `"test:coverage": "vitest run --coverage"`; CI's "Run Tests" step becomes
+   `npm run test:coverage` (single run — coverage replaces the plain run, no double
+   execution).
+2. **Close the 43 branch gaps** so the 100% threshold is true, preferring real tests:
+   - *Reachable — test them.* `result.ts` misuse throws (4); `money.ts`
+     subtract-mismatch + allocate negative-ratio guards (3); the calculators' and
+     settlement service's port-failure propagation paths (fake `SplitsService` /
+     ledger query returning `Result.fail` — the mock-the-port idiom already used in
+     those test files); the `cond-expr` else-arms in `line-item-key.ts` /
+     config files; `buffer-state-service.ts` comparison-failure guard if reachable
+     via mixed-currency injection.
+   - *Structurally unreachable — annotate.* Guards on operations over Money values
+     constructed with the same currency inside the same function (currency mismatch
+     cannot occur). Each gets `/* v8 ignore next N */` (or start/stop) plus a
+     one-line why-comment naming the invariant that makes it unreachable — this
+     resolves #209's open design point in favour of annotations over contrived tests,
+     keeping tests honest (no test that asserts a path that cannot happen).
+   - Split expectation from probe reading: ~25–30 testable, ~13–18 annotate. Sonnet
+     classifies each concretely; any guard that *can* be driven by a fake port gets a
+     test, not an annotation.
+3. **Boundary lint.** In `eslint.config.js`, add config blocks using core ESLint
+   `no-restricted-imports` (no new lint dependency):
+   - `src/core/**`: forbid **all** runtime dependencies except `dinero.js` and
+     **all** Node builtins, computed dynamically — the config imports
+     `builtinModules` from `node:module` and reads `package.json`
+     `dependencies`, building `paths` as
+     `[...deps except dinero.js, ...builtinModules, ...builtinModules.map(m => 'node:'+m)]`
+     — plus `patterns: ['**/infra/**', '**/cli/**']`. A future `chalk` or
+     `csv-parse` import into core (or any newly-added dependency) is blocked
+     without editing the rule (adopted from plan-review P3-1: a static blocklist
+     silently missed 6 of today's runtime deps). Message points at CLAUDE.md § 2.
+     (`@core/*` and relative core paths remain allowed by omission.)
+   - `src/infra/**`: forbid `**/cli/**`.
+   - `src/cli/commands/categorize-command.ts`: forbid `**/infra/db/**` (closes #228;
+     the subprocess test `categorize-end-to-end-wiring.test.ts` remains the dynamic
+     leg).
+   - CLAUDE.md § 2 gains one line noting mechanical enforcement (DoD item 10);
+     docs/architecture.md ditto.
+
+Alternatives set aside:
+
+- *`eslint-plugin-boundaries` / `import-x`* — richer layer model, but a new dependency
+  + R3 audit for what three `no-restricted-imports` blocks express today.
+- *Lower threshold (88%) + ratchet* — leaves the flagship claim false; the gap is
+  closable in one story.
+- *Contrived tests for unreachable guards* — tests that can never fail honestly are
+  themselves a test smell (R6 spirit); annotations with justification are more honest.
+- *Separate coverage job in CI* — a second full test run for no isolation benefit.
+
+## Production-code surface (R2)
+
+- **No type, signature, JSON-shape, error-code, or exit-code changes** (R31 not
+  triggered).
+- `src/core/` files gain `/* v8 ignore */` comments only (behaviour-identical).
+- `package.json`: +`@vitest/coverage-v8` devDep (rationale: the vitest-native v8
+  coverage provider — the only supported way to threshold-gate branch coverage in
+  the existing test runner; R3 audit in Selected solution leg 1), +`test:coverage`
+  script.
+- `vitest.config.ts`: +coverage block. `eslint.config.js`: +3 boundary blocks.
+- `.github/workflows/ci.yml`: test step runs `npm run test:coverage`.
+- CLAUDE.md § 5 coverage line + § 2 layer line annotated as tool-enforced; R-row per
+  DoD 10 if the retro mints a rule.
+
+## Gherkin acceptance scenarios
+
+Scenario 1 — coverage gate holds src/core at 100% branches (in-process; R7):
+```gherkin
+Given the repo's vitest coverage configuration
+When the full suite runs with coverage
+Then the run exits 0 and reports src/core branch coverage of 100%
+And the config declares a branches:100 threshold scoped to src/core/**
+```
+`fails if` the thresholds block is missing, mis-scoped (not `src/core/**`), or the
+gate is advisory — guards the CI "Run Tests" step being a real gate.
+*(Mechanism: automated assertion = threshold config + green `test:coverage` run in
+CI. The mutation arm — removing one guard test makes the run exit non-zero — is
+deliberately NOT automated (vitest-in-vitest is the #147-class trap); it is
+demonstrated once manually with output pasted in the PR body. Reworded at Phase 2:
+the original Then-clause claimed the manual arm as scenario behaviour — P1-2.)*
+
+Scenario 2 — boundary lint rejects a core→infra import (in-process; R7):
+```gherkin
+Given the eslint boundary configuration
+When a virtual src/core file imports 'better-sqlite3' (or 'node:fs', bare 'fs',
+  'chalk', or a src/infra path)
+Then the boundary rule reports a no-restricted-imports error for each
+And the unmodified real tree passes npm run lint with zero new errors
+```
+`fails if` the restriction blocks are missing or scoped to the wrong glob — guards the
+layer rule that anchors the architecture. *(Mechanism: a unit test in
+`tests/unit/eslint-rules/` runs ESLint programmatically against inline fixture
+snippets under virtual `src/core/...` paths using the exported boundary config —
+same pattern as the existing test-smell rule tests; no repo files are mutated. The
+`npm run lint` CLI-level arm is covered by CI's lint step on the real tree plus a
+one-time mutated-file demo in the PR body. Reworded at Phase 2: the original
+Then-clause claimed the CLI mechanism for the automated test — P1-3.)*
+
+Scenario 3 — categorize no-DB restriction (in-process; R7):
+```gherkin
+Given the categorize-specific restriction block
+When src/cli/commands/categorize-command.ts imports src/infra/db/database
+Then lint fails; and the real file passes today
+```
+`fails if` the block is absent — closes #228's static-enforcement half.
+*(Mechanism: same programmatic-Linter unit test as Scenario 2, with a virtual
+`src/cli/commands/categorize-command.ts` fixture path — added at Phase 2, P1-4.)*
+
+R4 note: `program.ts` is **not** touched — no composition-root subprocess test needed.
+
+## Slice plan
+
+R13 envelope, 7 slices (id `maint-29` in every subject; R30 prep + retro exempt):
+
+1. `test(harness): maint-29 boundary-lint fixtures — failing` →
+   `feat(lint): maint-29 no-restricted-imports layer blocks — minimal green`
+   (scenarios 2+3; includes the programmatic Linter unit test)
+2. `test(core): maint-29 result misuse-guard branches — failing` →
+   `feat(test): maint-29 cover result.ts guards — minimal green`
+3. `test(core): maint-29 money mismatch/negative-ratio guards — green-on-landing`
+   (sibling condition: guards already implemented; R28)
+4. `test(core): maint-29 remaining reachable guard branches — green-on-landing`
+   (sibling condition: all guarded paths pre-exist — this slice adds coverage via
+   fake-port injection and cond-expr else-arm cases, no production change; R28.
+   Wording tightened + else-arm tests moved here from slice 5 at Phase 2 — P3-2/P3-3)
+5. `refactor(core): maint-29 v8-ignore annotations for structurally-unreachable guards`
+   (annotations + why-comments only — behaviour-preserving, no test content; P3-2)
+6. `feat(ci): maint-29 coverage gate — vitest thresholds + CI step + devDep`
+   (lands last so the gate is born green; no `test: — failing` partner by design —
+   the gate's automated evidence is Scenario 1's config assertion + the green CI
+   run; a red-half would require vitest-in-vitest (see Scenario 1 mechanism) — P3-6)
+7. `chore(docs): maint-29 CLAUDE.md/architecture/engineering-standards enforcement notes`
+   (counted body slice — carries story id, not a canonical exempt subject; includes
+   the engineering-standards § Coverage line: reports stay advisory for *which
+   branches* human review, while the § 5 percentage claim is now a hard CI gate —
+   adopted from P2-2)
+
++ exempt: `chore(docs): story-maint-29 plan + P1/P2/P3 review` (prep, R30) and
+`chore(retro): …` (retro commit).
+
+## Risks & deferred items
+
+| Risk | Mitigation |
+| --- | --- |
+| A "reachable" branch turns out unreachable mid-implementation (or vice versa) | Sonnet reclassifies with a one-line note in the return report; annotation-vs-test decision rule is stated above, not per-case judgment |
+| Coverage adds runtime to CI | Single-run replacement (no second suite execution); v8 provider overhead measured ~+10–15% in probe |
+| `no-restricted-imports` misses a Node builtin spelled without `node:` prefix | Both bare and `node:`-prefixed names listed; scenario-2 fixture includes a bare `fs` case |
+| Vitest 4 per-glob threshold syntax differs from probe assumption | Probe validated `--coverage.include` CLI form; Sonnet verifies the config-file `thresholds` glob form against vitest 4.1 docs before slice 6; fallback is `coverage.include: ['src/core/**']` + global 100 threshold |
+| Infra/cli coverage now measured but ungated | Deliberate — deferred to #242 (ratchet from a measured CI baseline, not an arbitrary number) |
+
+Deferred: #242 (infra/cli threshold ratchet).
+
+## Verification plan
+
+- Locally: `npm run lint && npm run build && npm test` green.
+- CI (post-change step list): lint → build → **`npm run test:coverage`** (replaces
+  plain `npm test` — P1-5 wording fix) → test:harness → drift-scan → dod-check, all
+  green.
+- `npm run test:coverage` exits 0; summary shows `src/core` branches 100%.
+- Mutation demo (PR body): comment out one guard test → `npm run test:coverage`
+  exits non-zero with a threshold error naming `src/core/**`.
+- Boundary demo (PR body): add `import 'better-sqlite3'` to a core file →
+  `npm run lint` fails; revert.
+- `npx tsx harness/drift-scan/drift-scan.ts` and dod-check green.
+- Closes #209, #241, #228 on merge.
+
+## Suggestion log
+
+Phase 2 run 2026-07-20: `plan-reviewer` + `sibling-overlap` in parallel.
+Sibling-overlap: no overlap (PR #238 is docs/learning-only; no competing claimant on
+#209/#241/#228; id free per R23) — no findings to tag.
+Plan-reviewer findings (13):
+
+| # | Finding | Tag | Resolution |
+|---|---------|-----|------------|
+| P1-1 | R3 audit missing for `@vitest/coverage-v8` devDep | ADOPT | Audit run 2026-07-20; result recorded in Selected solution leg 1 |
+| P1-2 | Scenario 1's mutation arm claimed as behaviour but only demonstrated manually | ADOPT | Scenario reworded — automated assertion is config + green run; manual mutation demo explicitly moved to PR-body evidence |
+| P1-3 | Scenario 2's Then named `npm run lint` while the automated mechanism is a programmatic Linter test | ADOPT | Scenario reworded; CLI arm attributed to CI lint step + one-time PR-body demo |
+| P1-4 | Scenario 3 lacked a mechanism note | ADOPT | Mechanism parenthetical added (same programmatic-Linter test as Scenario 2) |
+| P1-5 | Verification plan said CI runs `npm test`, contradicting the `test:coverage` step change | ADOPT | Verification plan reworded with the post-change CI step list |
+| P2-1 | No QA-invariant surfaces implicated (informational) | ACKNOWLEDGE | No action — confirms scope |
+| P2-2 | engineering-standards § Coverage "advisory" framing vs the new hard gate unaddressed | ADOPT | Slice 7 extended to update engineering-standards § Coverage (reports advisory for *which-branches* review; percentage claim now CI-gated) |
+| P3-1 | Static blocklist missed 6 runtime deps (`chalk`, `csv-parse`, `@inquirer/*`, `cli-table3`, `ora`) — reproduces the silent-import failure mode | ADOPT | Blocklist redesigned as dynamic: all `package.json` dependencies except `dinero.js` + all `builtinModules` (bare and `node:`-prefixed), computed in `eslint.config.js` |
+| P3-2 | Slice 5 bundled new else-arm tests into a `refactor:` commit | ADOPT | Else-arm tests moved to slice 4 (green-on-landing); slice 5 is annotations-only |
+| P3-3 | Slice 4 sibling-condition wording didn't state the pre-existing-paths property R28 turns on | ADOPT | Slice 4 wording tightened |
+| P3-4 | Dep rationale not co-located in the R2 surface section | ADOPT | One-line rationale added at the devDep line |
+| P3-5 | Infra/cli measured-but-ungated decision surfaced for disposition | DEFER | #242 filed — ratchet from a measured CI baseline |
+| P3-6 | Slice 6 `feat:` has no `test: — failing` partner | ACKNOWLEDGE | By design: the red-half would require vitest-in-vitest (#147-class trap); justification recorded in the slice plan |
+
+## DoR checklist
+
+- [x] Phase 0 (Model): `No model impact` declared above (R24).
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review — plan-reviewer + sibling-overlap in parallel): findings triaged above.
+- [x] Draft PR with template sections 1–6 filled. *(PR opened at DoR — see PR body.)*

--- a/docs/retrospectives/story-maint-29.md
+++ b/docs/retrospectives/story-maint-29.md
@@ -1,0 +1,93 @@
+# Story maint-29 retrospective
+
+**PR:** [#243](https://github.com/xavierbriand/accounting/pull/243)  **Closed:** pending merge  **Closes issues:** [#209](https://github.com/xavierbriand/accounting/issues/209), [#241](https://github.com/xavierbriand/accounting/issues/241), [#228](https://github.com/xavierbriand/accounting/issues/228)
+
+First enforcement story spun directly out of a whole-project critical review
+([docs/reviews/2026-07-20-critical-project-review.md](../reviews/2026-07-20-critical-project-review.md)).
+Converted the repo's two convention-only trust claims into CI gates: the 100%-branch
+coverage claim on `src/core/` (which the pre-planning probe measured at **88.44%**,
+not 100 — 43 uncovered branches) and the layer-dependency rule (now a dynamic
+`no-restricted-imports` config in `eslint-rules/boundary/`). All 43 gaps closed:
+35 real tests, 8 `/* v8 ignore next */` annotations each carrying a why-comment
+naming the invariant that makes its guard unreachable. Full lane; 8 slices shipped
+(7 planned + 1 Phase-4 fix slice), Sonnet Phase 3, ~2 CI round-trips.
+
+## Keep
+
+- **Probe before planning.** Running `@vitest/coverage-v8` against the real suite
+  *before* writing the plan converted the story from "wire a tool" (the #209 framing)
+  to "close a measured 43-branch gap" — with the exact per-file, per-line branch list
+  embedded in the plan. Sonnet's leg needed zero discovery; every deviation it
+  reported was a *classification* judgment, not a surprise.
+- **Phase-2 review caught a real design hole, then Phase-4 caught its sibling.**
+  plan-reviewer P3-1 killed the static blocklist (missed 6 of the day's runtime
+  deps); code-reviewer P3-1 then caught that the dynamic version read
+  `dependencies` only, leaving devDependency imports (`fast-check`, `vitest`)
+  unblocked. Two review legs, same failure family, both fixed — the layered-review
+  design worked exactly as intended on this story.
+- **The gate caught its own author within one CI run.** dod-check's hard
+  `missing-story-id` failed the first CI run because the plan authored slice
+  subjects with the bare id (`maint-29`) instead of the canonical `story-maint-29`
+  form. The deterministic gate turned a coordinator error into a 10-minute
+  mechanical fix (8 subjects reworded via cherry-pick + amend, tree byte-identical)
+  instead of a silently mis-enveloped story.
+
+## Change
+
+- **A. Plan-authored commit subjects must be written against
+  `harness/lib/story-id-matcher.ts`'s actual pattern, not from memory.**
+  [story-maint-28's retro](story-maint-28.md) (Change B/C) already documented that
+  dod-check matches the current story id against every subject with no tolerance —
+  and this plan still authored non-matching subjects, just via a different variant
+  (bare id vs the superseded-id and paraphrased-prep variants maint-28 hit). Three
+  variants of the same trap across two consecutive maintenance stories is a
+  pattern: the slice-plan section should quote subjects in their final,
+  matcher-satisfying form, checked against the regex at plan time.
+- **B. The "structurally unreachable" estimate in the plan was off by 2×**
+  (~13–18 estimated, 8 actual): several guards that *look* unreachable are drivable
+  through the established `as unknown as X` fake-collaborator idiom, and three
+  others are unreachable for a subtler reason than the plan's rule anticipated (an
+  equivalent earlier same-function currency check). The pre-specified decision rule
+  ("drivable by a fake → test, not annotation") absorbed the drift without
+  re-planning — write that rule into any future coverage story; skip the count
+  estimate.
+
+## Try
+
+- Add a one-line check to the plan template's Slice-plan comment: "subjects must
+  match `buildStoryIdRegExp` — quote them final-form" — same-PR edit was considered
+  but the template is user-owned canon riding many stories; funneled instead as
+  [#244](https://github.com/xavierbriand/accounting/issues/244).
+- The `result.ts` misuse-throws vs security-checklist "no thrown exceptions inside
+  Core" tension (code-reviewer P3-3) is pre-existing, now visible in test
+  assertions. Documented here for the next security-checklist touch: the checklist
+  line should carve out invariant/programmer-error guards explicitly. Funneled into
+  [#244](https://github.com/xavierbriand/accounting/issues/244) alongside the
+  template line (same doc-hygiene batch).
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| Template line quoting the story-id matcher requirement + security-checklist carve-out for invariant throws | [#244](https://github.com/xavierbriand/accounting/issues/244) | open |
+| Infra/cli coverage-threshold ratchet once a CI baseline accrues | [#242](https://github.com/xavierbriand/accounting/issues/242) | open |
+
+No new § 8 rule minted — both candidate lessons (subject-form checking, annotation
+classification rule) are story-shape guidance funneled to #244, not loop-wide
+invariants.
+
+## Loop metrics (this run)
+
+- **Plan phase:** maintenance sub-loop (drain: #228 absorbed, net −3 open items) +
+  coverage probe + plan with embedded 43-branch enumeration.
+- **Phase 2:** plan-reviewer (13 findings: 10 adopted, 2 acknowledged, 1 deferred →
+  #242) + sibling-overlap (clean) in parallel.
+- **Phase 3:** sonnet-implementer, single round, 8 commits, 2 honest deviations
+  (slice-2 relabel, annotation reclassification) + 1 pre-existing test bug fixed
+  (mis-targeted `lteCapResult` fixture).
+- **Phase 4:** code-reviewer (6 findings: 2 P1, 4 P3 of which 3 soft) → 3 fix-now
+  (devDeps blocklist, infra clean-pass fixture, comma), 3 acknowledged.
+- **CI round-trips:** 2 (1st red: dod-check missing-story-id on all 8 subjects;
+  2nd expected green after reword + Phase-4 fix slice).
+- **Issues closed by this story:** #209, #241, #228 (via merge). **Opened:** #242
+  (deferred ratchet), #244 (Try funnel).

--- a/docs/status.d/2026-07-20-story-maint-29.md
+++ b/docs/status.d/2026-07-20-story-maint-29.md
@@ -1,0 +1,23 @@
+---
+date: 2026-07-20
+story: maint-29
+pr: 243
+epic: maintenance
+---
+
+The two convention-only trust claims from the 2026-07-20 critical project review
+(docs/reviews/) are now CI gates. The probe truth first: src/core branch coverage
+was 88.44% (329/372), not the documented 100% — 43 uncovered branches, mostly
+Result-propagation guards in the two calculators. All closed: 35 real tests
+(fake-collaborator port-failure paths, Result misuse throws, Money guard paths,
+comparator else-arms) + 8 /* v8 ignore next */ annotations with per-site
+unreachability why-comments (#209's design point resolved: annotate the
+unreachable, never contrive a test). `npm run test:coverage` (now CI's test step)
+enforces branches:100 on src/core/**. The layer rule is mechanized too:
+eslint-rules/boundary/ builds a dynamic no-restricted-imports blocklist from
+package.json dependencies + devDependencies + Node builtins (core → nothing but
+dinero.js; infra → no cli; categorize-command → no infra/db, closing #228/#241).
+dod-check earned its keep twice: its hard missing-story-id gate caught the plan's
+bare-id commit subjects on the first CI run. Deferred: #242 (infra/cli threshold
+ratchet); Try-funnel: #244. Next: unchanged — Epic 5 vs dogfooding per
+docs/status.md.

--- a/eslint-rules/boundary/index.d.ts
+++ b/eslint-rules/boundary/index.d.ts
@@ -1,0 +1,6 @@
+import type { Linter } from 'eslint';
+
+export declare const forbiddenCoreExternalPaths: readonly string[];
+export declare const boundaryConfig: Linter.Config[];
+declare const boundaryConfigDefault: Linter.Config[];
+export default boundaryConfigDefault;

--- a/eslint-rules/boundary/index.js
+++ b/eslint-rules/boundary/index.js
@@ -10,9 +10,13 @@ import packageJson from '../../package.json' with { type: 'json' };
 const CORE_ALLOWED_DEPENDENCY = 'dinero.js';
 
 function forbiddenRuntimeDependencies() {
-  return Object.keys(packageJson.dependencies ?? {}).filter(
-    (name) => name !== CORE_ALLOWED_DEPENDENCY,
-  );
+  // devDependencies too (Phase-4 P3-1): test/tooling packages (fast-check,
+  // vitest, ...) are just as installed and importable from core as runtime
+  // deps, and equally forbidden there.
+  return [
+    ...Object.keys(packageJson.dependencies ?? {}),
+    ...Object.keys(packageJson.devDependencies ?? {}),
+  ].filter((name) => name !== CORE_ALLOWED_DEPENDENCY);
 }
 
 function forbiddenBuiltinModules() {

--- a/eslint-rules/boundary/index.js
+++ b/eslint-rules/boundary/index.js
@@ -1,0 +1,78 @@
+import { builtinModules } from 'node:module';
+import packageJson from '../../package.json' with { type: 'json' };
+
+// Dynamic blocklist (P3-1, story-maint-29): a static list of runtime deps went
+// stale the moment a new one was added without a matching lint-config edit —
+// the probe that found this story's #241 missed 6 of today's deps that way.
+// Deriving the blocklist from package.json + node:module's own builtin list
+// means a newly-added dependency (or a Node builtin spelled without the
+// `node:` prefix) is blocked automatically, no rule edit required.
+const CORE_ALLOWED_DEPENDENCY = 'dinero.js';
+
+function forbiddenRuntimeDependencies() {
+  return Object.keys(packageJson.dependencies ?? {}).filter(
+    (name) => name !== CORE_ALLOWED_DEPENDENCY,
+  );
+}
+
+function forbiddenBuiltinModules() {
+  return [...builtinModules, ...builtinModules.map((name) => `node:${name}`)];
+}
+
+export const forbiddenCoreExternalPaths = [
+  ...forbiddenRuntimeDependencies(),
+  ...forbiddenBuiltinModules(),
+];
+
+const CORE_BOUNDARY_MESSAGE =
+  'src/core/ depends on nothing but dinero.js — see CLAUDE.md § 2 (enforced by no-restricted-imports — story-maint-29).';
+const INFRA_BOUNDARY_MESSAGE =
+  'src/infra/ must not import src/cli/ — see CLAUDE.md § 2 (enforced by no-restricted-imports — story-maint-29).';
+const CATEGORIZE_BOUNDARY_MESSAGE =
+  'categorize-command.ts must not import src/infra/db/ directly — see #228 (enforced by no-restricted-imports — story-maint-29).';
+
+// `@core/*` and relative core-to-core paths are allowed by omission — neither
+// `paths` nor `patterns` below name them.
+export const boundaryConfig = [
+  {
+    files: ['src/core/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: forbiddenCoreExternalPaths.map((name) => ({
+            name,
+            message: CORE_BOUNDARY_MESSAGE,
+          })),
+          patterns: [
+            { group: ['**/infra/**', '**/cli/**'], message: CORE_BOUNDARY_MESSAGE },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/infra/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [{ group: ['**/cli/**'], message: INFRA_BOUNDARY_MESSAGE }],
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/cli/commands/categorize-command.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [{ group: ['**/infra/db/**'], message: CATEGORIZE_BOUNDARY_MESSAGE }],
+        },
+      ],
+    },
+  },
+];
+
+export default boundaryConfig;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,5 +61,5 @@ export default tseslint.config(
   // Layer-boundary lint (story-maint-29, #241/#228) — mechanizes CLAUDE.md § 2's
   // dependency rule via no-restricted-imports instead of grep. See
   // eslint-rules/boundary/index.js for the dynamic blocklist.
-  ...boundaryConfig
+  ...boundaryConfig,
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import testSmellRules from "./eslint-rules/test-smells/index.js";
+import boundaryConfig from "./eslint-rules/boundary/index.js";
 
 export default tseslint.config(
   js.configs.recommended,
@@ -56,5 +57,9 @@ export default tseslint.config(
     rules: {
       "local/no-mystery-guest-db": "error",
     },
-  }
+  },
+  // Layer-boundary lint (story-maint-29, #241/#228) — mechanizes CLAUDE.md § 2's
+  // dependency rule via no-restricted-imports instead of grep. See
+  // eslint-rules/boundary/index.js for the dynamic blocklist.
+  ...boundaryConfig
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@eslint/js": "^10.0.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^26.1.1",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.7.0",
         "fast-check": "^4.9.0",
         "pixelmatch": "^6.0.0",
@@ -48,6 +49,66 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@colors/colors": {
@@ -1071,12 +1132,33 @@
         }
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1717,6 +1799,37 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -1930,6 +2043,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2795,6 +2920,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
@@ -2933,6 +3075,52 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
@@ -3301,6 +3489,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -4207,6 +4423,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tar-fs": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "vitest run",
     "test:quiet": "vitest run --reporter=dot",
+    "test:coverage": "vitest run --coverage",
     "test:perf": "vitest run tests/perf/",
     "lint": "eslint .",
     "build": "tsc && tsc-alias && tsc -p tsconfig.test.json && tsc-alias -p tsconfig.test.json && cp -R src/infra/db/migrations dist/infra/db/",
@@ -55,6 +56,7 @@
     "@eslint/js": "^10.0.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^26.1.1",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.7.0",
     "fast-check": "^4.9.0",
     "pixelmatch": "^6.0.0",

--- a/src/core/ledger/transaction.ts
+++ b/src/core/ledger/transaction.ts
@@ -85,10 +85,12 @@ export class Transaction {
     for (const entry of entries) {
       if (entry.side === 'debit') {
         const added = debitSum.add(entry.amount);
+        /* v8 ignore next -- unreachable: the currency-uniqueness check above already guarantees a shared currency */
         if (added.isFailure) return Result.fail(added.error);
         debitSum = added.value;
       } else {
         const added = creditSum.add(entry.amount);
+        /* v8 ignore next -- unreachable: the currency-uniqueness check above already guarantees a shared currency */
         if (added.isFailure) return Result.fail(added.error);
         creditSum = added.value;
       }

--- a/src/core/settlement/settlement-variance-service.ts
+++ b/src/core/settlement/settlement-variance-service.ts
@@ -117,6 +117,7 @@ function buildFollowThrough(
   }
 
   const totalDeltaResult = thisMonth.totalRequired.subtract(contributions.totalActual);
+  /* v8 ignore next -- unreachable: the currency check above already guarantees a shared currency */
   if (totalDeltaResult.isFailure) return Result.fail(totalDeltaResult.error);
 
   const perPartnerResult = buildPerPartnerFollowThrough(thisMonth, contributions, zero);
@@ -143,6 +144,7 @@ export function explainSettlementVariance(
   }
 
   const zeroResult = Money.fromCents(0, currency);
+  /* v8 ignore next -- unreachable: currency is read from an already-valid Money's .currency getter, and 0 is always an integer */
   if (zeroResult.isFailure) return Result.fail(zeroResult.error);
   const zero = zeroResult.value;
 
@@ -163,6 +165,7 @@ export function explainSettlementVariance(
   lines.sort((a, b) => a.key.compare(b.key));
 
   const totalDeltaResult = thisMonth.totalRequired.subtract(lastMonth.totalRequired);
+  /* v8 ignore next -- unreachable: the top-level currency check above already guarantees a shared currency */
   if (totalDeltaResult.isFailure) return Result.fail(totalDeltaResult.error);
 
   const perPartnerDeltaResult = buildPerPartnerDelta(thisMonth.perPartner, lastMonth.perPartner, zero);

--- a/src/core/transfer/safe-transfer-calculator.ts
+++ b/src/core/transfer/safe-transfer-calculator.ts
@@ -69,9 +69,11 @@ function buildBufferTopupLineItems(
   }
 
   const shortfallResult = state.target.subtract(state.balance);
+  /* v8 ignore next -- unreachable: a successful BufferStateService.getStateAsOf() (the only source of `state`) already proves target and balance share a currency */
   if (shortfallResult.isFailure) return Result.fail(shortfallResult.error);
 
   const monthlyFillsResult = shortfallResult.value.allocate(Array(monthsRemaining).fill(1));
+  /* v8 ignore next -- unreachable: the fill ratios are a literal array of 1s (monthsRemaining > 0 per the guard above), never negative */
   if (monthlyFillsResult.isFailure) return Result.fail(monthlyFillsResult.error);
   const monthlyFills = monthlyFillsResult.value;
 
@@ -173,6 +175,7 @@ export class SafeTransferCalculator {
       for (const [partner, share] of item.perPartnerSplit) {
         const current = perPartner.get(partner) ?? zero;
         const addPartner = current.add(share);
+        /* v8 ignore next -- unreachable: share always shares item.gross's currency (both come from the same allocate() call), and the addTotal guard above already proved item.gross matches the running total's currency */
         if (addPartner.isFailure) return Result.fail(addPartner.error);
         perPartner.set(partner, addPartner.value);
       }

--- a/tests/unit/core/buffers/buffer-state-service.test.ts
+++ b/tests/unit/core/buffers/buffer-state-service.test.ts
@@ -330,15 +330,27 @@ describe('BufferStateService', () => {
     });
 
     it('returns failure when balance currency differs from cap currency (deriveStatus lteCapResult guard)', () => {
-      // Branch: lteCapResult.isFailure in deriveStatus (line 21)
-      // Similar to above — forces the above-cap comparison with a mismatched currency.
-      const buckets = [makeBucket('Car', 'assets:buffer:car', 50_00, 200_00)];
-      const usdLedger: BufferLedgerQuery = {
+      // Branch: lteCapResult.isFailure in deriveStatus (line 21). Balance and target
+      // share a currency (EUR) so the ltTarget guard at line 15 passes through — cap
+      // alone is a different currency (USD), isolating the line-21 comparison guard.
+      // (story-maint-29: the prior version of this test put balance in USD, which
+      // tripped the earlier ltTarget guard instead of this one — it never reached
+      // line 21.)
+      const buckets: BufferBucket[] = [
+        {
+          name: 'Car',
+          account: 'assets:buffer:car',
+          target: makeEur(50_00),
+          targetDate: '2099-12-31',
+          cap: Money.fromCents(200_00, 'USD').value,
+        },
+      ];
+      const eurAboveTargetLedger: BufferLedgerQuery = {
         sumEntriesByAccount(): Result<Money> {
-          return Money.fromCents(100_00, 'USD');
+          return Money.fromCents(100_00, 'EUR');
         },
       };
-      const service = new BufferStateService(buckets, 'EUR', usdLedger);
+      const service = new BufferStateService(buckets, 'EUR', eurAboveTargetLedger);
       const result = service.getStateAsOf('2026-04-26');
       expect(result.isFailure).toBe(true);
     });

--- a/tests/unit/core/config/config-canonical-form.test.ts
+++ b/tests/unit/core/config/config-canonical-form.test.ts
@@ -117,6 +117,15 @@ describe('canonicalConfigForm — optional fields (coverage completion)', () => 
     const config = baseConfig({ settlement: { accounts: [{ account: 'joint-account', partner: 'Alice' }] } });
     expect(canonicalConfigForm(config)).toContain('"settlement":{"accounts":[{"account":"joint-account","partner":"Alice"}]}');
   });
+
+  it('a tied sort key (byKey comparator returns 0) does not crash and preserves both entries', () => {
+    // fails if byKey()'s equal-keys branch is removed and array.sort throws or drops an entry
+    const config = baseConfig({
+      buffers: [makeBuffer('Vacation', 1000), makeBuffer('Vacation', 2000)],
+    });
+    const form = canonicalConfigForm(config);
+    expect(form.match(/"name":"Vacation"/g)).toHaveLength(2);
+  });
 });
 
 describe('canonicalConfigForm — array reorder stability (property)', () => {

--- a/tests/unit/core/config/config-change-detector.test.ts
+++ b/tests/unit/core/config/config-change-detector.test.ts
@@ -12,7 +12,7 @@
  *   the changedSections/previousDigest/currentDigest on a real change don't match what
  *   diffConfigs/canonicalConfigForm would independently compute.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { ConfigChangeDetector } from '../../../../src/core/config/config-change-detector.js';
 import { canonicalConfigForm } from '../../../../src/core/config/config-canonical-form.js';
@@ -57,6 +57,20 @@ describe('ConfigChangeDetector — corrupted stored state (coverage completion)'
     const result = detector.detect({ canonical: 'not-json{{', digest: 'stale-digest' }, baseConfig());
     expect(result.isFailure).toBe(true);
     expect(result.error).toContain('not valid JSON');
+  });
+
+  it('falls back to String(err) when the parse failure is not an Error instance', () => {
+    // fails if the ternary's non-Error fallback (line 30) is removed — JS allows throwing
+    // any value, not just Error instances, so JSON.parse's real SyntaxError alone can't
+    // exercise this arm.
+    const parseSpy = vi.spyOn(JSON, 'parse').mockImplementationOnce(() => {
+      throw 'a thrown string, not an Error';
+    });
+    const detector = new ConfigChangeDetector(identityHashFn);
+    const result = detector.detect({ canonical: '{}', digest: 'stale-digest' }, baseConfig());
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toContain('a thrown string, not an Error');
+    parseSpy.mockRestore();
   });
 });
 

--- a/tests/unit/core/settlement/line-item-key.test.ts
+++ b/tests/unit/core/settlement/line-item-key.test.ts
@@ -85,6 +85,13 @@ describe('LineItemKey — compare() total order', () => {
     expect(a.compare(b)).toBeLessThan(0);
   });
 
+  it('orders by description in reverse when the description is lexicographically greater', () => {
+    // fails if the description tie-breaker's greater-than arm returns the wrong sign
+    const a = LineItemKey.of(makeItem({ kind: 'forecast', category: 'Rent', description: 'Beta' }));
+    const b = LineItemKey.of(makeItem({ kind: 'forecast', category: 'Rent', description: 'Alpha' }));
+    expect(a.compare(b)).toBeGreaterThan(0);
+  });
+
   it('returns 0 for identical keys', () => {
     // fails if compare() is not reflexive for equal keys
     const a = LineItemKey.of(makeItem());

--- a/tests/unit/core/settlement/settlement-variance-service.test.ts
+++ b/tests/unit/core/settlement/settlement-variance-service.test.ts
@@ -240,6 +240,142 @@ describe('explainSettlementVariance — follow-through assembly', () => {
   });
 });
 
+// ─── Defensive currency-mismatch propagation (coverage completion, story-maint-29) ────────
+//
+// The top-level currency guards (this vs last month's totalRequired; contributions vs this
+// month's currency) only validate the AGGREGATE totals. SafeTransferCalculation and LineItem
+// are plain data shapes with independently-settable fields, so a per-item gross or a
+// per-partner share can carry a currency that disagrees with the aggregate it sits beside —
+// a data anomaly that should never occur from a well-behaved SafeTransferCalculator, but the
+// internal Money.subtract() guards defend against it anyway. Each fixture below isolates one
+// such anomaly to drive one specific propagation branch.
+
+describe('explainSettlementVariance — defensive currency-mismatch propagation', () => {
+  it('propagates a "both" line\'s gross-currency mismatch (buildVarianceLine totalDelta guard)', () => {
+    // fails if the totalDelta subtract-failure guard (line 55) stops propagating
+    const thisMonth: SafeTransferCalculation = {
+      totalRequired: eur(100000),
+      perPartner: new Map([['Alex', eur(50000)], ['Sam', eur(50000)]]),
+      lineItems: [item({ description: 'Rent', gross: eur(100000) })],
+    };
+    const lastMonth: SafeTransferCalculation = {
+      totalRequired: eur(90000),
+      perPartner: new Map([['Alex', eur(45000)], ['Sam', eur(45000)]]),
+      lineItems: [item({ description: 'Rent', gross: usd(90000) })],
+    };
+    const result = explainSettlementVariance(thisMonth, lastMonth, noContributions);
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a "both" line\'s per-partner-share mismatch (buildPerPartnerDelta guard)', () => {
+    // fails if the perPartnerDelta subtract-failure guard (line 57, via buildPerPartnerDelta
+    // line 40) stops propagating
+    const thisMonth: SafeTransferCalculation = {
+      totalRequired: eur(100000),
+      perPartner: new Map([['Alex', eur(50000)], ['Sam', eur(50000)]]),
+      lineItems: [
+        item({ description: 'Rent', gross: eur(100000), perPartnerSplit: new Map([['Alex', eur(50000)], ['Sam', eur(50000)]]) }),
+      ],
+    };
+    const lastMonth: SafeTransferCalculation = {
+      totalRequired: eur(90000),
+      perPartner: new Map([['Alex', eur(45000)], ['Sam', eur(45000)]]),
+      lineItems: [
+        item({ description: 'Rent', gross: eur(90000), perPartnerSplit: new Map([['Alex', usd(45000)], ['Sam', eur(45000)]]) }),
+      ],
+    };
+    const result = explainSettlementVariance(thisMonth, lastMonth, noContributions);
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a "this-only" line\'s per-partner-share mismatch against the zero fallback', () => {
+    // fails if the this-only perPartnerDelta guard (line 68, via buildPerPartnerDelta line 40)
+    // stops propagating
+    const thisMonth: SafeTransferCalculation = {
+      totalRequired: eur(20000),
+      perPartner: new Map([['Alex', eur(10000)], ['Sam', eur(10000)]]),
+      lineItems: [
+        item({ description: 'Insurance', category: 'Insurance', gross: eur(20000), perPartnerSplit: new Map([['Alex', usd(10000)], ['Sam', eur(10000)]]) }),
+      ],
+    };
+    const lastMonth: SafeTransferCalculation = { totalRequired: eur(0), perPartner: new Map(), lineItems: [] };
+    const result = explainSettlementVariance(thisMonth, lastMonth, noContributions);
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a "last-only" line\'s gross-currency mismatch against the zero fallback', () => {
+    // fails if the last-only totalDelta guard (line 78) stops propagating
+    const thisMonth: SafeTransferCalculation = { totalRequired: eur(0), perPartner: new Map(), lineItems: [] };
+    const lastMonth: SafeTransferCalculation = {
+      totalRequired: eur(120000),
+      perPartner: new Map([['Alex', eur(60000)], ['Sam', eur(60000)]]),
+      lineItems: [
+        item({ description: 'One-off top-up', kind: 'buffer-topup', category: 'Vacation', gross: usd(120000), perPartnerSplit: new Map([['Alex', eur(60000)], ['Sam', eur(60000)]]) }),
+      ],
+    };
+    const result = explainSettlementVariance(thisMonth, lastMonth, noContributions);
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a "last-only" line\'s per-partner-share mismatch against the zero fallback', () => {
+    // fails if the last-only perPartnerDelta guard (line 80, via buildPerPartnerDelta line 40)
+    // stops propagating
+    const thisMonth: SafeTransferCalculation = { totalRequired: eur(0), perPartner: new Map(), lineItems: [] };
+    const lastMonth: SafeTransferCalculation = {
+      totalRequired: eur(120000),
+      perPartner: new Map([['Alex', eur(60000)], ['Sam', eur(60000)]]),
+      lineItems: [
+        item({ description: 'One-off top-up', kind: 'buffer-topup', category: 'Vacation', gross: eur(120000), perPartnerSplit: new Map([['Alex', usd(60000)], ['Sam', eur(60000)]]) }),
+      ],
+    };
+    const result = explainSettlementVariance(thisMonth, lastMonth, noContributions);
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a per-partner-delta mismatch at the report level (thisMonth.perPartner vs lastMonth.perPartner)', () => {
+    // fails if the report-level perPartnerDelta guard (line 169, via buildPerPartnerDelta
+    // line 40) stops propagating
+    const thisMonth: SafeTransferCalculation = {
+      totalRequired: eur(0),
+      perPartner: new Map([['Alex', eur(10000)], ['Sam', eur(10000)]]),
+      lineItems: [],
+    };
+    const lastMonth: SafeTransferCalculation = {
+      totalRequired: eur(0),
+      perPartner: new Map([['Alex', usd(10000)], ['Sam', eur(10000)]]),
+      lineItems: [],
+    };
+    const result = explainSettlementVariance(thisMonth, lastMonth, noContributions);
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('returns Result.fail when the same key appears twice within last month\'s window', () => {
+    // fails if the indexByKey duplicate-key guard (line 152) stops rejecting a dup in the
+    // LAST-month window specifically (the sibling this-month case is covered above)
+    const thisMonth = calc([item({ description: 'Rent', gross: eur(100000) })]);
+    const lastMonth = calc([
+      item({ description: 'Rent', gross: eur(50000) }),
+      item({ description: 'Rent', gross: eur(40000) }),
+    ]);
+    const result = explainSettlementVariance(thisMonth, lastMonth, noContributions);
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a per-partner follow-through mismatch (buildPerPartnerFollowThrough guard)', () => {
+    // fails if the follow-through perPartner guard (lines 101 and 123) stops propagating —
+    // totalActual matches this month's currency (passing the line-113 guard) but one
+    // partner's individual attributed contribution does not
+    const thisMonth = calc([item({ description: 'Rent', gross: eur(100000) })]);
+    const lastMonth = calc([item({ description: 'Rent', gross: eur(100000) })]);
+    const contributions: ContributionsInWindow = {
+      attributed: [{ partner: 'Alex', amount: usd(48000) }, { partner: 'Sam', amount: eur(46000) }],
+      totalActual: eur(94000),
+    };
+    const result = explainSettlementVariance(thisMonth, lastMonth, contributions);
+    expect(result.isFailure).toBe(true);
+  });
+});
+
 // ─── Property tests ───────────────────────────────────────────────────────────
 // Invariants 1-5 and 10 of the signed-off model note (docs/domain/model-notes/story-4.3.md).
 // Each generated "line" is index-keyed (Cat{i}/Item{i}, alternating kind), guaranteeing

--- a/tests/unit/core/shared/money.test.ts
+++ b/tests/unit/core/shared/money.test.ts
@@ -22,6 +22,13 @@ describe('Money Value Object', () => {
       expect(m.error).toMatch(/currency/i);
     });
 
+    it('Money.zero() should fail for an unknown currency code', () => {
+      // fails if zero() stops validating the currency code (test-helper factory, story-maint-29)
+      const m = Money.zero('XXX');
+      expect(m.isFailure).toBe(true);
+      expect(m.error).toMatch(/currency/i);
+    });
+
     it('should implement Bankers Rounding for decimals', () => {
       // 2.5 cents -> 2 cents (Round Half to Even)
       // Note: fromDecimal takes "Units". 0.025 units = 2.5 cents.
@@ -68,6 +75,30 @@ describe('Money Value Object', () => {
       expect(shares[1].amount).toBe(33);
       expect(shares[2].amount).toBe(33);
       expect(shares.reduce((sum, s) => sum + s.amount, 0)).toBe(100);
+    });
+
+    it('should subtract same currency', () => {
+      // fails if subtract() stops computing this - other for matching currencies
+      const m1 = Money.fromCents(150, 'EUR').value;
+      const m2 = Money.fromCents(50, 'EUR').value;
+      const result = m1.subtract(m2);
+      expect(result.isSuccess).toBe(true);
+      expect(result.value.amount).toBe(100);
+    });
+
+    it('should fail to subtract different currencies', () => {
+      // fails if subtract() silently mixes currencies instead of rejecting the pair
+      const m1 = Money.fromCents(100, 'EUR').value;
+      const m2 = Money.fromCents(50, 'USD').value;
+      const result = m1.subtract(m2);
+      expect(result.isFailure).toBe(true);
+    });
+
+    it('should fail to allocate with a negative ratio', () => {
+      // fails if allocate() stops rejecting a negative ratio before calling into dinero.js
+      const m = Money.fromCents(100, 'EUR').value;
+      const result = m.allocate([1, -1]);
+      expect(result.isFailure).toBe(true);
     });
   });
 

--- a/tests/unit/core/shared/result.test.ts
+++ b/tests/unit/core/shared/result.test.ts
@@ -175,3 +175,44 @@ describe('Result.all', () => {
     expect(r.error).toBe('first error');
   });
 });
+
+// The constructor is `private` — only reachable at runtime via a bypass cast
+// (TS `private` is compile-time-only, not a runtime `#`-field). This is the
+// idiomatic way to exercise a private invariant guard without weakening the
+// class's public API for production callers.
+type ResultConstructorBypass = new (isSuccess: boolean, error?: string, value?: unknown) => Result<unknown, string>;
+const ResultCtor = Result as unknown as ResultConstructorBypass;
+
+describe('Result — construction misuse guards', () => {
+  // fails if: the constructor stops rejecting isSuccess=true with a truthy error
+  it('throws when constructed with isSuccess=true and a truthy error', () => {
+    expect(() => new ResultCtor(true, 'boom', undefined)).toThrow(
+      'InvalidOperation: A result cannot be successful and contain an error',
+    );
+  });
+
+  // fails if: the constructor stops rejecting isSuccess=false with no error
+  it('throws when constructed with isSuccess=false and no error', () => {
+    expect(() => new ResultCtor(false, undefined, undefined)).toThrow(
+      "InvalidOperation: A failing result needs to contain an error message",
+    );
+  });
+});
+
+describe('Result — accessor misuse guards', () => {
+  // fails if: .value stops rejecting access on a failure result
+  it('.value throws when the result is a failure', () => {
+    const r = Result.fail<string>('boom');
+    expect(() => r.value).toThrow(
+      "Can't get the value of an error result. Use 'errorValue' instead.",
+    );
+  });
+
+  // fails if: .error stops rejecting access on a success result
+  it('.error throws when the result is a success', () => {
+    const r = Result.ok('fine');
+    expect(() => r.error).toThrow(
+      "Can't get the error of a success result. Use 'value' instead.",
+    );
+  });
+});

--- a/tests/unit/core/transfer/safe-transfer-calculator.test.ts
+++ b/tests/unit/core/transfer/safe-transfer-calculator.test.ts
@@ -798,3 +798,192 @@ describe('SafeTransferCalculator — property tests (buffer top-up)', () => {
     );
   });
 });
+
+// ─── Coverage completion (story-maint-29) ────────────────────────────────────
+// Each test below drives one previously-uncovered guard branch: either via real,
+// structurally-valid-but-anomalous config data (a config invariant this service
+// does not itself enforce, e.g. a negative split ratio or a stale roster), or via
+// a recording/failing fake collaborator (the same `as unknown as X` idiom already
+// used by the Property #3a/#3b/#3c tests above) when the real collaborator cannot
+// be made to fail from this call site.
+
+function makeUsd(cents: number): Money {
+  return Money.fromCents(cents, 'USD').value;
+}
+
+describe('SafeTransferCalculator — port-failure and guard-branch coverage completion', () => {
+  it('propagates a roster fetch failure when asOf precedes the earliest split window', () => {
+    // fails if the top-level roster-fetch guard (line 133) stops propagating
+    const windows = [splitWindow('2026-06-01', ['Alex', 0.5], ['Sam', 0.5])];
+    const calc = buildCalculator(windows, [], []);
+    const result = calc.calculateForWindow('2026-04-28', '2026-05-01', '2026-05-31');
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a forecastBetween failure (line 137) via a failing forecast fake', () => {
+    // fails if the forecast-fetch guard stops propagating. The real
+    // RecurringForecastService cannot fail here — calculateForWindow already
+    // validates the same from/to preconditions forecastBetween would check — so
+    // this guard is only drivable via a fake collaborator.
+    const windows = [splitWindow('2024-01-01', ['Alex', 0.5], ['Sam', 0.5])];
+    const splitsService = new SplitRulesService(windows);
+    const buffersService = new BufferStateService([], 'EUR', fakeLedger(new Map()));
+    const failingForecast = {
+      forecastBetween(): Result<readonly ForecastOccurrence[]> {
+        return Result.fail('forced forecastBetween failure (story-maint-29)');
+      },
+    };
+    const calc = new SafeTransferCalculator(
+      splitsService,
+      buffersService,
+      failingForecast as unknown as RecurringForecastService,
+      'EUR',
+    );
+    const result = calc.calculateForWindow('2026-04-28', '2026-05-01', '2026-05-31');
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a per-occurrence split lookup failure from buildForecastLineItems (lines 26 and 140)', () => {
+    // fails if the forecast-line-item build guard stops propagating. A recurring
+    // rule active since 2024 produces an occurrence dated before the split
+    // window's own validFrom, even though asOf (used for the top-level roster)
+    // is inside the window — the occurrence-level lookup fails independently.
+    const windows = [splitWindow('2026-06-01', ['Alex', 0.5], ['Sam', 0.5])];
+    const rules = [recurringRule('Rent', 'Rent', 100000, '2024-01-01')];
+    const calc = buildCalculator(windows, [], rules);
+    const result = calc.calculateForWindow('2026-06-15', '2026-05-01', '2026-06-30');
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a negative-ratio allocation failure from a forecast occurrence (line 30)', () => {
+    // fails if the forecast-occurrence allocate-failure guard stops propagating —
+    // a split window with a negative ratio is a config invariant this service
+    // does not itself validate
+    const windows = [splitWindow('2024-01-01', ['Alex', -0.2], ['Sam', 1.2])];
+    const rules = [recurringRule('Rent', 'Rent', 100000, '2024-01-01')];
+    const calc = buildCalculator(windows, [], rules);
+    const result = calc.calculateForWindow('2026-04-28', '2026-05-01', '2026-05-31');
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('skips a query-window month outside the buffer\'s own fill schedule (line 83 continue)', () => {
+    // fails if the indexByMonth undefined-lookup continue is removed — a query
+    // window wider than the buffer's own [asOf, targetDate) fill schedule would
+    // otherwise read past the fill-slot array
+    const windows = [splitWindow('2024-01-01', ['Alex', 0.5], ['Sam', 0.5])];
+    const { bucket, balance } = makeBucket('Vacation', 'assets:buffer:vacation', 100000, 0, '2026-07-01');
+    const calc = buildCalculator(windows, [{ bucket, balance }], []);
+    const result = calc.calculateForWindow('2026-04-28', '2026-05-01', '2026-08-31');
+    expect(result.isSuccess).toBe(true);
+    const topups = result.value.lineItems.filter(i => i.kind === 'buffer-topup');
+    expect(topups).toHaveLength(2);
+  });
+
+  it('propagates a per-month split lookup failure inside the buffer top-up loop (line 87)', () => {
+    // fails if the buffer-topup split-lookup guard stops propagating. The real
+    // SplitRulesService cannot fail here (every topup month is >= asOf, and asOf's
+    // own roster fetch already proved the earliest window has been reached), so
+    // this guard is only drivable via a fake collaborator that fails for one
+    // specific topup month.
+    const failOnDate = '2026-06-01';
+    const recordingSplits = {
+      getSplitsAsOf(date: string): Result<readonly { partner: string; ratio: number }[]> {
+        if (date === failOnDate) return Result.fail('forced topup split-lookup failure (story-maint-29)');
+        return Result.ok([{ partner: 'Alex', ratio: 0.5 }, { partner: 'Sam', ratio: 0.5 }]);
+      },
+    };
+    const { bucket, balance } = makeBucket('Vacation', 'assets:buffer:vacation', 100000, 0, '2026-08-01');
+    const buffersService = new BufferStateService([bucket], 'EUR', fakeLedger(new Map([[bucket.account, balance]])));
+    const forecastService = new RecurringForecastService([]);
+    const calc = new SafeTransferCalculator(
+      recordingSplits as unknown as SplitRulesService,
+      buffersService,
+      forecastService,
+      'EUR',
+    );
+    const result = calc.calculateForWindow('2026-05-28', '2026-06-01', '2026-07-31');
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a negative-ratio allocation failure from a buffer top-up month (line 91)', () => {
+    // fails if the buffer-topup allocate-failure guard stops propagating
+    const windows = [splitWindow('2024-01-01', ['Alex', -0.3], ['Sam', 1.3])];
+    const { bucket, balance } = makeBucket('Vacation', 'assets:buffer:vacation', 100000, 0, '2026-07-01');
+    const calc = buildCalculator(windows, [{ bucket, balance }], []);
+    const result = calc.calculateForWindow('2026-04-28', '2026-05-01', '2026-05-31');
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a buffer-state fetch failure (line 145) when a bucket\'s target currency mismatches the ledger', () => {
+    // fails if the top-level buffer-state-fetch guard stops propagating
+    const windows = [splitWindow('2024-01-01', ['Alex', 0.5], ['Sam', 0.5])];
+    const splitsService = new SplitRulesService(windows);
+    const mismatchedBucket: BufferBucket = {
+      name: 'Car',
+      account: 'assets:buffer:car',
+      target: makeUsd(100000),
+      targetDate: '2026-12-01',
+    };
+    const buffersService = new BufferStateService([mismatchedBucket], 'EUR', fakeLedger(new Map()));
+    const forecastService = new RecurringForecastService([]);
+    const calc = new SafeTransferCalculator(splitsService, buffersService, forecastService, 'EUR');
+    const result = calc.calculateForWindow('2026-04-28', '2026-05-01', '2026-05-31');
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('returns Result.fail when defaultCurrency is not a valid ISO 4217 code (line 162)', () => {
+    // fails if the zero-Money construction guard stops propagating
+    const windows = [splitWindow('2024-01-01', ['Alex', 0.5], ['Sam', 0.5])];
+    const splitsService = new SplitRulesService(windows);
+    const buffersService = new BufferStateService([], 'XXX', fakeLedger(new Map()));
+    const forecastService = new RecurringForecastService([]);
+    const calc = new SafeTransferCalculator(splitsService, buffersService, forecastService, 'XXX');
+    const result = calc.calculateForWindow('2026-04-28', '2026-05-01', '2026-05-31');
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('propagates a totalRequired-accumulation currency mismatch (line 170) when a rule\'s amount currency differs from defaultCurrency', () => {
+    // fails if the totalRequired accumulation guard stops propagating — a
+    // recurring rule's amount currency disagreeing with defaultCurrency is a
+    // config invariant this service does not itself validate
+    const windows = [splitWindow('2024-01-01', ['Alex', 0.5], ['Sam', 0.5])];
+    const rules: RecurringRule[] = [
+      { name: 'Rent', category: 'Rent', cadence: 'monthly', amount: makeUsd(100000), validFrom: '2024-01-01', amendments: [] },
+    ];
+    const calc = buildCalculator(windows, [], rules);
+    const result = calc.calculateForWindow('2026-04-28', '2026-05-01', '2026-05-31');
+    expect(result.isFailure).toBe(true);
+  });
+
+  it('falls back to zero for a partner outside the asOf roster (line 174) when a later split window introduces a new partner', () => {
+    // fails if the per-partner zero-fallback (?? zero) is removed — a partner who
+    // only appears in a LATER split window (not in the asOf roster) would
+    // otherwise throw on an undefined map lookup instead of defaulting to zero
+    const windows = [
+      splitWindow('2024-01-01', ['Alex', 1.0]),
+      splitWindow('2026-06-01', ['Alex', 0.5], ['Sam', 0.5]),
+    ];
+    const rules = [recurringRule('Rent', 'Rent', 100000, '2024-01-01')];
+    const calc = buildCalculator(windows, [], rules);
+    // asOf is in window 1 (Alex-only roster); the query window spans into window 2,
+    // where a "Sam" occurrence line item is produced.
+    const result = calc.calculateForWindow('2026-04-28', '2026-06-01', '2026-06-30');
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.perPartner.get('Sam')!.amount).toBeGreaterThan(0);
+  });
+
+  it('breaks a tied sort key without crashing and preserves both line items (line 158)', () => {
+    // fails if the lineItemSortKey comparator's tie branch (ka === kb -> 0) is
+    // removed and array.sort throws or drops an entry — two identical rules
+    // produce two line items with an identical sort key on the same date
+    const windows = [splitWindow('2024-01-01', ['Alex', 0.5], ['Sam', 0.5])];
+    const rules = [
+      recurringRule('Rent', 'Housing', 100000, '2024-01-01'),
+      recurringRule('Rent', 'Housing', 100000, '2024-01-01'),
+    ];
+    const calc = buildCalculator(windows, [], rules);
+    const result = calc.calculateForWindow('2026-04-28', '2026-05-01', '2026-05-31');
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.lineItems).toHaveLength(2);
+  });
+});

--- a/tests/unit/eslint-rules/boundary/layer-boundary.test.ts
+++ b/tests/unit/eslint-rules/boundary/layer-boundary.test.ts
@@ -32,6 +32,11 @@ describe('layer boundary — src/core/ forbids everything but dinero.js', () => 
     expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
   });
 
+  it('rejects a core file importing fast-check (devDependency half of the blocklist)', () => {
+    const messages = lintVirtualFile("import fc from 'fast-check';", 'src/core/example.ts');
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
   it('rejects a core file importing a src/infra path', () => {
     const messages = lintVirtualFile(
       "import { Database } from '../../infra/db/database.js';",
@@ -57,6 +62,14 @@ describe('layer boundary — src/infra/ forbids src/cli/', () => {
       'src/infra/example.ts',
     );
     expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('allows an infra file importing a core path (block does not over-restrict)', () => {
+    const messages = lintVirtualFile(
+      "import { Money } from '../core/shared/money.js';",
+      'src/infra/example.ts',
+    );
+    expect(messages.filter((m) => m.ruleId === 'no-restricted-imports')).toHaveLength(0);
   });
 });
 

--- a/tests/unit/eslint-rules/boundary/layer-boundary.test.ts
+++ b/tests/unit/eslint-rules/boundary/layer-boundary.test.ts
@@ -1,0 +1,79 @@
+// fails if: the no-restricted-imports boundary blocks in eslint-rules/boundary/index.js
+// stop rejecting a forbidden import for the layer they guard (CLAUDE.md § 2, #241/#228).
+import { Linter } from 'eslint';
+import { describe, it, expect } from 'vitest';
+import { boundaryConfig, forbiddenCoreExternalPaths } from '../../../../eslint-rules/boundary/index.js';
+
+const baseLanguageOptions = { languageOptions: { sourceType: 'module' as const, ecmaVersion: 2022 as const } };
+
+function lintVirtualFile(code: string, filename: string): ReturnType<Linter['verify']> {
+  const linter = new Linter({ configType: 'flat' });
+  return linter.verify(code, [baseLanguageOptions, ...boundaryConfig], { filename });
+}
+
+describe('layer boundary — src/core/ forbids everything but dinero.js', () => {
+  it('rejects a core file importing better-sqlite3', () => {
+    const messages = lintVirtualFile("import Database from 'better-sqlite3';", 'src/core/example.ts');
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('rejects a core file importing node:fs', () => {
+    const messages = lintVirtualFile("import { readFileSync } from 'node:fs';", 'src/core/example.ts');
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('rejects a core file importing bare fs (no node: prefix)', () => {
+    const messages = lintVirtualFile("import { readFileSync } from 'fs';", 'src/core/example.ts');
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('rejects a core file importing chalk (dynamic-blocklist proof — not statically enumerated)', () => {
+    const messages = lintVirtualFile("import chalk from 'chalk';", 'src/core/example.ts');
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('rejects a core file importing a src/infra path', () => {
+    const messages = lintVirtualFile(
+      "import { Database } from '../../infra/db/database.js';",
+      'src/core/example.ts',
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('allows a clean core file that only imports dinero.js', () => {
+    const messages = lintVirtualFile("import { dinero } from 'dinero.js';", 'src/core/example.ts');
+    expect(messages.filter((m) => m.ruleId === 'no-restricted-imports')).toHaveLength(0);
+  });
+
+  it('the forbidden-paths list includes chalk (proves it is dynamic, not a hand-authored subset)', () => {
+    expect(forbiddenCoreExternalPaths).toContain('chalk');
+  });
+});
+
+describe('layer boundary — src/infra/ forbids src/cli/', () => {
+  it('rejects an infra file importing a src/cli path', () => {
+    const messages = lintVirtualFile(
+      "import { program } from '../cli/program.js';",
+      'src/infra/example.ts',
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+});
+
+describe('layer boundary — categorize-command.ts forbids src/infra/db/ (#228)', () => {
+  it('rejects categorize-command.ts importing src/infra/db/database', () => {
+    const messages = lintVirtualFile(
+      "import { Database } from '../../infra/db/database.js';",
+      'src/cli/commands/categorize-command.ts',
+    );
+    expect(messages.some((m) => m.ruleId === 'no-restricted-imports')).toBe(true);
+  });
+
+  it('allows categorize-command.ts importing a non-db infra path', () => {
+    const messages = lintVirtualFile(
+      "import { AutoTagRules } from '../../infra/config/auto-tag-rules.js';",
+      'src/cli/commands/categorize-command.ts',
+    );
+    expect(messages.filter((m) => m.ruleId === 'no-restricted-imports')).toHaveLength(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,5 +12,20 @@ export default defineConfig({
       '@core': path.resolve(__dirname, './src/core'),
     },
     exclude: ['**/node_modules/**', '**/.claude/**', 'harness/**'],
+    coverage: {
+      provider: 'v8',
+      // `.ts`-only: `src/infra/db/migrations/*.sql` matches a bare `src/**` glob and
+      // v8/rolldown then tries (and audibly fails) to parse SQL as JS — harmless but
+      // noisy. Scoping to `*.ts` excludes it without excluding any source file.
+      include: ['src/**/*.ts'],
+      // CLAUDE.md § 5: 100% branch coverage on src/core/ is non-negotiable and now
+      // CI-gated; infra/cli are measured but not yet thresholded (deferred to #242 —
+      // a ratchet from a measured CI baseline, not an arbitrary number).
+      thresholds: {
+        'src/core/**': {
+          branches: 100,
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## 1. Story

Story maint-29 — maintenance/enforcement story (no `docs/epics.md` entry; targets tracker items [#209](https://github.com/xavierbriand/accounting/issues/209), [#241](https://github.com/xavierbriand/accounting/issues/241), absorbing [#228](https://github.com/xavierbriand/accounting/issues/228)). Plan: [docs/plans/story-maint-29.md](https://github.com/xavierbriand/accounting/blob/claude/project-review-critical-3stjy0/docs/plans/story-maint-29.md). **Lane: Full** (touches `src/core/` via `/* v8 ignore */` annotations).

## 2. Intent

The [2026-07-20 critical review](https://github.com/xavierbriand/accounting/blob/main/docs/reviews/2026-07-20-critical-project-review.md) found the repo's two most load-bearing trust claims are convention-enforced only. Pre-planning probe: `src/core` branch coverage was actually **88.44% (329/372, 43 uncovered branches)**, not the claimed 100%. Outcome: both claims are now CI-enforced gates — a coverage regression or a layer-rule violation turns the build red.

## 3. Alternatives considered

- `eslint-plugin-boundaries`/`import-x` — new dependency + R3 audit for what `no-restricted-imports` blocks express.
- Lower threshold (88%) + ratchet — leaves the flagship claim false; the gap was closable now.
- Contrived tests for unreachable guards — a test that cannot fail is itself a smell; annotations with why-comments are more honest.
- Separate CI coverage job — doubles suite runtime for no isolation benefit.

## 4. Selected solution & rationale

(1) `@vitest/coverage-v8` devDep (R3 audit in plan) + `coverage.thresholds` scoped `src/core/**` branches 100 in `vitest.config.ts`; CI test step now runs `npm run test:coverage` (single run). (2) All 43 gaps closed: **35 real tests** + **8 `/* v8 ignore next */` annotations** each with a why-comment naming the invariant that makes the guard unreachable — resolving #209's open design point. (3) `no-restricted-imports` boundary config (`eslint-rules/boundary/`) with a **dynamic blocklist** — all `package.json` `dependencies` **and `devDependencies`** except `dinero.js`, plus all Node builtins bare and `node:`-prefixed, so future deps are auto-blocked (Phase-2 P3-1 + Phase-4 P3-1): core → nothing external; infra → no cli; `categorize-command.ts` → no `infra/db` (closes #228). CLAUDE.md § 2/§ 5, docs/architecture.md, and engineering-standards § Coverage annotated as tool-enforced.

## 5. Gherkin scenarios

```gherkin
Feature: Convention-only claims become CI gates

  Scenario: Coverage gate holds src/core at 100% branches
    Given the repo's vitest coverage configuration
    When the full suite runs with coverage
    Then the run exits 0 and reports src/core branch coverage of 100%
    And the config declares a branches:100 threshold scoped to src/core/**

  Scenario: Boundary lint rejects a core-to-infra import
    Given the eslint boundary configuration
    When a virtual src/core file imports 'better-sqlite3', 'node:fs', bare 'fs', 'chalk', 'fast-check', or a src/infra path
    Then the boundary rule reports a no-restricted-imports error for each
    And the unmodified real tree passes npm run lint

  Scenario: Categorize no-DB restriction
    Given the categorize-specific restriction block
    When categorize-command.ts imports src/infra/db/database
    Then lint fails, and the real file passes today
```

`fails if` annotations and mechanism notes (R6/R7): plan § Gherkin. The two manual demo arms are captured in § 8 below.

## 6. Plan for Sonnet

Plan file § Slice plan — R13 envelope; 8 slices shipped (7 planned + 1 Phase-4 fix slice), within 6–10. **Post-plan correction:** the plan's slice subjects carried the bare id `maint-29`; dod-check's hard `missing-story-id` gate caught it on the first CI run and all subjects were reworded to the canonical `story-maint-29` form (commit contents untouched) — see retro Change A.

## 7. Suggestion log

Phase-2 log (13 plan-reviewer findings: 10 ADOPT / 2 ACKNOWLEDGE / 1 DEFER → [#242](https://github.com/xavierbriand/accounting/issues/242)) fully tagged in [the plan file § Suggestion log](https://github.com/xavierbriand/accounting/blob/claude/project-review-critical-3stjy0/docs/plans/story-maint-29.md#suggestion-log). Sibling-overlap: clean. Phase-4 dispositions:

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P2 | 13 findings — full tagged table in plan § Suggestion log | adopted ×10, acknowledged ×2, deferred ×1 | Deferred: #242 (infra/cli threshold ratchet) |
| P4 | P3-1: dynamic blocklist read `dependencies` only — devDependency imports into core passed silently | fix-now | `feat(lint): story-maint-29 phase-4 fixes` — devDeps included + `fast-check` reject fixture |
| P4 | P1-2: infra→cli block had no clean-pass fixture | fix-now | same commit — infra-imports-core clean-pass added |
| P4 | P3-4: missing trailing comma in eslint.config.js | fix-now | same commit |
| P4 | P1-1: Scenario 1 has no dedicated test file | acknowledged | Plan-approved at Phase 2 (P1-2 adopt): automated evidence = threshold config + green CI run; mutation demo in § 8; a red-half would be vitest-in-vitest (#147-class trap) |
| P4 | P3-2: slice-2 relabel (failing/green → green-on-landing) plan-vs-diff divergence | acknowledged | Honest R28 relabel, sibling condition in commit body; recorded in § 8 deviations |
| P4 | P3-3: result.ts misuse-throws now visibly tension with security-checklist "no throws in Core" | acknowledged | Pre-existing design, not introduced here; funneled to [#244](https://github.com/xavierbriand/accounting/issues/244) (checklist carve-out for invariant guards) |

## 8. Sonnet's learnings

**What was built:** boundary lint (`eslint-rules/boundary/` dynamic blocklist + 3 blocks) and the CI-gated 100%-branch threshold on `src/core/**`; 43 gaps closed (35 tests / 8 annotated); `npm run test:coverage` exits 0 at 356/356 core branches.

**Red → green:** failing boundary fixtures → boundary config green → result.ts / money.ts / remaining-guard tests (green-on-landing, R28) → v8-ignore annotations → gate wiring → docs notes; + Phase-4 fix slice (devDeps blocklist, clean-pass fixture).

**Deviations from plan (with rationale):**
- Slice 2 relabeled failing/green → green-on-landing: the result.ts guards pre-exist and the test passed immediately; a `— failing` subject that wasn't honestly failing would violate R6/R7.
- Fixed a pre-existing mis-targeted test in `buffer-state-service.test.ts` (fixture tripped the earlier `ltTarget` guard, never reaching the `lteCapResult` guard it claimed to cover).
- Annotation count 8 vs plan's ~13–18 estimate: several "unreachable-looking" guards proved drivable via fake collaborators (tested instead); three settlement guards are unreachable via an equivalent earlier same-function currency check — in-spirit generalization, applied consistently.
- `coverage.include` scoped to `'src/**/*.ts'` (not `'src/**'`) so v8 doesn't attempt migration `.sql` files; numbers unchanged.

**Unknowns:** `story-id-matcher` git-grep harness test fails only in the dev sandbox (shallow clone); CI checks out full history and passes — confirmed on the first CI run. One transient 2-test subprocess flake under coverage overhead; clean on re-runs.

**Mutation demo (gate is real)** — one guard test temporarily skipped, then restored:
```
ERROR: Coverage for branches (99.71%) does not meet "src/core/**" threshold (100%)
```
(exit code 1)

**Boundary lint demo** — `import 'better-sqlite3';` temporarily added to `src/core/shared/money.ts`, then reverted:
```
/home/user/accounting/src/core/shared/money.ts
  1:1  error  'better-sqlite3' import is restricted from being used. src/core/ depends on nothing but dinero.js — see CLAUDE.md § 2 (enforced by no-restricted-imports — story-maint-29)  no-restricted-imports

✖ 1 problem (1 error, 0 warnings)
```
(exit code 1)

## 9. Retrospective

- **Keep:** probe-before-planning (the 43-branch enumeration made Phase 3 discovery-free); layered review catching the same failure family twice (static blocklist at P2, devDeps gap at P4); the dod-check gate catching its own author's bare-id subjects in one CI run.
- **Change:** author slice-plan commit subjects in final matcher-satisfying form (third id-subject trap variant in two consecutive maintenance stories); drop annotation-count estimates, keep the classification rule.
- **Try:** funneled to [#244](https://github.com/xavierbriand/accounting/issues/244) (plan-template subject line + security-checklist invariant-throw carve-out). No new § 8 rule minted.

Full retrospective: [docs/retrospectives/story-maint-29.md](https://github.com/xavierbriand/accounting/blob/claude/project-review-critical-3stjy0/docs/retrospectives/story-maint-29.md)

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI (run 29783684737 on the final head — includes the new coverage-gated test step)
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-maint-29.md`
- [x] All suggestion-log items resolved (no blank `Resolution` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation — findings dispositioned in § 7, fixes in the phase-4 slice)
- [ ] User approval

Closes #209. Closes #241. Closes #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2pH8cjmHTAJkmg3ke8HEU