### PR TITLE
chore(deps): drop pixelmatch devDep — quickpickle ≥1.11.2 declares it an optional peer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.7.0",
         "fast-check": "^4.9.0",
-        "pixelmatch": "^6.0.0",
         "prettier": "^3.9.5",
         "quickpickle": "^1.11.2",
         "tsc-alias": "^1.9.1",
@@ -3823,19 +3822,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pixelmatch": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-6.0.0.tgz",
-      "integrity": "sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "pngjs": "^7.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
       }
     },
     "node_modules/plimit-lit": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.7.0",
     "fast-check": "^4.9.0",
-    "pixelmatch": "^6.0.0",
     "prettier": "^3.9.5",
     "quickpickle": "^1.11.2",
     "tsc-alias": "^1.9.1",


### PR DESCRIPTION
## What

Removes the `pixelmatch` direct devDependency (package.json + lockfile only, −15 lines).

## Why now

[#57](https://github.com/xavierbriand/accounting/issues/57) tracked quickpickle's undeclared `pixelmatch` import upstream, with the pre-agreed resolution: *"When upstream fixes, drop the pixelmatch entry from devDependencies."* Upstream fixed it — quickpickle 1.11.2 declares `pixelmatch` as an **optional peerDependency** and lazy-imports it (`await import('pixelmatch')`) only on the screenshot-comparison path, which this repo does not use. It even ships a graceful error message if the peer is absent.

## Validation

- `npm rm pixelmatch` resolves with no peer conflicts (optional peer honored)
- Full suite green without it: 119 files, 1263 passed / 1 pre-existing skip — the acceptance tier loads quickpickle as a vitest plugin, so the lazy-import path is exercised at plugin load
- `npm audit`: 0 vulnerabilities

## Side benefit

Ends the pixelmatch-major Dependabot noise: story-maint-28 had to exclude `pixelmatch` 7 from the dev-deps group bump by empirical probe (peer-range conflict). With no direct dep, there is nothing for Dependabot to bump.

Routine dependency chore per CLAUDE.md § 6.7 — no story DoR/DoD/retro. Surfaced as the maintenance sub-loop **drain** item of the story-maint-30 session (issue #245).

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)