### PR TITLE
story-maint-32: Doc hygiene — plan-template final-form-subject line + security-checklist invariant-throw carve-out

### DIFF
--- a/docs/retrospectives/story-maint-32.md
+++ b/docs/retrospectives/story-maint-32.md
@@ -1,0 +1,119 @@
+# Story maint-32 retrospective
+
+**PR:** [#247](https://github.com/xavierbriand/accounting/pull/247)  **Closed:** pending merge  **Closes issues:** [#244](https://github.com/xavierbriand/accounting/issues/244)
+
+Doc-hygiene batch executing story-maint-29's two Try-funnel items ([#244](https://github.com/xavierbriand/accounting/issues/244)):
+the plan template's Slice-plan comment now requires commit subjects quoted in
+final, matcher-satisfying form, and the security checklist's Error-handling box
+carves out invariant/programmer-error throws. Light lane, plan folded into the
+PR body, no sonnet-implementer leg. 4 slices; 1 Phase-4 fix slice; 1 CI
+round-trip.
+
+## Keep
+
+- **The Phase-4 review caught the story's own subject matter being wrong.**
+  The whole point of this story was "stop authoring commit subjects from
+  memory — check them against the matcher." The first draft of that very line
+  was itself written from memory and conflated two distinct dod-check matchers:
+  `checkCommitSubjects` (`buildStoryIdRegExp` → hard `missing-story-id`) and
+  `PREP_COMMIT_SUBJECT` (literal `plan + P1/P2/P3 review` → envelope count).
+  A paraphrased prep subject *passes* the gate the line named, and fails a
+  different one. `code-reviewer` traced both call sites and produced the
+  correction. A doc-hygiene story is exactly where a review leg looks
+  skippable, and exactly where it paid.
+- **Dogfooding the new rule inside the story that writes it.** All five
+  subjects were verified against the live `buildStoryIdRegExp` (first for
+  `maint-30`, then re-verified for `maint-32` after the renumber below) via a
+  `tsx -e` one-liner before committing. Zero `missing-story-id` findings, for
+  *that* failure mode — against two consecutive prior stories that each ate a
+  history rewrite from it. The check costs one command; the trap it replaces
+  costs a `git reset --soft` + `--force-with-lease` cycle. A different failure
+  mode still forced that exact cycle anyway (see Change).
+
+## Change
+
+- **The maintenance sub-loop's R23 check is a snapshot, and this story's own
+  pause was long enough for the snapshot to go stale.** R23 verified
+  `story-maint-30` free against `origin/main` and open PR branch names at
+  pre-planning time (0 open PRs at branch cut). This session then stalled
+  ~8h on a usage limit. On resume, a concurrent session's PR #250 (closing
+  #245) had claimed the identical id and **merged into `main`** nine minutes
+  after this story's own PR opened — turning a live race into a settled fact.
+  Both PRs added byte-identical paths (`docs/retrospectives/story-maint-30.md`,
+  `docs/status.d/2026-07-21-story-maint-30.md`), so recovery wasn't a merge
+  conflict to resolve but a full renumber to `story-maint-32`: five commits
+  rewritten (`git reset --soft` to the pre-branch merge-base, cherry-pick +
+  `commit --amend` per slice, two file renames, self-references in the retro
+  and status fragment corrected), then rebased onto the now-current
+  `origin/main` and force-pushed with `--lease`. This is the same remedy the
+  Keep bullet above describes for a subject-form error — here forced by a
+  structurally different cause (an id race across sessions, invisible to a
+  branch-name-only check) that no amount of dogfooding the matcher could have
+  caught. Not filed as a new issue: `docs/retrospectives/story-maint-28.md`'s
+  Try section already proposes the fix (extend R23 to grep open PRs' *added
+  file paths*, not just branch names) — this session adds a second confirmed
+  occurrence to that existing record rather than opening a duplicate.
+- **Two consecutive stories' Try items funneled to one issue produced one
+  clean batch — but the batch's value was uneven.** The security-checklist
+  carve-out was a five-minute uncontroversial edit; the template line needed a
+  source trace through two harness modules and got the P1 finding. Batching by
+  *file ownership* ("both are user-owned canon docs") rather than by *risk*
+  meant the risky half rode in on the safe half's framing. The lane was still
+  right (Light — docs-only), but the plan should have flagged which half had
+  falsifiable claims about live code, so the review leg knew where to aim.
+- **The R16 envelope was reachable only because Phase 4 produced a fix
+  slice.** The canonical Light-lane shape landed at 3 counted body commits;
+  dod-check's `R16: { min: 4, max: 4 }` cannot accept that, so the token stays
+  undeclared and the story takes the advisory path — the third story in a row
+  to do so (maint-27, h14, this one). The fix slice brought it to exactly 4,
+  so R16 *is* declared here, but by accident of review outcome, not design.
+  [#239](https://github.com/xavierbriand/accounting/issues/239)'s option (a)
+  (recalibrate to min2/max3) now has three data points behind it.
+
+## Try
+
+- Re-run the maint-28 Change-C watch: that retro's Try said "if the prep-subject
+  wording drift recurs, promote it from watch to an explicit line quoting R30's
+  literal phrase." It recurred (as the P1 finding's guidance gap), and this PR
+  executes that promotion — the literal `plan + P1/P2/P3 review` phrase is now
+  quoted in the plan template itself. Same-PR edit:
+  [docs/templates/plan-template.md](../templates/plan-template.md).
+- When a Light-lane batch mixes a prose-only edit with one making falsifiable
+  claims about live code, say so in the PR body's scenario section so the
+  Phase-4 review aims at the second. Same-PR edit: this story's § 5 already
+  splits scenarios A/B by artifact, but did not flag A as source-traceable —
+  noted here rather than funneled, as it is authoring guidance, not a rule.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| R16 envelope range recalibration (three advisory-path stories now: maint-27, h14, maint-32) | [#239](https://github.com/xavierbriand/accounting/issues/239) | open |
+
+No new § 8 rule minted. The subject-form discipline landed as template prose
+(where it is read at authoring time) rather than as a loop-wide invariant —
+consistent with maint-29's own judgment that this is story-shape guidance.
+
+## Loop metrics (this run)
+
+- **Plan phase:** maintenance sub-loop (drain: closes #244, net −1 open item) +
+  plan folded into PR body (Light lane, R26); 0 open PRs at branch cut,
+  `story-maint-30` verified free — claimed by a concurrent session during
+  the session's usage-limit pause; renumbered to `story-maint-32` (see
+  Change).
+- **Phase 0/2:** skipped by lane (no model impact; no plan-reviewer /
+  sibling-overlap — sibling risk nil at 0 open PRs).
+- **Phase 3:** no sonnet-implementer leg — docs-only, coordinator-authored
+  (h14 precedent). Phase 3's Sonnet leg is vacuous for a docs-only story
+  rather than skipped: there is no implementation to delegate.
+- **Phase 4:** `code-reviewer` (5 findings: 1 P1, 4 P3 all soft) → 2 fix-now
+  (matcher conflation, bold placement), 1 PR-body fix (explicit R2 line),
+  2 acknowledged (#239 R16 prose, Light-lane Phase-3 vacuity).
+- **CI round-trips:** 1 (green on the 3-commit push; fix slice pushed after).
+- **Session note:** the first `code-reviewer` invocation died on a session
+  usage limit and was re-run verbatim after a model switch — no state lost,
+  since the review leg is read-only and the branch was already pushed. The
+  same pause caused the id collision above; a second history rewrite (5
+  commits) followed the Phase-4 fix rewrite, both on a solo unmerged draft
+  branch.
+- **Issues closed by this story:** #244. **Opened:** none.

--- a/docs/security-checklist.md
+++ b/docs/security-checklist.md
@@ -45,7 +45,7 @@ A failure of any item at P3-retro is a **merge blocker**, not a deferred suggest
 
 ## Error handling
 
-- [ ] Core returns `Result<T, E>`; no thrown exceptions inside Core.
+- [ ] Core returns `Result<T, E>`; no thrown exceptions inside Core for **domain failures**. Carve-out: invariant/programmer-error guards throw deliberately — contract misuse is a bug to surface loudly, not a domain outcome to model (e.g. `src/core/shared/result.ts` throws on Result misuse: accessing `.value` of a failure, constructing a success that carries an error). Tests may assert these throws directly; they are not checklist violations.
 - [ ] Infra catches only exceptions it can translate to `Result.fail`; others propagate.
 - [ ] No bare `catch` blocks that swallow errors.
 - [ ] CLI boundary converts `Result.fail` to a human-readable message plus a non-zero exit code.

--- a/docs/security-checklist.md
+++ b/docs/security-checklist.md
@@ -45,7 +45,7 @@ A failure of any item at P3-retro is a **merge blocker**, not a deferred suggest
 
 ## Error handling
 
-- [ ] Core returns `Result<T, E>`; no thrown exceptions inside Core for **domain failures**. Carve-out: invariant/programmer-error guards throw deliberately — contract misuse is a bug to surface loudly, not a domain outcome to model (e.g. `src/core/shared/result.ts` throws on Result misuse: accessing `.value` of a failure, constructing a success that carries an error). Tests may assert these throws directly; they are not checklist violations.
+- [ ] Core returns `Result<T, E>`; inside Core, **domain failures** never throw. Carve-out: invariant/programmer-error guards throw deliberately — contract misuse is a bug to surface loudly, not a domain outcome to model (e.g. `src/core/shared/result.ts` throws on Result misuse: accessing `.value` of a failure, constructing a success that carries an error). Tests may assert these throws directly; they are not checklist violations.
 - [ ] Infra catches only exceptions it can translate to `Result.fail`; others propagate.
 - [ ] No bare `catch` blocks that swallow errors.
 - [ ] CLI boundary converts `Result.fail` to a human-readable message plus a non-zero exit code.

--- a/docs/status.d/2026-07-21-story-maint-32.md
+++ b/docs/status.d/2026-07-21-story-maint-32.md
@@ -1,0 +1,17 @@
+---
+date: 2026-07-21
+story: maint-32
+pr: 247
+---
+
+Doc-hygiene batch from story-maint-29's retro Try funnel (#244), Light lane,
+plan-in-PR-body. Two user-owned-canon edits: the plan template's Slice-plan
+comment now requires commit subjects quoted in their final, matcher-satisfying
+form (checked against `buildStoryIdRegExp` at plan time — the trap that hit
+maint-28 and maint-29 in three variants), and the security checklist's
+Error-handling box now carves out invariant/programmer-error guards from the
+"no thrown exceptions inside Core" ban (domain failures return `Result`;
+contract misuse — e.g. `result.ts`'s accessor guards — throws deliberately).
+No new § 8 rule; net −1 open tracker item. Originally drafted as
+`story-maint-30`; renumbered after a concurrent session's PR claimed and
+merged that id during this session's usage-limit pause.

--- a/docs/templates/plan-template.md
+++ b/docs/templates/plan-template.md
@@ -55,10 +55,17 @@ program.ts is touched (R4).
 One slice = one behaviour (R13: 6–10 commits; R14 adapter: 5–7; R16
 zero-behaviour-change: 4 change-body). Subjects follow § 6.4 with the story
 id in every subject (R12: summary verbs).
-Quote subjects in their final, matcher-satisfying form: every subject must
-match `buildStoryIdRegExp` (harness/lib/story-id-matcher.ts), i.e. contain
-`story-<id>` — bare ids, superseded ids, and paraphrased prep subjects all
-fail dod-check's hard missing-story-id gate at CI (story-maint-28/-29).
+Quote subjects in their final, matcher-satisfying form and check them at plan
+time against dod-check's two distinct matchers
+(harness/dod-check/lib/commit-subject.ts) — they fail in different ways:
+  - Every subject must match `buildStoryIdRegExp`
+    (harness/lib/story-id-matcher.ts), i.e. contain `story-<id>`. A bare or
+    superseded id fails the hard `missing-story-id` gate at CI
+    (story-maint-28 Change A; story-maint-29).
+  - The R30 prep subject must carry the literal phrase
+    `plan + P1/P2/P3 review`. A paraphrase still carries the story id, so it
+    passes the gate above and is silently counted as a body slice, inflating
+    the envelope count instead (story-maint-28 Change C).
 -->
 
 ## Risks & deferred items

--- a/docs/templates/plan-template.md
+++ b/docs/templates/plan-template.md
@@ -55,6 +55,10 @@ program.ts is touched (R4).
 One slice = one behaviour (R13: 6–10 commits; R14 adapter: 5–7; R16
 zero-behaviour-change: 4 change-body). Subjects follow § 6.4 with the story
 id in every subject (R12: summary verbs).
+Quote subjects in their final, matcher-satisfying form: every subject must
+match `buildStoryIdRegExp` (harness/lib/story-id-matcher.ts), i.e. contain
+`story-<id>` — bare ids, superseded ids, and paraphrased prep subjects all
+fail dod-check's hard missing-story-id gate at CI (story-maint-28/-29).
 -->
 
 ## Risks & deferred items


### PR DESCRIPTION
## 1. Story

Story maint-32 — doc hygiene from [story-maint-29's retro](docs/retrospectives/story-maint-29.md) ([#244](https://github.com/xavierbriand/accounting/issues/244)). Not an epics.md entry — dev-loop maintenance (`scope: product-dev-loop`).

**Renumbered mid-session from `story-maint-30`.** The pre-planning check verified that id free; while this session was paused ~8h on a usage limit, a concurrent session's PR #250 (closing #245) claimed the identical id and merged into `main` first. Recovery was a full 5-commit history rewrite (not a merge conflict — both PRs added byte-identical retro/status-fragment paths), landing here as `story-maint-32`. Full account: [retro § Change](docs/retrospectives/story-maint-32.md).

**Lane: Light** (docs-only — two files under `docs/`, no `src/`, no `harness/` code, no `.claude/` specs). Per R26: plan folded into this PR body (§§ 1–6), Phase 0 skipped (**No model impact** — docs/process story, R24 default), Phase 2 skipped, Phase 4 = `code-reviewer` only, R16 commit collapse.

## 2. Intent

Two batched user-owned-canon edits funneled from story-maint-29's retro Try items:

1. **plan-template.md Slice-plan comment** — require commit subjects quoted in their final, matcher-satisfying form. Three variants of the non-matching-subject trap hit two consecutive maintenance stories (maint-28: superseded-id + paraphrased-prep; maint-29: bare-id), each caught only at CI, each costing a history rewrite.
2. **security-checklist.md Error-handling line** — carve out invariant/programmer-error guards from "no thrown exceptions inside Core". `src/core/shared/result.ts` deliberately throws on Result contract misuse, and story-maint-29's coverage tests assert those throws directly, making the tension visible (code-reviewer P3-3). The design is sound; the checklist prose predated the distinction.

## 3. Alternatives considered

- **Same-PR edit inside story-maint-29** — rejected there: template + checklist are user-owned canon riding many stories; funneled to a dedicated user-gated story instead (this one).
- **Ride-along with the next process-touching PR** (the issue's other option) — set aside: the user opened the story directly; a dedicated Light PR keeps the two canon edits reviewable in isolation.
- **Minting a § 8 rule for subject-form checking** — rejected in the maint-29 retro: story-shape guidance, not a loop-wide invariant; lands as template prose, not a rule row.
- **Also updating CLAUDE.md § 2's "never throw" cheat-sheet line** — set aside: that line describes *domain methods*, which still never throw under the carve-out; the misuse guards live in the `Result` class itself. `docs/` canon wins on conflict and now documents the distinction.

## 4. Selected solution & rationale

- **[docs/templates/plan-template.md](docs/templates/plan-template.md)** — the Slice-plan comment now names dod-check's **two distinct matchers** and their **different failure modes**: every subject must match `buildStoryIdRegExp` (`harness/lib/story-id-matcher.ts`) or fail the hard `missing-story-id` gate; *and* the R30 prep subject must carry the literal phrase `plan + P1/P2/P3 review`, because a paraphrase still carries the story id, passes that gate, and is silently counted as a body slice — inflating the envelope instead. Placing this in the template comment puts the check at the exact moment subjects are authored, the only point where it's free to fix. (The two-matcher split is the Phase-4 P1 correction; the first draft conflated them.)
- **[docs/security-checklist.md](docs/security-checklist.md)** — the Error-handling box now reads "inside Core, **domain failures** never throw" with an explicit carve-out: invariant/programmer-error guards throw deliberately (contract misuse is a bug to surface loudly, not a domain outcome to model), citing `result.ts`'s misuse throws as the canonical example, and stating that tests may assert those throws. This keeps the box tickable on every P3 walk without a documented-exception issue, while leaving the domain-failure ban fully intact.

**Production-code surface (R2): None.** No type, signature, `--json` shape, error code, or exit-code mapping changes — the diff is `docs/` prose only. Files touched: `docs/templates/plan-template.md`, `docs/security-checklist.md`, `docs/retrospectives/story-maint-32.md`, `docs/status.d/2026-07-21-story-maint-32.md`. R31 n/a (no CLI contract surface).

## 5. Gherkin scenarios

Prose acceptance (Light lane, no feature files — spec/process-story convention):

- **A — template line** *(source-traceable: makes falsifiable claims about live harness code — aim the review here)*. Given the plan template's Slice-plan comment, when a coordinator authors slice subjects from it, then the comment requires quoting them final-form and correctly attributes each failure mode to the matcher that produces it. *Fails if* the comment permits authoring subjects from memory, or misattributes a variant to the wrong gate (the Phase-4 P1: a paraphrased prep subject passes `missing-story-id` and fails the envelope count instead). Verification: doc prose traced to `harness/dod-check/lib/commit-subject.ts` call sites by the Phase-4 review (no in-process/subprocess mechanism — R7 n/a).
- **B — checklist carve-out** *(prose-only)*. Given the security-checklist's Error-handling section, when a P3 reviewer walks the no-throw box against `src/core/shared/result.ts`'s misuse guards (whose throws maint-29's tests assert directly), then the box is tickable without a documented exception because the carve-out classifies them as deliberate invariant guards — while domain failures still must return `Result`. *Fails if* the line reads as a blanket ban, forcing either a false tick or a spurious P3 merge-blocker on every walk (the maint-29 P3-3 tension).
- **Dogfood check** (verification, not a scenario): all five commit subjects were verified against the live `buildStoryIdRegExp` — first for `maint-30`, then re-verified for `maint-32` after the renumber — before pushing; all match, zero `missing-story-id` findings.

## 6. Plan for Sonnet

No sonnet-implementer leg — Light lane, two single-scope doc edits; coordinator authored directly (h14 precedent). Phase 3's Sonnet leg is *vacuous* for a docs-only story rather than skipped: there is no implementation to delegate.

**Slice plan** (subjects quoted final-form and verified against the matcher — the discipline slice 1 adds):

1. `chore(docs): plan-template Slice-plan comment — quote subjects final-form against buildStoryIdRegExp (story-maint-32)`
2. `chore(docs): security-checklist Error-handling carve-out — invariant throws are deliberate (story-maint-32)`
3. `refactor: empty slot — docs-only story, no structure to move (story-maint-32)` — R11 justification in the commit body
4. `fix(docs): Phase-4 corrections — split the two dod-check matchers, unambiguous no-throw scope (story-maint-32)`
5. `chore(retro): story-maint-32 retrospective + status fragment` — R30-exempt

(Authored and pushed once as `story-maint-30`; rewritten in place to `story-maint-32` after the id collision — same 5 slices, same content, `git reset --soft` to the pre-branch merge-base + cherry-pick/amend per slice + two file renames, rebased onto post-collision `origin/main`, `--force-with-lease`. Doc content of `plan-template.md`/`security-checklist.md` verified byte-identical across the rewrite.)

**Commit envelope: R16** — 4 counted body commits (2 `chore(docs)` + 1 empty `refactor:` + 1 Phase-4 `fix(docs)`; retro exempt; no prep commit — Light lane folds the plan into this body). Verified via `countSlices` = 4, inside R16's min4/max4. Note this only fits *because* Phase 4 produced a fix slice: the canonical 3-counted Light shape cannot declare R16 ([#239](https://github.com/xavierbriand/accounting/issues/239) — third story in a row to hit this, after maint-27 and h14).

**Maintenance sub-loop (§ 6.7) run 2026-07-21 pre-planning:**

- Sibling work: 0 open PRs; 46 open issues walked — none addressing #244's scope (#245/#246 are fresh unrelated intake).
- Story-id uniqueness (R23): `story-maint-30` free on `origin/main` (plans/retros/status.d) and in open PR branch names (none) *at pre-planning time* — claimed and merged by a concurrent session during this session's pause; renumbered to `story-maint-32` (see the renumbering note above and the retro).
- Working tree: clean; session branch `claude/issue-244-2af83b` at parity with `origin/main` (session-branch precedent: story-ddd-1).
- Open issues re-prioritised: [#239](https://github.com/xavierbriand/accounting/issues/239) directly governs this story's envelope handling (cited above); nothing stale closed beyond scope.
- Backlog refinement: skipped this sub-loop (not required every run; tracker refreshed in the recent h13-era pass).
- Open PRs / Dependabot: none *at pre-planning time*.
- `npm audit --audit-level=high`: 0 vulnerabilities *at pre-planning time*; drifted to 4 high (transitive: `brace-expansion`, `js-yaml`, `nanoid`, `postcss`, all lockfile-fixable) by push time via unrelated merges during the pause — filed as [#262](https://github.com/xavierbriand/accounting/issues/262), out of scope for this docs-only branch rather than fixed inline.
- Drain: this story closes [#244](https://github.com/xavierbriand/accounting/issues/244) (a Try-funnel deferred item) — net −1 open item.
- Proceed-to-planning: recorded here (plan-in-body, Light lane).

## 7. Suggestion log

Phase 2 skipped by lane (Light, R26 — no plan-reviewer, no sibling-overlap; sibling risk nil: 0 open PRs at branch cut, story id verified free). Phase-4 `code-reviewer` findings (5 total: 1 P1 / 4 P3, all four soft) dispositioned:

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| 4 | **P1/R5** — the new template line conflated two matchers: `checkCommitSubjects` tests only `buildStoryIdRegExp` (→ hard `missing-story-id`), while the paraphrased-prep-subject variant fails the separate literal `PREP_COMMIT_SUBJECT` regex (→ envelope count). The line misattributed that variant and gave no guidance for avoiding it. | **fix-now** | `946d113` — verified both call sites at [commit-subject.ts:28](harness/dod-check/lib/commit-subject.ts:28) and [:70](harness/dod-check/lib/commit-subject.ts:70); line now names both matchers, both failure modes, and R30's literal phrase |
| 4 | **P3 soft** — "no thrown exceptions inside Core for **domain failures**" momentarily misparses as narrowing *Core* rather than scoping the *ban*. | **fix-now** | `946d113` — reworded to "inside Core, **domain failures** never throw" |
| 4 | **P3 soft** — no explicit "Production-code surface (R2)" line in the PR body (the PR template folds it into § 4; only the plan template has a dedicated section). | **fix-now** | § 4 now carries an explicit `Production-code surface (R2): None` line with the file list |
| 4 | **P3 soft** — R16's § 8 row prose reads as if a prep commit is standard, which the Light lane doesn't produce; canonical shape yields 2–3 counted vs `min4`. | **acknowledged** | Pre-existing, already tracked at [#239](https://github.com/xavierbriand/accounting/issues/239); this story is its third data point (retro Change B) — not a gap introduced by this diff |
| 4 | **P3 soft** — the § 6 lane table names Phase 0/2/4 as lane-varying but not Phase 3, so Light-lane coordinator-direct authorship rests on precedent (h14) rather than stated policy. | **acknowledged** | No text added: for a docs-only story Phase 3's Sonnet leg is *vacuous* (nothing to implement), not skipped — so there is no deviation to codify. Stated explicitly in § 6 and the retro's metrics rather than expanding CLAUDE.md (h13 subtraction discipline) |

## 8. Sonnet's learnings

No sonnet-implementer leg (Light lane, docs-only — coordinator-authored; h14 precedent). The plan-time matcher verification ran as a `tsx -e` one-liner against the real `buildStoryIdRegExp`, and the envelope count was verified the same way against the real `countSlices` — both reflected in § 5 and § 6.

## 9. Retrospective

[docs/retrospectives/story-maint-32.md](docs/retrospectives/story-maint-32.md) — committed with the `chore(retro)` slice alongside the status fragment. The `docs/status.md` "Next" line is unchanged (no epic milestone), so the fragment lands alone per CLAUDE.md § 1.

- **Keep:** The Phase-4 review caught the story's own subject matter being wrong — a story about not authoring subjects from memory had its key line written from memory, conflating two matchers. A doc-hygiene story is exactly where a review leg looks skippable, and exactly where it paid.
- **Change:** Two distinct rewrite-forcing events, same remedy. (1) Batching the two Try items by *file ownership* rather than *risk* let the source-traceable half ride in on the prose-only half's framing — the plan should flag which half makes falsifiable claims about live code. (2) R23's uniqueness check is a snapshot; a concurrent session claimed and merged this story's id during a session pause, invisible to a branch-name-only check — forcing the id renumber above. Both required the identical `reset --soft` + recommit + `--force-with-lease` cycle, for unrelated root causes.
- **Try:** Executed maint-28's Change-C watch item — the literal `plan + P1/P2/P3 review` phrase is now quoted in the plan template (same-PR edit), promoting it from "watch for recurrence" to codified guidance.

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-maint-32.md`
- [x] All suggestion-log items resolved (no blank `Resolution` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [x] User approval

Closes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

