### PR TITLE
v0.2 part 2: agent-obs capture + fingerprint (phases A and B)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/agent-obs/hooks/session-outcome.ts\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/agent-obs/hooks/session-outcome.ts\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,14 @@
 {
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
+    "OTEL_TRACES_EXPORTER": "otlp",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+    "OTEL_SERVICE_NAME": "sluice-agent"
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .claude/settings.local.json
 .claude/worktrees/
+agent-obs/.state/

--- a/agent-obs/Justfile
+++ b/agent-obs/Justfile
@@ -1,0 +1,42 @@
+default:
+    @just --list
+
+up:
+    docker compose -f compose.yaml up -d
+    @echo "Grafana  http://localhost:3000"
+    @echo "Phoenix  http://localhost:6006"
+
+down:
+    docker compose -f compose.yaml down
+
+logs:
+    docker compose -f compose.yaml logs -f --tail=50
+
+# Sends one span through the collector to both backends. Exits non-zero if the
+# collector does not accept it.
+smoke:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    trace_id=$(openssl rand -hex 16)
+    now=$(python3 -c 'import time;print(int(time.time()*1e9))')
+    code=$(curl -s -o /dev/null -w '%{http_code}' -X POST http://localhost:4318/v1/traces \
+      -H 'content-type: application/json' \
+      -d "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"sluice-agent\"}}]},\"scopeSpans\":[{\"spans\":[{\"traceId\":\"${trace_id}\",\"spanId\":\"$(openssl rand -hex 8)\",\"name\":\"agent_obs.smoke\",\"kind\":1,\"startTimeUnixNano\":\"${now}\",\"endTimeUnixNano\":\"${now}\"}]}]}]}")
+    [ "$code" = "200" ] || { echo "collector rejected span: HTTP $code"; exit 1; }
+    echo "accepted. trace_id=${trace_id}"
+    echo "Grafana  http://localhost:3000/explore  (Tempo, search this trace id)"
+    echo "Phoenix  http://localhost:6006"
+
+# Non-negotiable in Phase A: a dead endpoint must not stall a session.
+# Run with the stack DOWN. Passes if the hook exits 0, quickly.
+smoke-offline:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if docker compose -f compose.yaml ps --status running -q 2>/dev/null | grep -q .; then
+      echo "stack is UP — run 'just down' first; this test is only meaningful offline"; exit 1
+    fi
+    start=$(python3 -c 'import time;print(time.time())')
+    echo '{"session_id":"offline-test","hook_event_name":"Stop"}' | node hooks/session-outcome.ts
+    elapsed=$(python3 -c "import time;print(round(time.time()-${start},2))")
+    echo "hook exited 0 with collector down, in ${elapsed}s"
+    python3 -c "import sys;sys.exit(0 if ${elapsed} < 10 else 1)" || { echo "TOO SLOW"; exit 1; }

--- a/agent-obs/Justfile
+++ b/agent-obs/Justfile
@@ -2,15 +2,15 @@ default:
     @just --list
 
 up:
-    docker compose -f compose.yaml up -d
+    docker compose -p sluice-agent-obs -f compose.yaml up -d
     @echo "Grafana  http://localhost:3000"
     @echo "Phoenix  http://localhost:6006"
 
 down:
-    docker compose -f compose.yaml down
+    docker compose -p sluice-agent-obs -f compose.yaml down
 
 logs:
-    docker compose -f compose.yaml logs -f --tail=50
+    docker compose -p sluice-agent-obs -f compose.yaml logs -f --tail=50
 
 # Sends one span through the collector to both backends. Exits non-zero if the
 # collector does not accept it.
@@ -32,7 +32,7 @@ smoke:
 smoke-offline:
     #!/usr/bin/env bash
     set -euo pipefail
-    if docker compose -f compose.yaml ps --status running -q 2>/dev/null | grep -q .; then
+    if docker compose -p sluice-agent-obs -f compose.yaml ps --status running -q 2>/dev/null | grep -q .; then
       echo "stack is UP — run 'just down' first; this test is only meaningful offline"; exit 1
     fi
     start=$(python3 -c 'import time;print(time.time())')

--- a/agent-obs/README.md
+++ b/agent-obs/README.md
@@ -1,0 +1,55 @@
+# agent-obs
+
+Observability for two workloads through one pipeline: P1 in production
+(`service.name=sluice`) and agent sessions (`service.name=sluice-agent`).
+
+It lives inside this repo because its fingerprint hashes this repo's config. A
+sibling repo would be a second thing to keep in sync for no gain.
+
+## Run
+
+```bash
+source agent-obs/env.sh   # then run claude from the same shell
+cd agent-obs && just up   # Grafana :3000, Phoenix :6006
+just smoke                # one span end-to-end
+just smoke-offline        # stack DOWN: proves a dead collector cannot stall a session
+```
+
+## Shape
+
+```
+claude (native OTel)  ──grpc:4317──┐
+                                   ├──> collector ──┬──> LGTM    (traces+metrics+logs)
+hooks/session-outcome ──http:4318──┘                └──> Phoenix (traces)
+```
+
+Claude Code emits `claude_code.interaction` / `.llm_request` / `.tool` natively.
+Do not hand-roll session or tool spans.
+
+You cannot mutate a span you did not create, so the fingerprint rides a **sibling**
+span, `agent_obs.session_outcome`, joined to the session on `session.id`. When
+`TRACEPARENT` is present the sibling lands inside the session's own trace.
+
+## Verified (2026-08-14)
+
+- Hook exits 0 in ~0s against a refused endpoint, ~2s against a black-holed one.
+  `AbortSignal.timeout` does **not** cut undici's connect phase — it ran to
+  undici's 10s connect timeout until a hard watchdog was added. Measured, not assumed.
+- OTLP JSON accepted by a listener; `TRACEPARENT` correctly joined; model read
+  from the live transcript.
+- **Not yet verified end-to-end** — no container runtime on this machine yet, so
+  no span has reached Grafana or Phoenix. `just up` / `just smoke` are unrun.
+
+## Known gaps
+
+- `agent.mcp_servers` only sees repo-level `.mcp.json` / `.claude/settings.json`.
+  Servers configured at user scope are invisible to the fingerprint.
+- `agent.version` reads `claude --version`; records `unknown` when not on PATH.
+- Traces are beta. For **interactive** CLI sessions they also require org
+  allowlisting; `-p`/SDK sessions are not gated. If interactive waterfalls never
+  appear, that gate is the first thing to check, not this config.
+
+## Phases
+
+A capture · B fingerprint — here. C outcomes (needs a test suite) · D replay
+suite · E views as code — later, behind the dogfood gate.

--- a/agent-obs/README.md
+++ b/agent-obs/README.md
@@ -9,11 +9,14 @@ sibling repo would be a second thing to keep in sync for no gain.
 ## Run
 
 ```bash
-source agent-obs/env.sh   # then run claude from the same shell
 cd agent-obs && just up   # Grafana :3000, Phoenix :6006
 just smoke                # one span end-to-end
 just smoke-offline        # stack DOWN: proves a dead collector cannot stall a session
 ```
+
+Claude Code picks up telemetry from `env` in `.claude/settings.json` — no shell
+setup. `env.sh` is only for subprocesses (the eval runner), which do not inherit
+`OTEL_*` from the session.
 
 ## Shape
 
@@ -32,13 +35,22 @@ span, `agent_obs.session_outcome`, joined to the session on `session.id`. When
 
 ## Verified (2026-08-14)
 
-- Hook exits 0 in ~0s against a refused endpoint, ~2s against a black-holed one.
-  `AbortSignal.timeout` does **not** cut undici's connect phase — it ran to
-  undici's 10s connect timeout until a hard watchdog was added. Measured, not assumed.
-- OTLP JSON accepted by a listener; `TRACEPARENT` correctly joined; model read
-  from the live transcript.
-- **Not yet verified end-to-end** — no container runtime on this machine yet, so
-  no span has reached Grafana or Phoenix. `just up` / `just smoke` are unrun.
+Stack up, `just smoke` accepted, and the span confirmed **present in both Tempo
+and Phoenix** — the fan-out works, not just the receive.
+
+The `agent_obs.session_outcome` span reached both backends carrying all nine
+fingerprint attributes, correctly parented under `TRACEPARENT`, with the model
+read live from the transcript (`claude-opus-5`).
+
+Resilience, measured rather than assumed: the hook exits 0 in ~0s against a
+refused endpoint and ~2s against a black-holed one. `AbortSignal.timeout` does
+**not** cut undici's connect phase — the first version ran to undici's 10s connect
+timeout, stalling every session stop, until a hard watchdog was added.
+
+**Still unverified: the native `claude_code.*` waterfall.** No session has yet
+started with telemetry enabled, so nothing has emitted `claude_code.interaction`.
+The `env` block landed after this session began; the first session started *after*
+it should produce the waterfall, and that is what closes M0.
 
 ## Known gaps
 

--- a/agent-obs/compose.yaml
+++ b/agent-obs/compose.yaml
@@ -1,0 +1,43 @@
+# Collector fans out to two backends. Nothing else in the repo talks OTLP directly —
+# everything goes through the collector on 4317/4318 so the backends can be swapped
+# without touching any emitter.
+
+name: sluice-agent-obs
+
+services:
+  collector:
+    image: otel/opentelemetry-collector-contrib:0.158.0
+    command: ["--config=/etc/otel/config.yaml"]
+    volumes:
+      - ./otel/config.yaml:/etc/otel/config.yaml:ro
+    ports:
+      - "4317:4317" # OTLP gRPC  — Claude Code native telemetry
+      - "4318:4318" # OTLP HTTP  — session-outcome hook (no npm deps, raw JSON)
+    depends_on:
+      - lgtm
+      - phoenix
+
+  # Grafana + Tempo + Prometheus + Loki in one process. Claude Code emits traces,
+  # metrics AND logs; a bare trace backend would silently drop two of the three.
+  lgtm:
+    image: grafana/otel-lgtm:0.30.2
+    ports:
+      - "3000:3000" # Grafana UI
+    environment:
+      - ENABLE_LOGS_ALL=true
+    volumes:
+      - lgtm-data:/data
+
+  # LLM-native view: OpenInference conventions, datasets, LLM-as-judge.
+  phoenix:
+    image: arizephoenix/phoenix:20.2.0
+    ports:
+      - "6006:6006" # Phoenix UI
+    environment:
+      - PHOENIX_WORKING_DIR=/mnt/data
+    volumes:
+      - phoenix-data:/mnt/data
+
+volumes:
+  lgtm-data:
+  phoenix-data:

--- a/agent-obs/compose.yaml
+++ b/agent-obs/compose.yaml
@@ -2,7 +2,8 @@
 # everything goes through the collector on 4317/4318 so the backends can be swapped
 # without touching any emitter.
 
-name: sluice-agent-obs
+# Project name is passed as `-p sluice-agent-obs` rather than a top-level `name:`,
+# which Compose only learned in 2.3.3.
 
 services:
   collector:

--- a/agent-obs/env.sh
+++ b/agent-obs/env.sh
@@ -1,4 +1,10 @@
-# source agent-obs/env.sh  — then run `claude` from the same shell.
+# For SUBPROCESSES only — the eval runner, scripts, anything not Claude Code itself.
+#
+# Claude Code sessions in this repo get these from `env` in .claude/settings.json
+# instead. That matters: Claude Code here runs inside the desktop app, launched
+# from Finder, which never sees a shell's exports — `source env.sh && claude`
+# silently does nothing. settings.json is read by Claude Code itself, so it works
+# in both the app and the standalone CLI, and it version-controls with the repo.
 #
 # Claude Code emits interaction/llm_request/tool spans natively. Do not hand-roll
 # session or tool spans; the only thing this repo emits is the sibling

--- a/agent-obs/env.sh
+++ b/agent-obs/env.sh
@@ -1,0 +1,25 @@
+# source agent-obs/env.sh  — then run `claude` from the same shell.
+#
+# Claude Code emits interaction/llm_request/tool spans natively. Do not hand-roll
+# session or tool spans; the only thing this repo emits is the sibling
+# agent_obs.session_outcome span (see hooks/session-outcome.ts).
+
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1   # traces are beta-gated
+
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+# Two workloads share this collector. This is the agent one; P1 in production
+# uses service.name=sluice.
+export OTEL_SERVICE_NAME=sluice-agent
+
+# Claude Code does NOT pass OTEL_* to subprocesses (hooks, Bash, MCP servers),
+# so the hook reads its endpoint from this variable instead and defaults to
+# localhost when unset. TRACEPARENT *is* propagated, which is what lets the
+# outcome span join the session's trace.
+export SLUICE_OTLP_HTTP_ENDPOINT=http://localhost:4318

--- a/agent-obs/hooks/session-outcome.ts
+++ b/agent-obs/hooks/session-outcome.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// Emits agent_obs.session_outcome — a SIBLING span to Claude Code's native
+// claude_code.interaction tree. You cannot mutate a span you did not create, so
+// the fingerprint rides its own span and is joined on session.id at query time.
+//
+// Zero dependencies on purpose: raw OTLP/HTTP JSON over fetch. No SDK to keep in
+// step with a beta trace shape, and no npm install before the P1 stack is chosen.
+//
+// SessionStart captures the config the session began under; Stop emits.
+
+import { createHash, randomBytes } from 'node:crypto';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const STATE_DIR = join(REPO, 'agent-obs', '.state');
+const ENDPOINT = process.env.SLUICE_OTLP_HTTP_ENDPOINT ?? 'http://localhost:4318';
+const EXPORT_TIMEOUT_MS = 2000;
+
+// Files whose content defines how the agent behaves. A change to any of these is
+// a different agent, and comparing runs across such a change is comparing apples
+// to oranges — which is the entire reason the fingerprint exists.
+const FINGERPRINTED = ['CLAUDE.md', '.claude/settings.json', '.mcp.json', 'agent-obs/evals/rubric.md'];
+
+type HookInput = {
+  session_id?: string;
+  hook_event_name?: string;
+  transcript_path?: string;
+  cwd?: string;
+};
+
+type Attr = { key: string; value: Record<string, unknown> };
+
+function str(key: string, value: string): Attr {
+  return { key, value: { stringValue: value } };
+}
+
+function int(key: string, value: number): Attr {
+  return { key, value: { intValue: String(value) } };
+}
+
+function strArray(key: string, values: string[]): Attr {
+  return { key, value: { arrayValue: { values: values.map((v) => ({ stringValue: v })) } } };
+}
+
+function sha256(path: string): string {
+  try {
+    return createHash('sha256').update(readFileSync(path)).digest('hex');
+  } catch {
+    return 'absent';
+  }
+}
+
+function agentVersion(): string {
+  try {
+    return execFileSync('claude', ['--version'], { encoding: 'utf8', timeout: 5000 }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function mcpServers(): string[] {
+  for (const candidate of ['.mcp.json', '.claude/settings.json']) {
+    try {
+      const parsed = JSON.parse(readFileSync(join(REPO, candidate), 'utf8'));
+      const servers = parsed.mcpServers;
+      if (servers) return Object.keys(servers).sort();
+    } catch {
+      // Not present, or not valid JSON. Either way there is nothing to report.
+    }
+  }
+  return [];
+}
+
+function skills(): string[] {
+  try {
+    return readdirSync(join(REPO, '.claude', 'skills'), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+// The transcript is the only place the model actually used is recorded; the hook
+// payload does not carry it.
+function modelFromTranscript(transcriptPath: string | undefined): string {
+  if (!transcriptPath || !existsSync(transcriptPath)) return 'unknown';
+  try {
+    const lines = readFileSync(transcriptPath, 'utf8').split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      if (!lines[i]) continue;
+      const model = JSON.parse(lines[i])?.message?.model;
+      if (typeof model === 'string') return model;
+    }
+  } catch {
+    // A truncated or mid-write transcript is not worth failing a session over.
+  }
+  return 'unknown';
+}
+
+function fingerprint(input: HookInput): Attr[] {
+  const attrs: Attr[] = [
+    str('agent.version', agentVersion()),
+    strArray('agent.mcp_servers', mcpServers()),
+    strArray('agent.skills', skills()),
+    str('agent.model', modelFromTranscript(input.transcript_path)),
+  ];
+  for (const file of FINGERPRINTED) {
+    attrs.push(str(`agent.config_sha256.${file.replace(/^\.+/, '')}`, sha256(join(REPO, file))));
+  }
+  return attrs;
+}
+
+// Set by Claude Code in hook subprocesses when tracing is active, which is what
+// lets this span land in the same trace as the interaction it describes.
+function traceContext(): { traceId: string; parentSpanId?: string } {
+  const parts = (process.env.TRACEPARENT ?? '').split('-');
+  if (parts.length === 4 && parts[1]?.length === 32 && parts[2]?.length === 16) {
+    return { traceId: parts[1], parentSpanId: parts[2] };
+  }
+  return { traceId: randomBytes(16).toString('hex') };
+}
+
+async function emit(input: HookInput, startedAtNs: bigint, attrs: Attr[]): Promise<void> {
+  const { traceId, parentSpanId } = traceContext();
+  const body = {
+    resourceSpans: [
+      {
+        resource: { attributes: [str('service.name', process.env.OTEL_SERVICE_NAME ?? 'sluice-agent')] },
+        scopeSpans: [
+          {
+            scope: { name: 'sluice.agent-obs' },
+            spans: [
+              {
+                traceId,
+                spanId: randomBytes(8).toString('hex'),
+                ...(parentSpanId ? { parentSpanId } : {}),
+                name: 'agent_obs.session_outcome',
+                kind: 1,
+                startTimeUnixNano: String(startedAtNs),
+                endTimeUnixNano: String(BigInt(Date.now()) * 1_000_000n),
+                attributes: attrs,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  // A dead collector must never stall a session. Bounded timeout, errors swallowed.
+  await fetch(`${ENDPOINT}/v1/traces`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(EXPORT_TIMEOUT_MS),
+  });
+}
+
+function statePath(sessionId: string): string {
+  return join(STATE_DIR, `${sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')}.json`);
+}
+
+async function main(): Promise<void> {
+  const raw = readFileSync(0, 'utf8');
+  const input: HookInput = raw.trim() ? JSON.parse(raw) : {};
+  const sessionId = input.session_id ?? 'unknown';
+
+  if (input.hook_event_name === 'SessionStart') {
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(statePath(sessionId), JSON.stringify({ startedAtNs: String(BigInt(Date.now()) * 1_000_000n) }));
+    return;
+  }
+
+  let startedAtNs = BigInt(Date.now()) * 1_000_000n;
+  try {
+    startedAtNs = BigInt(JSON.parse(readFileSync(statePath(sessionId), 'utf8')).startedAtNs);
+  } catch {
+    // No SessionStart seen (hook added mid-session): a zero-width span still
+    // carries the fingerprint, which is the point of Phase B.
+  }
+
+  const attrs = [str('session.id', sessionId), ...fingerprint(input)];
+
+  // AbortSignal.timeout does not cut undici's connect phase: against a black-holed
+  // endpoint the fetch runs to undici's 10s connect timeout, stalling session stop.
+  // Measured, not assumed — see `just smoke-offline`. A hard watchdog is the only
+  // thing that actually bounds this. Losing a span to a dead collector is free;
+  // making the user wait is not.
+  const watchdog = setTimeout(() => process.exit(0), EXPORT_TIMEOUT_MS);
+  try {
+    await emit(input, startedAtNs, attrs);
+  } catch {
+    // Collector down is the normal case on a laptop; exit immediately rather
+    // than idling out the watchdog.
+  } finally {
+    clearTimeout(watchdog);
+  }
+}
+
+// Nothing this hook does is worth failing a session over.
+main().catch(() => {});

--- a/agent-obs/otel/config.yaml
+++ b/agent-obs/otel/config.yaml
@@ -1,0 +1,49 @@
+# One receiver, two exporters. Traces fan out to both backends; metrics and logs
+# go to LGTM only (Phoenix is traces-native and would reject them).
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+  # A laptop stack cycled daily should never be the reason a session stalls.
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 75
+    spike_limit_percentage: 15
+
+exporters:
+  otlp/lgtm:
+    endpoint: lgtm:4317
+    tls:
+      insecure: true
+  otlp/phoenix:
+    endpoint: phoenix:4317
+    tls:
+      insecure: true
+  debug:
+    verbosity: normal
+
+service:
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/lgtm, otlp/phoenix]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/lgtm]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/lgtm]


### PR DESCRIPTION
Superseded by #285 — same commits, same base, same content.

Closed as a side effect of renaming its head branch for consistency with the `M0 reboot-and-trace` milestone. GitHub retargets a pull request when its *base* branch is renamed, but not when its *head* is, and a pull request cannot be reopened once the old head name is gone.

No history is lost: the commits are intact on `claude/v0.2-trace` and the review moved to #285.