### PR TITLE
story-maint-34: Move the CLAUDE.md conflict-resolution protocol into an on-demand command

### DIFF
--- a/.claude/commands/rebase-conflict-protocol.md
+++ b/.claude/commands/rebase-conflict-protocol.md
@@ -1,0 +1,26 @@
+WHEN_TO_USE: Load this when `git rebase origin/main` reports conflicts during the
+push protocol (CLAUDE.md § 6.4.1) — before resolving anything by hand.
+
+## Conflict-resolution protocol
+
+When a rebase conflict appears, the agent's reply must include three sections:
+
+1. **Diagnosis** — for each conflicted file: which hunks conflict, who introduced
+   the competing change (`git log --oneline origin/main -- <file>` and the local
+   commit), classification *mechanical* (independent edits to a shared structure)
+   vs *semantic* (same lines edited for different reasons).
+2. **Suggested resolutions** — at least two named options each with the concrete
+   edit. For mechanical conflicts on append-style sections (e.g. CLAUDE.md § 8 rule
+   table): "(a) keep both, stack chronologically (or by tag id)" / "(b) drop ours
+   and re-author after rebase if upstream supersedes." For semantic conflicts: name
+   the trade-off. `--ours`/`--theirs` only when one side is unambiguously stale.
+3. **Recommendation + question** — one-sentence pick with reason; explicit ask
+   before applying.
+
+If the conflict is on `docs/status.d/<file>` (rare — only if two retros pick the
+same `<date>-story-<id>` filename), the diagnosis must name that specifically and
+the Suggested-resolutions section must offer at least: **(a) rename the local
+fragment by appending `-b` to the story id** (e.g. `2026-04-28-story-B.md` →
+`2026-04-28-story-B-b.md`) so both fragments coexist verbatim; or **(b) merge the
+two fragment bodies into a single file** (rarely correct — only when the retros
+documented the same outcome).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,19 +123,9 @@ Full agent spec: [.claude/agents/sonnet-implementer.md](.claude/agents/sonnet-im
 - **Before every push:**
   1. `git fetch origin`
   2. `git rebase origin/main` (or `git pull --rebase` if upstream is the story branch)
-  3. If rebase reports **conflicts** → enter the Conflict-resolution protocol below. Do not auto-resolve.
+  3. If rebase reports **conflicts** → run the `rebase-conflict-protocol` command and follow it exactly. Do not auto-resolve.
   4. If rebase fails for **non-conflict reasons** (lockfile, detached HEAD, corruption, network failure mid-fetch, etc.) → stop, report the error verbatim to the user, ask before any recovery action (`git rebase --abort`, removing `.git/index.lock`, etc.). Never silently retry.
 - **Push only the current branch:** `git push origin HEAD`. Don't use bare `git push` if local `push.default` is unset/`matching` — it can advance `main` unintentionally.
-
-#### Conflict-resolution protocol
-
-When a rebase conflict appears, the agent's reply must include three sections:
-
-1. **Diagnosis** — for each conflicted file: which hunks conflict, who introduced the competing change (`git log --oneline origin/main -- <file>` and the local commit), classification *mechanical* (independent edits to a shared structure) vs *semantic* (same lines edited for different reasons).
-2. **Suggested resolutions** — at least two named options each with the concrete edit. For mechanical conflicts on append-style sections (e.g. CLAUDE.md § 8 rule table): "(a) keep both, stack chronologically (or by tag id)" / "(b) drop ours and re-author after rebase if upstream supersedes." For semantic conflicts: name the trade-off. `--ours`/`--theirs` only when one side is unambiguously stale.
-3. **Recommendation + question** — one-sentence pick with reason; explicit ask before applying.
-
-If the conflict is on `docs/status.d/<file>` (rare — only if two retros pick the same `<date>-story-<id>` filename), the diagnosis must name that specifically and the Suggested-resolutions section must offer at least: **(a) rename the local fragment by appending `-b` to the story id** (e.g. `2026-04-28-story-B.md` → `2026-04-28-story-B-b.md`) so both fragments coexist verbatim; or **(b) merge the two fragment bodies into a single file** (rarely correct — only when the retros documented the same outcome).
 
 ### 6.5 Refactor-during-green policy
 

--- a/docs/harness/control-inventory.md
+++ b/docs/harness/control-inventory.md
@@ -64,7 +64,7 @@ Gaps).
 | ddd-modeler | `.claude/agents/ddd-modeler.md` | sensor (Mode B) / guide (Mode A, generates candidate shapes before the fact) | inferential | judge (Mode A is advisor-shaped — recorded in the description field, not a second role value; see model note § Rejected alternatives) | user + main-session dialogue converges Mode A; Opus disposes Mode B findings | The one spec with a mode-dependent kind |
 | backlog-refiner | `.claude/agents/backlog-refiner.md` | sensor | inferential | advisor | user tags its proposed-actions table | Propose-only; never mutates the tracker |
 
-## Commands (`.claude/commands/*.md`, 4 files) — playbooks, no role
+## Commands (`.claude/commands/*.md`, 5 files) — playbooks, no role
 
 | Control | Where | Kind | Mechanism | Role | Paired counterpart | Notes/Gap |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -72,6 +72,7 @@ Gaps).
 | new-story-preflight | `.claude/commands/new-story-preflight.md` | guide (playbook) | inferential | — | maintenance-sub-loop template (step 1) | — |
 | refine-backlog | `.claude/commands/refine-backlog.md` | guide (playbook) | inferential | — | invokes backlog-refiner | — |
 | story-status | `.claude/commands/story-status.md` | guide (playbook) | inferential | — | none | Reads `docs/status.d/` + open PRs |
+| rebase-conflict-protocol | `.claude/commands/rebase-conflict-protocol.md` | guide (playbook) | inferential | — | CLAUDE.md § 6.4.1 push protocol | Loaded on demand during a rebase conflict; relocated out of always-loaded CLAUDE.md (story-maint-34) |
 
 ## drift-scan Checks (computational sensors)
 

--- a/docs/plans/story-maint-34.md
+++ b/docs/plans/story-maint-34.md
@@ -1,0 +1,175 @@
+# Story maint-34 — Move the CLAUDE.md conflict-resolution protocol into an on-demand command
+
+## Context
+
+Originated from a `/doctor` health-check run (harness maintenance, not a PRD-driven story). The
+doctor skill's Check 4 (migrate always-loaded content to lazy loading) found that CLAUDE.md's
+Conflict-resolution protocol (§ 6.4.1, ~9 lines / ~1.5k chars) is a detailed three-section
+template only relevant during an actual rebase conflict, yet was loaded into every session's
+context regardless. The user approved the migration at the doctor report's confirmation gate; this
+story formalizes that already-applied change into the standard commit/PR/retro shape.
+
+**No model impact** — pure harness/docs reorganization, no Core domain concept touched (R24
+default for maint/process stories).
+
+**Renumbered from story-maint-32 (Phase-4 finding).** This story originally planned and opened as
+`story-maint-32` (PR #263). The Phase-4 `sibling-overlap` re-check found that PR #247 — itself
+originally misnumbered `story-maint-30`, colliding with the already-merged #250 (a separate,
+earlier-flagged issue) — had been renumbered by a concurrent session to `story-maint-32` and
+merged to `main` while this story was mid-flight, landing `docs/retrospectives/story-maint-32.md`
++ `docs/status.d/2026-07-21-story-maint-32.md` for a wholly unrelated change (plan-template +
+security-checklist doc hygiene). A fresh R23 scan at renumbering time also found `story-maint-33`
+already claimed by another concurrent in-flight PR title (dev-dependencies bump). `story-maint-34`
+confirmed free against `origin/main`'s `docs/plans/`/`docs/retrospectives/`/`docs/status.d/` trees
+and every open PR title at renumbering time. See the retrospective for the full account.
+
+**Maintenance sub-loop (CLAUDE.md § 6.7) — this run, 2026-08-10.**
+
+- **Sibling work:** one open draft PR touches harness-adjacent surface (#255, story-maint-31,
+  `program.ts` wrapper extraction) — no file overlap with `CLAUDE.md`/`.claude/commands/`.
+  Dependabot PRs #257/#259/#260 (dep bumps) — `package.json`/`package-lock.json` only, no overlap.
+  #248 (story-5.0 epic intent refresh) — `docs/epics.md`/domain docs, no overlap. #247 (see
+  renumbering note above) — different files, no overlap with this story's actual surface. Full
+  sibling-overlap agent runs (Phase 2 and Phase 4) recorded in the Suggestion log below.
+- **Story-id uniqueness (R23):** re-checked at renumbering time — see renumbering note above.
+- **Open issues:** reviewed the full open list (50 issues). Nothing else stale enough to act on in
+  this story beyond the drain item below.
+- **`npm audit --audit-level=high`:** 4 high-severity transitive findings (brace-expansion,
+  js-yaml, nanoid, postcss) — already tracked in [#262](https://github.com/xavierbriand/accounting/issues/262)
+  (bug, umbrella) and [#261](https://github.com/xavierbriand/accounting/issues/261)
+  (deferred-suggestion, postcss-specific, fix available via `npm audit fix`). Pre-existing,
+  unrelated to this story's surface (`CLAUDE.md` + `.claude/commands/` only) — not fixed here;
+  re-confirmed both issues are still open and accurately describe current `npm audit` output.
+- **Drain:** re-justifying [#239](https://github.com/xavierbriand/accounting/issues/239)
+  (dod-check's R16 envelope `min4/max4` cannot fit the canonical R16 commit shape, since the tool
+  excludes `chore(retro)` from the count while CLAUDE.md § 8's R16 text includes it). This story's
+  own commit sequence below reproduces exactly the gap the issue describes — fresh corroboration
+  that it's still live. Not fixed here (a tool-logic fix belongs in its own harness story, per the
+  issue's own "pick one in a harness story" framing); the envelope token is left **undeclared** in
+  the Slice plan below, matching the maint-27/h14 precedent the issue documents. The Phase-4
+  `code-reviewer` run additionally surfaced a second, previously-unfiled tooling-conformance gap in
+  the same family (R30's prep-commit-subject regex vs. established precedent's phrasing) — see
+  Suggestion log.
+- **Backlog refinement:** skipped — not required every sub-loop (checklist item is optional); no
+  signal this session that the tracker needs a deeper pass beyond the open-issues skim above.
+- **Proceed-to-planning.**
+
+## Selected solution
+
+**Option A — new `.claude/commands/rebase-conflict-protocol.md`; CLAUDE.md keeps only the short
+"do not auto-resolve" pointer.** Chosen. Matches this repo's existing convention for lightweight
+commands (`.claude/commands/*.md`, no YAML frontmatter, opening `WHEN_TO_USE:` line — confirmed
+against `model-session.md`/`story-status.md`) rather than the generic `.claude/skills/<name>/SKILL.md`
+layout a generic checklist would default to. The one safety-critical prohibition ("do not
+auto-resolve") stays resident in CLAUDE.md § 6.4.1; only the multi-section template — needed in
+maybe one session in twenty — loads on demand. The command is also registered in
+`docs/harness/control-inventory.md`'s Commands table (R27 — mechanically enforced by drift-scan
+Check F; caught by the Phase-4 `code-reviewer` run, folded into this story rather than filed
+separately since it's a direct consequence of this story's own new file).
+
+**Option B — leave CLAUDE.md as-is.** Rejected. The protocol was resident in every session's
+context regardless of whether a conflict ever occurs in that session — est. ~375 tokens/session
+paid for content that's rarely relevant.
+
+**Option C — shrink the protocol's prose in place instead of relocating it.** Rejected. The
+three-section structure (diagnosis / suggested resolutions / recommendation+question) plus the
+`docs/status.d/` special case is the valuable part; cutting words would degrade the protocol
+itself rather than just its loading cost.
+
+## Production-code surface (R2)
+
+None. No `src/` types, signatures, or output formats touched — pure harness-doc reorganization.
+
+## Verification (pseudo-Gherkin, not automatable)
+
+No `.feature` files — this is a docs/harness-config change with no CLI-observable behavior
+change, same shape as story-maint-27/h14. Fenced as ` ```text ` rather than ` ```gherkin `
+deliberately, per [issue #198](https://github.com/xavierbriand/accounting/issues/198)
+(drift-scan's Gherkin↔step hard gate treats any ` ```gherkin ` block as scenarios needing real
+`.feature`/step-definition backing).
+
+```text
+Feature: Conflict-resolution protocol loads on demand instead of always
+
+  Scenario: CLAUDE.md keeps only the short pointer
+    Given CLAUDE.md § 6.4.1 previously inlined the full 3-section conflict-resolution template
+    When the migration lands
+    Then CLAUDE.md line ~126 references the `rebase-conflict-protocol` command
+    And the "#### Conflict-resolution protocol" heading no longer appears in CLAUDE.md
+
+  Scenario: the relocated command carries the protocol verbatim
+    Given the original template covered diagnosis / suggested-resolutions /
+      recommendation+question, plus the docs/status.d/ special case
+    When .claude/commands/rebase-conflict-protocol.md is created
+    Then its body matches the removed CLAUDE.md section's substance exactly
+    And it opens with a WHEN_TO_USE line, matching this repo's other command files
+      (no YAML frontmatter)
+
+  Scenario: the new command registers with the harness AND the control inventory
+    Given a new file exists at .claude/commands/rebase-conflict-protocol.md
+    When a Claude Code session starts in this repo
+    Then `rebase-conflict-protocol` appears in the available-skills listing
+    And docs/harness/control-inventory.md's Commands table lists it (R27, drift-scan Check F)
+```
+
+| Scenario | Verification mechanism (not a new test file) |
+| --- | --- |
+| 1 — CLAUDE.md trimmed | `git diff CLAUDE.md` |
+| 2 — command carries protocol verbatim | `git diff` on the new file vs. the block quoted in the originating doctor report; independently re-verified byte-identical (whitespace-normalized) by the Phase-4 `code-reviewer` run |
+| 3 — command registers (harness + inventory) | Skill listing: observed live in-session immediately after the file was written. Control inventory: `npx tsx harness/drift-scan/drift-scan.ts` Check F, and CI's "Run Harness Tests" step (`drift-scan.integration.test.ts`) |
+
+## Slice plan — R16 zero-behaviour-change collapse
+
+Per CLAUDE.md § 8 R16, a zero-behaviour-change harness/docs story collapses to 4 change-body
+commits. Per issue #239 (open, re-justified above), the envelope token is left **undeclared**:
+dod-check's counter excludes `chore(retro)` from the R16 count, so declaring `R16` here would
+produce a spurious "under target" advisory finding for a story that's actually shaped correctly.
+
+1. `chore(docs): story-maint-34 plan + P1/P2/P3 review (story-maint-34)` — this plan doc. *(prep commit, uncounted per R30; canonical subject form per CLAUDE.md § 6.4 — see Suggestion log for why this differs from the original `story-maint-32` commit's phrasing)*
+2. `feat(harness): add rebase-conflict-protocol command (story-maint-34)` — new `.claude/commands/rebase-conflict-protocol.md`, plus its `docs/harness/control-inventory.md` registration (R27).
+3. `docs: point CLAUDE.md push protocol at rebase-conflict-protocol command (story-maint-34)` — CLAUDE.md § 6.4.1 edit.
+4. `refactor: empty slot — nothing further to extract (story-maint-34)` — no-op; the relocation is already minimal (one file moved + registered, one pointer line changed).
+5. `chore(retro): story-maint-34 retrospective (story-maint-34)`.
+
+**Phase 3 (Implement) already happened** during the originating `/doctor` run, user-approved at
+its confirmation gate — same "probe/change collapses into Phase 1" precedent as
+story-maint-05/06/21/22/27. No Sonnet invocation.
+
+Squash on merge optional.
+
+## Risks & deferred items
+
+| Risk | Mitigation |
+| --- | --- |
+| A future session hits a rebase conflict and doesn't know to load the new command | The CLAUDE.md pointer at § 6.4.1 names the command explicitly ("run the `rebase-conflict-protocol` command and follow it exactly"), same reliability as any other command reference already in CLAUDE.md (e.g. `model-session`) |
+| R23's story-id uniqueness check has a real gap under high concurrency (this story hit it twice-removed, via #247's collision then its own renumbering racing #260/#263) | Not fixed here — a process-level fix (e.g., a claim-reservation mechanism) belongs in its own harness story. Flagged in the retrospective's Try section. |
+
+No new deferred-suggestion issues opened by this story.
+
+## Verification plan
+
+`git diff` review of both files against the doctor report's quoted blocks; confirm the new command
+appears in the skill listing and the control inventory; `npx tsx harness/drift-scan/drift-scan.ts`
+clean; no test suite run required beyond CI's standard `npm test` (R2: no production-code surface
+changed).
+
+## Suggestion log
+
+Phase 2 review is **Reduced lane** (`.claude/commands/` touched — CLAUDE.md § 6 lane table, R26):
+`sibling-overlap` only, `plan-reviewer` dropped. Phase 4 adds `code-reviewer` + a second
+`sibling-overlap` pass per the lane table.
+
+| # | Finding | Tag | Resolution |
+|---|---------|-----|------------|
+| 1 (P2, sibling-overlap) | Checked all 5 open PRs (#260, #259, #257, #255, #251) and all 46 open issues — none touch `CLAUDE.md` or `.claude/commands/`; none propose this extraction or overlap with the push-protocol/conflict-resolution surface. | acknowledge | No action needed — confirms the plan's own sibling-work check above. |
+| 2 (P1, code-reviewer) | New `.claude/commands/rebase-conflict-protocol.md` was not registered in `docs/harness/control-inventory.md`'s Commands table — R27 / drift-scan Check F violation, CI-verified failing (`drift-scan.integration.test.ts`, `real registry conforms` and 5 collateral tests). | fix-now | Registration folded into slice 2 (see Slice plan) rather than filed as a separate issue — direct, same-PR consequence of this story's own new file. |
+| 3 (P3, code-reviewer) | Original `story-maint-32` prep commit subject used "plan + P2 review" phrasing, which doesn't match `harness/dod-check/lib/commit-subject.ts`'s `PREP_COMMIT_SUBJECT` regex (expects literal "plan + P1/P2/P3 review", per CLAUDE.md § 6.4's own canonical text). Three prior Reduced-lane precedents (maint-22/24/25) carry the same non-matching phrasing — a pre-existing, unfiled tooling-conformance gap, distinct from #239. | fix-now (this story) / defer-issue (the broader precedent pattern) | This story's prep commit reworded to the literal canonical phrase during the renumbering rewrite. The broader pattern (3 prior stories, plus whether `commit-subject.ts`'s regex or CLAUDE.md's prose should flex) is out of scope for a 2-file doc-relocation story — filed as a follow-up issue (see retrospective Action items). |
+| 4 (P4, sibling-overlap) | **Blocking**: `story-maint-32` (this story's original id) collided with PR #247, renumbered to `story-maint-32` by a concurrent session and merged mid-flight. | fix-now | Story renumbered to `story-maint-34` (see Context renumbering note); this PR's branch history rewritten accordingly. |
+| 5 (soft, code-reviewer) | Gherkin scenario 3's "harness registration" verification leans on a transient in-session observation not independently re-derivable from the diff alone. | acknowledge | Low severity; the file's presence at the conventional path is independently re-verifiable, and Check F (added this renumbering) now gives scenario 3 a second, durable, CI-checked verification mechanism. |
+
+## DoR checklist
+
+- [x] Phase 0 (Model): `No model impact` declared above (R24).
+- [x] Phase 1 (Plan): complete in this document.
+- [x] Phase 2 (Critical review — sibling-overlap, Reduced lane): findings triaged above.
+- [x] Draft PR with template sections 1–6 filled.

--- a/docs/retrospectives/story-maint-34.md
+++ b/docs/retrospectives/story-maint-34.md
@@ -1,0 +1,85 @@
+# Story maint-34 retrospective
+
+**PR:** [#263](https://github.com/xavierbriand/accounting/pull/263)  **Closed:** pending merge
+
+Relocated CLAUDE.md's Conflict-resolution protocol (§ 6.4.1) into an on-demand
+`.claude/commands/rebase-conflict-protocol.md` command, per a `/doctor` health-check run's
+Check-4 (lazy-loading) proposal the user approved. Reduced lane, R16 zero-behaviour-change
+collapse. Opened as `story-maint-32`; renumbered to `story-maint-34` mid-flight after a real
+story-id collision surfaced at Phase 4 (see Change, below).
+
+## Keep
+
+- **The doctor-report-to-formal-PR pipeline works.** The change was fully specified and
+  user-approved during the `/doctor` session itself (quoted verbatim in the doctor report, which
+  doubled as the plan's evidence trail). Formalizing it afterward into the standard
+  plan/commits/review/retro shape needed zero re-derivation of what to build — only the process
+  scaffolding around an already-correct change. Same "Phase 3 collapses into Phase 1" precedent as
+  story-maint-05/06/21/22/27, extended to a doctor-originated change.
+- **Phase 4 caught two independent real problems a Phase-2-only pass would have missed.**
+  `code-reviewer` caught a CI-failing drift-scan Check F gap (the new command wasn't registered in
+  `docs/harness/control-inventory.md`) that Phase 2's `sibling-overlap`-only review has no
+  mechanism to catch (it doesn't read the diff against the control inventory). The Phase-4
+  `sibling-overlap` re-check caught the story-id collision — a Phase-2 check, run hours earlier,
+  necessarily can't see a collision that hadn't happened yet. This is exactly why the lane table
+  runs `sibling-overlap` at *both* Phase 2 and Phase 4, not just once.
+- **The renumbering recovery held together.** `git reset --soft origin/main` + selective
+  re-staging + `git mv` + content edits + `force-with-lease` push cleanly rebuilt a 4-commit R16
+  sequence under a new id without losing any work, and without the interactive-rebase tooling this
+  harness's own Bash tool disallows. Same "cherry-pick + amend" spirit as story-maint-29's subject
+  fixup, just via reset+recommit instead of cherry-pick.
+
+## Change
+
+- **R23's point-in-time check is not enough under this repo's actual concurrency.** This story's
+  id was claimed cleanly per R23 at Phase-1 time, then collided anyway — twice-removed, via a
+  *different* story's mid-flight renumbering landing on the same id independently. The
+  next-candidate id (`maint-33`) was *also* already claimed by another concurrent session by the
+  time the collision was discovered. Three sessions effectively contended for ids in the same
+  ~20-minute window. Filed as [#266](https://github.com/xavierbriand/accounting/issues/266) —
+  R23 needs either a claim mechanism or a documented cheap-recovery playbook, not just a
+  point-in-time scan.
+- **The R30 canonical prep-commit phrasing has silently drifted across multiple stories.** This
+  story's own first attempt used "plan + P2 review" instead of CLAUDE.md § 6.4's literal "plan +
+  P1/P2/P3 review" — the same substitution three prior Reduced-lane stories (maint-22/24/25) made.
+  `dod-check`'s exemption regex only recognizes the literal canonical form, so all four instances
+  are mis-classified as ordinary change-body commits rather than R30-exempt prep commits. Filed as
+  [#265](https://github.com/xavierbriand/accounting/issues/265) — either the regex should tolerate
+  the phrasing actually in use, or the plan template should quote the exact canonical subject the
+  way story-maint-29's Try item already did for slice-plan subjects (issue #244).
+- **A doctor-originated story has no natural "Phase 1" moment to run the maintenance sub-loop
+  before implementation.** Implementation happened first (inside `/doctor`, before any plan
+  existed), so the sibling-work/story-id/npm-audit checks all ran retroactively, after the change
+  was already made. It worked out fine here because the change was narrow and self-contained, but
+  a larger doctor-approved change could paint the session into a corner (e.g. discovering a real
+  sibling conflict only after the change is already applied and approved by the user). No action
+  this story — noting the pattern for the next doctor-originated maintenance PR.
+
+## Try
+
+- Disposition the fix for [#265](https://github.com/xavierbriand/accounting/issues/265) (prep-commit
+  regex) and [#266](https://github.com/xavierbriand/accounting/issues/266) (R23 concurrency) in a
+  future harness story — both are scoped with concrete options, same "pick one in a harness story"
+  shape as #239.
+- Consider whether `/doctor`-originated changes should run the maintenance sub-loop's sibling-work
+  and story-id checks *before* presenting the confirmation gate, not after — would have caught
+  this story's eventual collision one step earlier (though not necessarily in time, given the
+  collision's root cause happened in a fully separate session).
+
+## Drift scan (mandatory)
+
+- [x] Did this story introduce contradictions between CLAUDE.md and any `docs/` file? **No.** The
+  only CLAUDE.md change is the § 6.4.1 pointer edit; the relocated content is unchanged in
+  substance, just moved. `docs/harness/control-inventory.md` was updated in the same commit as the
+  file it describes, so no drift window opened there either.
+- [x] If yes, reconciled in this PR? N/A.
+
+## Action items
+
+| Item | Where it lands | Status |
+| --- | --- | --- |
+| dod-check prep-commit subject regex vs. established phrasing drift (4 stories) | [#265](https://github.com/xavierbriand/accounting/issues/265) | open |
+| R23 story-id uniqueness — race window under concurrent sessions | [#266](https://github.com/xavierbriand/accounting/issues/266) | open |
+
+No new § 8 rule minted — both lessons are tooling/process gaps with concrete fix options already
+scoped in their issues, not loop-wide invariants ready to codify yet.


### PR DESCRIPTION
## 1. Story

Harness maintenance — no `docs/epics.md` entry (non-product, process/harness story per CLAUDE.md § 6 lane table).

## 2. Intent

`/doctor`'s Check 4 (migrate always-loaded content to lazy loading) found that CLAUDE.md's
Conflict-resolution protocol (§ 6.4.1) — a detailed 3-section template only relevant during an
actual rebase conflict — was fully loaded into every session's context regardless. Moving it into
an on-demand command saves ~375 est. tokens/session of content most sessions never need, while the
safety-critical "do not auto-resolve" rule stays resident in CLAUDE.md.

## 3. Alternatives considered

- Leave CLAUDE.md as-is — rejected, pays the token cost every session for content needed in maybe one session in twenty.
- Shrink the protocol's prose in place instead of relocating it — rejected, the 3-section structure is the valuable part; cutting words would degrade the protocol itself.

## 4. Selected solution & rationale

New `.claude/commands/rebase-conflict-protocol.md`, matching this repo's existing lightweight-command convention (no YAML frontmatter, `WHEN_TO_USE:` opening line, per `model-session.md`/`story-status.md`). CLAUDE.md § 6.4.1 keeps only the one-line pointer + the "do not auto-resolve" prohibition. Full rationale: [docs/plans/story-maint-34.md § Selected solution](https://github.com/xavierbriand/accounting/blob/claude/context-engineering-dev-harness-e6aa82/docs/plans/story-maint-34.md#selected-solution).

## 5. Gherkin scenarios

No `.feature` files — docs/harness-config change with no CLI-observable behavior, pseudo-Gherkin fenced as `text` per #198 (drift-scan's Gherkin↔step hard gate). Full scenarios: [plan § Verification](https://github.com/xavierbriand/accounting/blob/claude/context-engineering-dev-harness-e6aa82/docs/plans/story-maint-34.md#verification-pseudo-gherkin-not-automatable).

```text
Feature: Conflict-resolution protocol loads on demand instead of always

  Scenario: CLAUDE.md keeps only the short pointer
    Given CLAUDE.md § 6.4.1 previously inlined the full 3-section conflict-resolution template
    When the migration lands
    Then CLAUDE.md references the `rebase-conflict-protocol` command
    And the "#### Conflict-resolution protocol" heading no longer appears in CLAUDE.md

  Scenario: the relocated command carries the protocol verbatim
    Given the original template covered diagnosis / suggested-resolutions / recommendation+question
    When .claude/commands/rebase-conflict-protocol.md is created
    Then its body matches the removed CLAUDE.md section's substance exactly

  Scenario: the new command registers with the harness
    Given a new file exists at .claude/commands/rebase-conflict-protocol.md
    When a Claude Code session starts in this repo
    Then `rebase-conflict-protocol` appears in the available-skills listing
```

## 6. Plan for Sonnet

No Sonnet invocation — Phase 3 (Implement) collapsed into the Phase 1 probe: the change was
already applied and user-approved during the originating `/doctor` session (R16 zero-behaviour
precedent, same shape as story-maint-05/06/21/22/27). Full plan: [docs/plans/story-maint-34.md](https://github.com/xavierbriand/accounting/blob/claude/context-engineering-dev-harness-e6aa82/docs/plans/story-maint-34.md).

## 7. Suggestion log

Phase 2 review is **Reduced lane** (`.claude/commands/` touched — CLAUDE.md § 6 lane table, R26): `sibling-overlap` only, `plan-reviewer` dropped. Phase 4 adds `code-reviewer` + a second `sibling-overlap` pass per the lane table. Full log: [plan § Suggestion log](https://github.com/xavierbriand/accounting/blob/claude/context-engineering-dev-harness-e6aa82/docs/plans/story-maint-34.md#suggestion-log).

| Phase | Suggestion | Resolution | Link / Reason |
| --- | --- | --- | --- |
| P2 (sibling-overlap) | Checked all 5 open PRs and all 46 open issues — none touch `CLAUDE.md` or `.claude/commands/`; none overlap with this narrow change. | acknowledge | No action needed. |
| P4 (code-reviewer) | New command wasn't registered in `docs/harness/control-inventory.md` — R27/drift-scan Check F, CI-verified failing. | fix-now | Registration folded into the `feat(harness)` commit; verified locally (`drift-scan` exit 0, `npm run test:harness` 379/379 green) before pushing. |
| P4 (code-reviewer) | Original prep-commit subject phrasing ("plan + P2 review") didn't match dod-check's `PREP_COMMIT_SUBJECT` regex; 3 prior stories share the gap. | fix-now (this story) / defer-issue (broader pattern) | This story's prep commit reworded to the literal canonical phrase. Broader 3-story pattern filed as a follow-up issue. |
| P4 (sibling-overlap) | **Blocking**: this story's original id `story-maint-32` collided with PR #247, independently renumbered to `story-maint-32` by a concurrent session and merged mid-flight. | fix-now | Renumbered to `story-maint-34`; branch history rewritten (force-with-lease push) under the corrected id. |

## 8. Sonnet's learnings

N/A — no Sonnet invocation this story (see § 6). The change was implemented directly during the
originating `/doctor` session, user-approved at its confirmation gate, before this plan/PR
formalized it.

## 9. Retrospective

- **Keep:** the doctor-report-to-formal-PR pipeline needed zero re-derivation; Phase 4 caught two real problems (CI-failing control-inventory gap, the story-id collision) a Phase-2-only pass structurally couldn't have seen.
- **Change:** R23's point-in-time uniqueness check isn't enough under this repo's actual concurrency (this story's id collided *and* its replacement candidate was also already taken); the R30 canonical prep-commit phrasing has silently drifted across 4 stories now.
- **Try:** disposition both filed issues in a future harness story; consider whether doctor-originated changes should run sibling-work/story-id checks before the confirmation gate rather than after.

Full retrospective: [docs/retrospectives/story-maint-34.md](https://github.com/xavierbriand/accounting/blob/claude/context-engineering-dev-harness-e6aa82/docs/retrospectives/story-maint-34.md)

## 10. Merge checklist

- [x] `lint` / `build` / `test` green on CI
- [x] PR out of draft
- [x] Retrospective file committed at `docs/retrospectives/story-maint-34.md`
- [x] All suggestion-log items resolved (no blank `Resolution` cells)
- [x] All phase-4 retro-checks pass (P1 + P2 + P3 against the implementation)
- [ ] User approval
