### PR TITLE
MVP step 2 · config: sluice.toml schema, parser and validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ next-env.d.ts
 *.xlsx
 sluice.toml
 
-# ...with one deliberate exception: hand-written synthetic fixtures, which
-# contain no real transaction. Anything real is rejected by the pattern above
-# before it can reach a commit.
-!src/ingest/__fixtures__/**
+# ...with one deliberate exception. Fixtures are built in code rather than stored
+# as files, so nothing here is currently excluded by the patterns above — this
+# guards the day someone adds a stored synthetic export, which would otherwise be
+# ignored silently and fail only in CI, on a clean clone, for no visible reason.
+# Anything real is still rejected by the patterns above before reaching a commit.
+!src/**/__fixtures__/**

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ monthly = "3200.00"       # exactly one of "monthly" and "annual"
 [envelopes.groceries]
 name = "Groceries"
 matches = [{ category = "Food", sub_category = "Supermarket" }]
-estimate = "7800.00"      # realistic
-goal = "7200.00"          # optimised — both or neither
+estimate = "7800.00"      # what it is expected to cost. Required.
+goal = "7200.00"          # an optimisation target, only where there is one
 ```
 
 A fuller worked example lives in [`src/config/__fixtures__/build.ts`](src/config/__fixtures__/build.ts). It is a test fixture that a test parses, so it cannot drift away from what the parser actually accepts.
@@ -73,6 +73,7 @@ Four things about the format are deliberate, and each has a reason worth knowing
 
 - **Amounts are quoted strings.** A bare `7800.10` is a TOML float, and money here is whole cents so the card-settlement check can be exact to the cent.
 - **Envelopes are optional, and declaring one never hides the rest.** Every category the bank reports that no envelope claims gets one of its own, derived from the ledger. The section is for grouping and planning, never for deciding what counts.
+- **An estimate is written down, not derived.** Its first value comes from last year's actuals, but from then on it is a commitment you own, and last year's actuals are a separate number it is measured against. An estimate that re-derived itself each year would agree with reality by construction — spending could grow every year, the plan would silently grow to match, and nothing would ever report drift.
 - **Seasonal shapes are per envelope**, as twelve relative weights or a list of months. A flat one-twelfth line marks a holiday envelope as catastrophically over in July, when July is exactly when it should empty.
 - **Every problem in the file is reported at once**, not one per run — including keys sluice does not recognise, which are refused rather than ignored, because a misspelt key leaves the real one at its default and the figure that comes out is wrong rather than missing.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,67 @@ That is an information outcome, not a software one. The software has to keep ear
 
 ## Status
 
-v0.2 is at its opening. There is no product code yet — the first version is being discovered by interview rather than specified up front, which is the correction v0.1 needed most.
+v0.2 is being built in steps, each its own pull request. The first version was discovered by interview rather than specified up front, which is the correction v0.1 needed most.
+
+| | step | state |
+|---|---|---|
+| 1 | **ingest** — bank exports into one reconciled ledger | merged |
+| 2 | **config** — `sluice.toml`: income, envelopes, goals, buffer | in review |
+| 3 | the numbers — the split, envelope consumption, seasonal pacing, the checks | next |
+| 4 | the page — instalment strip and four sections | |
+| 5 | `CLAUDE.md`, written once there is code to describe | |
+
+## Running it
+
+```bash
+npm install
+npm run check      # typecheck and tests
+npm run dev        # the app, on localhost
+```
+
+sluice reads two things and holds nothing: a folder of bank exports, and one configuration file. There is no database and no import step — every run re-reads the files, because a stale render of a household's money is worse than a slow one.
+
+## Configuration
+
+Everything sluice cannot read out of the bank exports lives in **`sluice.toml`**, which sits outside this repository because it holds household data.
+
+```toml
+[exports]
+# Relative paths resolve from this file's folder, not the shell's cwd.
+directory = "~/sluice-private/exports"
+
+[buffer]
+# The cushion the joint account holds on top of the month's spending.
+target = "2500.00"
+
+[funding]
+# A contribution leaving on or after this day funds the FOLLOWING month.
+cutoff_day = 25
+
+[people.alice]
+name = "Alice"
+# Inbound transfers whose label contains one of these are credited to Alice.
+transfer_labels = ["VIR ALICE MARTIN"]
+
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"       # exactly one of "monthly" and "annual"
+
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "7800.00"      # realistic
+goal = "7200.00"          # optimised — both or neither
+```
+
+A fuller worked example lives in [`src/config/__fixtures__/build.ts`](src/config/__fixtures__/build.ts). It is a test fixture that a test parses, so it cannot drift away from what the parser actually accepts.
+
+Four things about the format are deliberate, and each has a reason worth knowing:
+
+- **Amounts are quoted strings.** A bare `7800.10` is a TOML float, and money here is whole cents so the card-settlement check can be exact to the cent.
+- **Envelopes are optional, and declaring one never hides the rest.** Every category the bank reports that no envelope claims gets one of its own, derived from the ledger. The section is for grouping and planning, never for deciding what counts.
+- **Seasonal shapes are per envelope**, as twelve relative weights or a list of months. A flat one-twelfth line marks a holiday envelope as catastrophically over in July, when July is exactly when it should empty.
+- **Every problem in the file is reported at once**, not one per run — including keys sluice does not recognise, which are refused rather than ignored, because a misspelt key leaves the real one at its default and the figure that comes out is wrong rather than missing.
 
 ## v0.1
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ goal = "7200.00"          # an optimisation target, only where there is one
 
 A fuller worked example lives in [`src/config/__fixtures__/build.ts`](src/config/__fixtures__/build.ts). It is a test fixture that a test parses, so it cannot drift away from what the parser actually accepts.
 
-Four things about the format are deliberate, and each has a reason worth knowing:
+Five things about the format are deliberate, and each has a reason worth knowing:
 
 - **Amounts are quoted strings.** A bare `7800.10` is a TOML float, and money here is whole cents so the card-settlement check can be exact to the cent.
 - **Envelopes are optional, and declaring one never hides the rest.** Every category the bank reports that no envelope claims gets one of its own, derived from the ledger. The section is for grouping and planning, never for deciding what counts.

--- a/src/config/__fixtures__/build.ts
+++ b/src/config/__fixtures__/build.ts
@@ -11,6 +11,13 @@
  */
 
 export interface ConfigParts {
+  /**
+   * Emitted before every table, so a test can put a value at the root of the
+   * document. Without it a fragment that opens no table of its own is swallowed
+   * by whichever table precedes it, and a test aimed at "this must be a section"
+   * passes on an unknown-key error from a different rule entirely.
+   */
+  readonly root?: string;
   readonly exports?: string;
   readonly buffer?: string;
   readonly funding?: string;
@@ -48,6 +55,7 @@ const DEFAULT_ENVELOPES = '';
 
 export function configToml(parts: ConfigParts = {}): string {
   return [
+    parts.root ?? '',
     parts.exports ?? DEFAULT_EXPORTS,
     parts.buffer ?? DEFAULT_BUFFER,
     parts.funding ?? DEFAULT_FUNDING,

--- a/src/config/__fixtures__/build.ts
+++ b/src/config/__fixtures__/build.ts
@@ -118,7 +118,8 @@ matches = [
   { category = "Food", sub_category = "Supermarket" },
   { category = "Food", sub_category = "Market" },
 ]
-# Two annual scenarios: realistic, and optimised. Both or neither.
+# The estimate is always given and is a commitment, not a derivation. The goal
+# is the optimised scenario, and only when there is one.
 estimate = "7800.00"
 goal = "7200.00"
 
@@ -141,5 +142,6 @@ seasonal = { weights = [3, 3, 2, 1, 1, 1, 1, 1, 1, 2, 3, 3] }
 [envelopes.leisure]
 name = "Leisure"
 matches = [{ category = "Leisure" }]   # a whole category
-# No estimate and no goal: groups only, figures come from history.
+# An estimate is always given; a goal only when there is something to optimise.
+estimate = "2400.00"
 `;

--- a/src/config/__fixtures__/build.ts
+++ b/src/config/__fixtures__/build.ts
@@ -1,0 +1,145 @@
+/**
+ * Fixtures for the config tests.
+ *
+ * A document is assembled from five fragments, each defaulting to a good one, so
+ * a test writes only the fragment it is exercising and the rest stays valid.
+ * Without that, every test of one rule carries a full config's worth of noise
+ * and quietly stops testing what its name says when an unrelated default moves.
+ *
+ * Nothing here is a real household's figures, and no real category name from any
+ * real export appears — the same rule the ingest fixtures state.
+ */
+
+export interface ConfigParts {
+  readonly exports?: string;
+  readonly buffer?: string;
+  readonly funding?: string;
+  readonly people?: string;
+  readonly envelopes?: string;
+}
+
+const DEFAULT_EXPORTS = `
+[exports]
+directory = "./exports"
+`;
+
+const DEFAULT_BUFFER = `
+[buffer]
+target = "2500.00"
+`;
+
+const DEFAULT_FUNDING = `
+[funding]
+cutoff_day = 25
+`;
+
+const DEFAULT_PEOPLE = `
+[people.alice]
+name = "Alice"
+transfer_labels = ["VIR ALICE MARTIN"]
+
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+`;
+
+/** Envelopes are optional, so the default is none. */
+const DEFAULT_ENVELOPES = '';
+
+export function configToml(parts: ConfigParts = {}): string {
+  return [
+    parts.exports ?? DEFAULT_EXPORTS,
+    parts.buffer ?? DEFAULT_BUFFER,
+    parts.funding ?? DEFAULT_FUNDING,
+    parts.people ?? DEFAULT_PEOPLE,
+    parts.envelopes ?? DEFAULT_ENVELOPES,
+  ].join('\n');
+}
+
+/**
+ * The example that documents the format.
+ *
+ * It is a fixture and a test parses it, so the documentation and the parser
+ * cannot drift apart. A worked example that no longer loads is a documentation
+ * bug that reads to the user as a product bug.
+ */
+export const EXAMPLE_TOML = `
+# sluice.toml — the household's plan.
+#
+# Amounts are always quoted strings. A bare 7800.10 is a TOML float, and a float
+# is not an exact number of cents.
+
+[exports]
+# Relative paths resolve from this file's folder, not the shell's cwd.
+# A leading "~/" is expanded.
+directory = "./exports"
+
+[buffer]
+# The cushion the joint account holds on top of the month's spending. Deferred
+# card purchases are already spent before they are charged; this covers the gap.
+target = "2500.00"
+
+[funding]
+# A contribution leaving on or after this day funds the FOLLOWING month.
+# 1–28 only: the 30th does not exist in February.
+cutoff_day = 25
+
+[people.alice]
+name = "Alice"
+# Inbound transfers whose label contains one of these are credited to Alice.
+# Case-insensitive substring, whitespace runs collapsed. Transfers matching
+# nobody — or two people — stay in the unattributed band rather than be guessed.
+transfer_labels = ["VIR ALICE MARTIN"]
+
+# Exactly one of "monthly" and "annual" per entry.
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[[people.alice.income]]
+label = "Profit share"
+annual = "4800.00"
+
+[people.bruno]
+name = "Bruno"
+transfer_labels = ["VIR B DUPONT"]
+
+[[people.bruno.income]]
+label = "Salary"
+monthly = "2450.00"
+
+# Envelopes are optional, and declaring one never hides the rest: every
+# (category, sub-category) no envelope claims gets one of its own, derived from
+# the ledger. This section is for grouping and planning, never for deciding
+# what counts.
+[envelopes.groceries]
+name = "Groceries"
+matches = [
+  { category = "Food", sub_category = "Supermarket" },
+  { category = "Food", sub_category = "Market" },
+]
+# Two annual scenarios: realistic, and optimised. Both or neither.
+estimate = "7800.00"
+goal = "7200.00"
+
+[envelopes.home_insurance]
+name = "Home insurance"
+matches = [{ category = "Home", sub_category = "Insurance" }]
+estimate = "480.00"
+goal = "420.00"
+# Taken once a year, in June. Shorthand for weights with one non-zero month.
+seasonal = { months = [6] }
+
+[envelopes.heating]
+name = "Heating"
+matches = [{ category = "Home", sub_category = "Energy" }]
+estimate = "1440.00"
+goal = "1200.00"
+# Twelve relative weights, Jan→Dec, for THIS envelope. Twelve 1s is a flat year.
+seasonal = { weights = [3, 3, 2, 1, 1, 1, 1, 1, 1, 2, 3, 3] }
+
+[envelopes.leisure]
+name = "Leisure"
+matches = [{ category = "Leisure" }]   # a whole category
+# No estimate and no goal: groups only, figures come from history.
+`;

--- a/src/config/load.test.ts
+++ b/src/config/load.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { ConfigError, ConfigNotFoundError, loadConfig, SLUICE_TOML } from './load.ts';
+import { configToml } from './__fixtures__/build.ts';
+import { loadLedger } from '../ingest/load.ts';
+import { csvFixture, ofxFixture, type FixtureRow } from '../ingest/__fixtures__/build.ts';
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(created.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'sluice-config-'));
+  created.push(dir);
+  return dir;
+}
+
+async function withConfig(text: string): Promise<string> {
+  const dir = await tempDir();
+  await writeFile(join(dir, SLUICE_TOML), text, 'utf8');
+  return dir;
+}
+
+describe('loadConfig', () => {
+  it('reads the plan from a file called sluice.toml', async () => {
+    // The name the ingest's own error message tells the user to edit. Pinned
+    // here so the two modules cannot drift apart on it.
+    expect(SLUICE_TOML).toBe('sluice.toml');
+    const dir = await withConfig(configToml());
+    const config = await loadConfig(dir);
+    expect(config.people).toHaveLength(1);
+  });
+
+  it('resolves a relative exports directory against the config file, not the cwd', async () => {
+    // The config lives beside the exports it points at. Resolving against the
+    // process's working directory would make the same file read a different
+    // folder depending on where the app was started — a wrong answer that looks
+    // like a right one.
+    const dir = await withConfig(configToml({ exports: '[exports]\ndirectory = "./exports"\n' }));
+    const config = await loadConfig(dir);
+    expect(config.exportsDirectory).toBe(resolve(dir, 'exports'));
+    expect(config.exportsDirectory).not.toBe(resolve(process.cwd(), 'exports'));
+  });
+
+  it('leaves an absolute exports directory alone', async () => {
+    const dir = await withConfig(
+      configToml({ exports: `[exports]\ndirectory = "${tmpdir()}/elsewhere"\n` }),
+    );
+    expect((await loadConfig(dir)).exportsDirectory).toBe(join(tmpdir(), 'elsewhere'));
+  });
+
+  it('expands a leading ~/ to the home directory', async () => {
+    const dir = await withConfig(
+      configToml({ exports: '[exports]\ndirectory = "~/sluice-private/exports"\n' }),
+    );
+    expect((await loadConfig(dir)).exportsDirectory).toBe(
+      join(homedir(), 'sluice-private/exports'),
+    );
+  });
+
+  it('reads a file that starts with a byte-order mark', async () => {
+    // Invisible in an editor, and it would otherwise become part of the first
+    // key's name — so the file would be refused for a reason nobody could see.
+    const dir = await withConfig('﻿' + configToml());
+    await expect(loadConfig(dir)).resolves.toBeDefined();
+  });
+
+  it('says where it looked when there is no config', async () => {
+    const dir = await tempDir();
+    await expect(loadConfig(dir)).rejects.toThrow(ConfigNotFoundError);
+    await expect(loadConfig(dir)).rejects.toThrow(new RegExp(dir));
+  });
+
+  it('reports a bad plan as a config problem, not a missing file', async () => {
+    const dir = await withConfig(configToml({ funding: '[funding]\ncutoff_day = 30\n' }));
+    await expect(loadConfig(dir)).rejects.toThrow(ConfigError);
+    await expect(loadConfig(dir)).rejects.toThrow(/between 1 and 28/);
+  });
+});
+
+describe('config and ingest together', () => {
+  const ROWS: FixtureRow[] = [
+    { postedOn: '05/01/2025', amount: '-40,00' },
+    { postedOn: '06/01/2025', amount: '-60,00' },
+  ];
+
+  it('points the ingest at the folder the plan names', async () => {
+    // The only check that the two halves meet. Everything either side of this
+    // line is tested in isolation, and a mismatch here would surface as an empty
+    // page rather than an error.
+    const root = await tempDir();
+    const exports = join(root, 'exports');
+    await mkdir(exports);
+
+    const stem = '00000000001_01012025_31012025';
+    await writeFile(join(exports, `${stem}.ofx`), ofxFixture(ROWS, { balance: '+500.00' }));
+    await writeFile(join(exports, `${stem}.csv`), csvFixture(ROWS));
+    await writeFile(
+      join(root, SLUICE_TOML),
+      configToml({ exports: '[exports]\ndirectory = "./exports"\n' }),
+      'utf8',
+    );
+
+    const config = await loadConfig(root);
+    const ledger = await loadLedger(config.exportsDirectory);
+
+    expect(ledger.transactions).toHaveLength(2);
+    expect(ledger.reconciliation.accountBalance).toBe(50000);
+  });
+});

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,0 +1,71 @@
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { isAbsolute, join, resolve } from 'node:path';
+
+import { parseConfig, type Config } from './schema.ts';
+
+export type {
+  Config,
+  EnvelopeConfig,
+  EnvelopeMatcher,
+  EnvelopePlan,
+  IncomeSource,
+  Person,
+  SeasonalWeights,
+} from './schema.ts';
+export { ConfigError, envelopeIndex, peopleMatching } from './schema.ts';
+
+/**
+ * The name the ingest already tells the user to edit, in
+ * `ExportsNotFoundError`. Exported so the two modules cannot drift apart on it.
+ */
+export const SLUICE_TOML = 'sluice.toml';
+
+export class ConfigNotFoundError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ConfigNotFoundError';
+  }
+}
+
+/** A leading `~/` is the household's home directory. */
+function expandHome(path: string): string {
+  if (path === '~') return homedir();
+  if (path.startsWith('~/')) return join(homedir(), path.slice(2));
+  return path;
+}
+
+/**
+ * Read and validate the household's plan.
+ *
+ * `exports.directory` is resolved against **the config file's own folder**, not
+ * the process's working directory. The config lives beside the exports it points
+ * at, so a relative path means "next to me" — resolving against the cwd would
+ * make the same file read a different folder depending on where the app happened
+ * to be started from, which is a wrong answer that looks like a right one.
+ */
+export async function loadConfig(directory: string): Promise<Config> {
+  const path = join(directory, SLUICE_TOML);
+
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch (cause) {
+    throw new ConfigNotFoundError(
+      `No ${SLUICE_TOML} in "${directory}". sluice reads the household's plan from a ` +
+        `file of that name: it needs at least an [exports] table whose directory points ` +
+        `at the bank's exports, the people who live here and what they earn.`,
+      { cause },
+    );
+  }
+
+  // A BOM is invisible in an editor and would otherwise become part of the first
+  // key's name, so the file would be refused for a reason nobody could see.
+  const config = parseConfig(text.replace(/^﻿/, ''), path);
+
+  const declared = expandHome(config.exportsDirectory);
+  return {
+    ...config,
+    exportsDirectory: isAbsolute(declared) ? declared : resolve(directory, declared),
+  };
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -8,7 +8,6 @@ export type {
   Config,
   EnvelopeConfig,
   EnvelopeMatcher,
-  EnvelopePlan,
   IncomeSource,
   Person,
   SeasonalWeights,

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -7,12 +7,16 @@ import { parseConfig, type Config } from './schema.ts';
 export type {
   Config,
   EnvelopeConfig,
+  EnvelopeIndex,
   EnvelopeMatcher,
   IncomeSource,
   Person,
   SeasonalWeights,
 } from './schema.ts';
 export { ConfigError, envelopeIndex, peopleMatching } from './schema.ts';
+// Exported so the code that spends the config asks the config what a matcher
+// claims, rather than reimplementing the comparison and drifting from it.
+export { matcherMatches } from './match.ts';
 
 /**
  * The name the ingest already tells the user to edit, in

--- a/src/config/match.test.ts
+++ b/src/config/match.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  labelMatches,
+  matcherMatches,
+  matchersOverlap,
+  normaliseLabel,
+  type EnvelopeMatcher,
+} from './match.ts';
+
+const wholeCategory = (category: string): EnvelopeMatcher => ({ kind: 'category', category });
+const onePair = (category: string, subCategory: string): EnvelopeMatcher => ({
+  kind: 'sub-category',
+  category,
+  subCategory,
+});
+
+describe('matcherMatches', () => {
+  it('matches the one pair a sub-category matcher names', () => {
+    const m = onePair('Alimentation', 'Supermarche');
+    expect(matcherMatches(m, 'Alimentation', 'Supermarche')).toBe(true);
+    expect(matcherMatches(m, 'Alimentation', 'Restaurant')).toBe(false);
+  });
+
+  it('matches every sub-category under a category matcher', () => {
+    const m = wholeCategory('Alimentation');
+    expect(matcherMatches(m, 'Alimentation', 'Supermarche')).toBe(true);
+    expect(matcherMatches(m, 'Alimentation', 'Restaurant')).toBe(true);
+  });
+
+  it('does not reach into another category', () => {
+    expect(matcherMatches(wholeCategory('Alimentation'), 'Transports', 'Carburant')).toBe(false);
+    expect(matcherMatches(onePair('Alimentation', 'Supermarche'), 'Transports', 'Supermarche')).toBe(
+      false,
+    );
+  });
+
+  it('compares exactly, rather than folding case', () => {
+    // The bank's taxonomy is a fixed list picked from at source, so there is no
+    // spelling variance to be lenient about — and leniency would silently merge
+    // two categories the bank deliberately keeps apart.
+    expect(matcherMatches(wholeCategory('Alimentation'), 'alimentation', 'Supermarche')).toBe(false);
+  });
+});
+
+describe('matchersOverlap', () => {
+  it('sees two envelopes claiming the same pair', () => {
+    expect(
+      matchersOverlap(onePair('Alimentation', 'Supermarche'), onePair('Alimentation', 'Supermarche')),
+    ).toBe(true);
+  });
+
+  it('sees a category matcher swallowing a sub-category one beneath it', () => {
+    // The case worth catching: "all of Alimentation" and "Alimentation /
+    // Supermarche" look unrelated in the file and count the same spending twice.
+    expect(matchersOverlap(wholeCategory('Alimentation'), onePair('Alimentation', 'Supermarche'))).toBe(
+      true,
+    );
+    expect(matchersOverlap(onePair('Alimentation', 'Supermarche'), wholeCategory('Alimentation'))).toBe(
+      true,
+    );
+  });
+
+  it('leaves sibling sub-categories alone', () => {
+    expect(
+      matchersOverlap(onePair('Alimentation', 'Supermarche'), onePair('Alimentation', 'Restaurant')),
+    ).toBe(false);
+  });
+
+  it('leaves different categories alone', () => {
+    expect(matchersOverlap(wholeCategory('Alimentation'), wholeCategory('Transports'))).toBe(false);
+  });
+});
+
+describe('labelMatches', () => {
+  it('matches a substring of the transfer label', () => {
+    expect(labelMatches('ALICE MARTIN', 'VIR RECU ALICE MARTIN 03/26')).toBe(true);
+  });
+
+  it('ignores case, because banks are inconsistent about it', () => {
+    expect(labelMatches('alice martin', 'VIR RECU ALICE MARTIN')).toBe(true);
+    expect(labelMatches('ALICE MARTIN', 'Vir recu Alice Martin')).toBe(true);
+  });
+
+  it('collapses runs of whitespace on both sides', () => {
+    expect(labelMatches('ALICE  MARTIN', 'VIR ALICE MARTIN')).toBe(true);
+    expect(labelMatches('ALICE MARTIN', 'VIR   ALICE   MARTIN')).toBe(true);
+  });
+
+  it('does not fold accents, so it fails in the direction that shows', () => {
+    // A missed match leaves the contribution in the visible unattributed band,
+    // where it can be found and fixed. A false match silently credits money to
+    // the wrong person.
+    expect(labelMatches('BENOIT', 'VIR RECU BENOÎT')).toBe(false);
+  });
+
+  it('never matches on an empty pattern', () => {
+    // An empty string is a substring of everything, so this would credit every
+    // inbound transfer in the ledger to one person.
+    expect(labelMatches('', 'VIR RECU ALICE MARTIN')).toBe(false);
+    expect(labelMatches('   ', 'VIR RECU ALICE MARTIN')).toBe(false);
+  });
+
+  it('does not match a label that merely shares a prefix', () => {
+    expect(labelMatches('ALICE MARTIN', 'VIR RECU ALICE')).toBe(false);
+  });
+});
+
+describe('normaliseLabel', () => {
+  it('trims and collapses, leaving the words alone', () => {
+    expect(normaliseLabel('  VIR   RECU  ALICE ')).toBe('VIR RECU ALICE');
+  });
+});

--- a/src/config/match.ts
+++ b/src/config/match.ts
@@ -1,0 +1,79 @@
+/**
+ * What a configured envelope claims, and what a configured transfer label
+ * catches.
+ *
+ * These live with the config rather than with the code that spends them,
+ * because they are the *meaning* of a config key. If the page re-implemented
+ * substring matching, then a validator saying "this matcher matches nothing"
+ * and a runtime that matched something could disagree, and the disagreement
+ * would be invisible.
+ */
+
+/**
+ * Modelled as a union rather than a matcher with an optional sub-category, for
+ * the same reason `Source` is: code that narrows on `kind` needs no defensive
+ * branch, and "the whole of this category" and "this one sub-category" are
+ * different claims rather than one claim with a hole in it.
+ */
+export type EnvelopeMatcher =
+  | { readonly kind: 'category'; readonly category: string }
+  | { readonly kind: 'sub-category'; readonly category: string; readonly subCategory: string };
+
+/**
+ * Does this matcher claim this transaction's category pair?
+ *
+ * Exact, case-sensitive comparison. The bank's taxonomy is a fixed list the
+ * user picks from at source and cannot extend, so there is no spelling variance
+ * to be lenient about — and leniency here would silently merge two categories
+ * the bank deliberately keeps apart, which is the mistake that made an annual
+ * charge and a monthly one look like one lumpy envelope.
+ */
+export function matcherMatches(
+  matcher: EnvelopeMatcher,
+  category: string,
+  subCategory: string,
+): boolean {
+  if (matcher.category !== category) return false;
+  return matcher.kind === 'category' || matcher.subCategory === subCategory;
+}
+
+/**
+ * Could these two matchers ever claim the same transaction?
+ *
+ * Used to refuse a config where two envelopes overlap. A category matcher
+ * overlaps every sub-category matcher beneath it, which is the case worth
+ * catching: "all of Groceries" and "Groceries / Supermarket" look unrelated in
+ * the file and count the same spending twice.
+ */
+export function matchersOverlap(a: EnvelopeMatcher, b: EnvelopeMatcher): boolean {
+  if (a.category !== b.category) return false;
+  if (a.kind === 'category' || b.kind === 'category') return true;
+  return a.subCategory === b.subCategory;
+}
+
+/**
+ * Collapse runs of whitespace and trim, so a label copied out of a statement
+ * with doubled spaces still matches one typed by hand.
+ */
+export function normaliseLabel(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Does a configured transfer label catch this transaction's label?
+ *
+ * Case-insensitive substring, after collapsing whitespace. Deliberately *not*
+ * accent-folded: a missed match leaves a contribution in the visible
+ * unattributed band, where it can be seen and fixed, while a false match
+ * silently credits money to the wrong person. Given the choice, this fails in
+ * the direction that shows.
+ *
+ * An empty pattern is never a match. It is refused by the validator too, but a
+ * substring test would otherwise claim every transfer in the ledger, and that
+ * is too expensive a default to leave to one caller remembering to check.
+ */
+export function labelMatches(pattern: string, label: string): boolean {
+  const needle = normaliseLabel(pattern).toLowerCase();
+  if (needle === '') return false;
+  return normaliseLabel(label).toLowerCase().includes(needle);
+}

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -440,7 +440,289 @@ monthly = "2450.00"
   });
 });
 
+describe('parseConfig — refusals the reader makes on shape alone', () => {
+  // These were all removable without a single test failing. Each one is a value
+  // of the wrong TOML type that would otherwise be carried into the plan.
+
+  it('refuses text where an amount belongs', () => {
+    expect(() => parse({ buffer: '[buffer]\ntarget = "twelve"\n' })).toThrow(/not an amount/);
+  });
+
+  it('refuses an empty amount rather than reading it as zero', () => {
+    // `parseAmount` reads "" as zero for the bank's CSV, where debit and credit
+    // share a row. On a hand-edited file that turns a half-finished edit into a
+    // confident zero — and a blank income gives that person a zero share.
+    const bad = () => parse({ buffer: '[buffer]\ntarget = ""\n' });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/would be read as zero euros/);
+    expect(() =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+[[people.alice.income]]
+label = "Salary"
+monthly = "   "
+`,
+      }),
+    ).toThrow(/would be read as zero euros/);
+  });
+
+  it('refuses a number where text belongs', () => {
+    expect(() =>
+      parse({
+        people: `
+[people.alice]
+name = 5
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+`,
+      }),
+    ).toThrow(/must be text/);
+  });
+
+  it('refuses a non-string amount', () => {
+    expect(() => parse({ buffer: '[buffer]\ntarget = true\n' })).toThrow(/must be an amount/);
+  });
+
+  it('refuses a fractional whole number', () => {
+    expect(() => parse({ funding: '[funding]\ncutoff_day = 25.5\n' })).toThrow(
+      /must be a whole number/,
+    );
+  });
+
+  it('refuses a non-integer in a list of whole numbers', () => {
+    expect(() =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries" }]
+estimate = "1200.00"
+seasonal = { months = ["6"] }
+`,
+      }),
+    ).toThrow(/must be a list of whole numbers/);
+  });
+
+  it('refuses a non-string in a list of labels', () => {
+    expect(() =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+transfer_labels = [5]
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+`,
+      }),
+    ).toThrow(/must be a list of quoted strings/);
+  });
+
+  it('refuses a value where a section belongs', () => {
+    // Reachable only through the root fragment: a bare key placed after a table
+    // would land inside it, and the test would pass on a different rule.
+    expect(() => parse({ root: 'envelopes = 5\n', envelopes: '' })).toThrow(/must be a section/);
+    expect(() => parse({ root: 'people = 5\n', people: '' })).toThrow(/must be a section/);
+  });
+
+  it('refuses a value where a list of sections belongs', () => {
+    expect(() =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+income = 5
+`,
+      }),
+    ).toThrow(/must be a list of sections/);
+  });
+});
+
+describe('parseConfig — refusals on amounts that would reverse a figure', () => {
+  it('refuses a negative envelope estimate', () => {
+    expect(() =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries" }]
+estimate = "-1200.00"
+`,
+      }),
+    ).toThrow(/estimate of/);
+  });
+
+  it('refuses a negative goal, which "not above the estimate" lets through', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries" }]
+estimate = "1200.00"
+goal = "-500.00"
+`,
+      });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/goal cannot be negative/);
+  });
+
+  it('refuses negative income', () => {
+    expect(() =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+[[people.alice.income]]
+label = "Salary"
+monthly = "-3200.00"
+`,
+      }),
+    ).toThrow(/Income cannot be negative/);
+  });
+});
+
+describe('parseConfig — seasonal shapes', () => {
+  const withSeasonal = (seasonal: string) =>
+    parse({
+      envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries" }]
+estimate = "1200.00"
+${seasonal}
+`,
+    });
+
+  it('names a misspelt key rather than advising the table be deleted', () => {
+    // Arriving at "you gave neither form" almost always means a key was
+    // misspelt. Advising removal sends the user to throw away the thing they
+    // got nearly right.
+    const bad = () => withSeasonal('seasonal = { month = [1, 2] }');
+    expect(bad).toThrow(/seasonal\.month" is not a key sluice knows/);
+    expect(bad).not.toThrow(/gives neither/);
+  });
+
+  it('reports an unknown key alongside giving both forms', () => {
+    const bad = () =>
+      withSeasonal('seasonal = { months = [6], weights = [1,1,1,1,1,1,1,1,1,1,1,1], bogus = 1 }');
+    expect(bad).toThrow(/seasonal\.bogus" is not a key sluice knows/);
+    expect(bad).toThrow(/gives both/);
+  });
+
+  it('refuses a seasonal table giving neither form', () => {
+    expect(() => withSeasonal('seasonal = { }')).toThrow(/gives neither/);
+  });
+
+  it('refuses an empty month list, which the all-zero rule would not catch', () => {
+    // The months branch builds its own twelve zeros and returns before the
+    // all-zero check, which guards only the weights branch.
+    expect(() => withSeasonal('seasonal = { months = [] }')).toThrow(/List the months/);
+  });
+});
+
 describe('parseConfig — reporting', () => {
+  it('carries the problems as a list, not only as one joined message', () => {
+    // The page renders one problem per row. Without the list its only route is
+    // splitting the message back apart on its bullet characters.
+    let caught: ConfigError | undefined;
+    try {
+      parse({ buffer: '[buffer]\ntarget = 2500\n', funding: '[funding]\ncutoff_day = 30\n' });
+    } catch (error) {
+      caught = error as ConfigError;
+    }
+    expect(caught?.problems).toHaveLength(2);
+    expect(caught?.problems[0]).toMatch(/binary float/);
+    expect(caught?.problems[1]).toMatch(/between 1 and 28/);
+  });
+
+  it('complains once about a fault under a named-table parent', () => {
+    // `namedTables` was the one accessor without the already-refused guard, so
+    // one date here produced the date complaint, then "must be a section", then
+    // a third line claiming no people were declared.
+    let caught: ConfigError | undefined;
+    try {
+      parse({ people: '[people]\nbruno = 2024-01-01\n' });
+    } catch (error) {
+      caught = error as ConfigError;
+    }
+    expect(caught?.problems.filter((p) => /people\.bruno/.test(p))).toHaveLength(1);
+    expect(caught?.problems.join('\n')).not.toMatch(/must be a section/);
+  });
+
+  it('reports a symmetric label collision once, not once per direction', () => {
+    let caught: ConfigError | undefined;
+    try {
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["ALICE"]
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.bruno]
+name = "Bruno"
+transfer_labels = ["alice"]
+[[people.bruno.income]]
+label = "Salary"
+monthly = "2450.00"
+`,
+      });
+    } catch (error) {
+      caught = error as ConfigError;
+    }
+    expect(caught?.problems).toHaveLength(1);
+  });
+
+  it('still catches a collision whichever way round the labels are declared', () => {
+    for (const [first, second] of [
+      ['"ALICE"', '"ALICE MARTIN"'],
+      ['"ALICE MARTIN"', '"ALICE"'],
+    ]) {
+      expect(() =>
+        parse({
+          people: `
+[people.alice]
+name = "Alice"
+transfer_labels = [${first}]
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.bruno]
+name = "Bruno"
+transfer_labels = [${second}]
+[[people.bruno.income]]
+label = "Salary"
+monthly = "2450.00"
+`,
+        }),
+      ).toThrow(/credited to neither/);
+    }
+  });
+
+  it('does not treat a sub-category named after a built-in as reserved', () => {
+    // A plain-object lookup walks the prototype chain, so "constructor" was
+    // refused with a stringified function as the explanation.
+    const config = parse({
+      envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries", sub_category = "constructor" }]
+estimate = "1200.00"
+`,
+    });
+    expect(config.envelopes[0]?.matches[0]).toEqual({
+      kind: 'sub-category',
+      category: 'Groceries',
+      subCategory: 'constructor',
+    });
+  });
   it('reports every problem in the file at once, not one per run', () => {
     // The file is hand-edited once a year. Five runs to find five typos works
     // against the reason this product exists.
@@ -645,5 +927,33 @@ monthly = "2450.00"
 
   it('credits nobody when no label catches it', () => {
     expect(peopleMatching(config, 'VIR VERS COMPTE CHEQUE')).toEqual([]);
+  });
+
+  it('returns both people when a transfer matches two, rather than picking one', () => {
+    // The whole reason this returns an array. Validation cannot rule the case
+    // out: "ALICE" and "MARTIN" contain neither, so the config is accepted, and
+    // a transfer naming both matches both. A caller taking the first would move
+    // real money between two people's totals.
+    const ambiguous = parse({
+      people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["ALICE"]
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.bruno]
+name = "Bruno"
+transfer_labels = ["MARTIN"]
+[[people.bruno.income]]
+label = "Salary"
+monthly = "2450.00"
+`,
+    });
+    expect(peopleMatching(ambiguous, 'VIR RECU ALICE MARTIN').map((p) => p.id)).toEqual([
+      'alice',
+      'bruno',
+    ]);
   });
 });

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -458,6 +458,116 @@ describe('parseConfig — reporting', () => {
     expect(message).toMatch(/has 2 problems/);
   });
 
+  it('complains once about a refused value, not twice', () => {
+    // A date was refused and then re-examined by the type check that followed,
+    // which reported it a second time as the wrong kind of fault entirely. One
+    // mistake in the file has to be one line in the report, or the report stops
+    // being a list of things to fix.
+    let message = '';
+    try {
+      parse({
+        people: `
+[people.alice]
+name = 2026-01-01
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+`,
+      });
+    } catch (error) {
+      message = (error as ConfigError).message;
+    }
+    expect(message).toMatch(/Nothing in sluice\.toml is a date/);
+    expect(message).not.toMatch(/must be text/);
+    expect(message).toMatch(/has 1 problem:/);
+  });
+
+  it('reports every overlapping pair of envelopes, not only the first', () => {
+    let message = '';
+    try {
+      parse({
+        envelopes: `
+[envelopes.a]
+name = "A"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "1000.00"
+[envelopes.b]
+name = "B"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "1000.00"
+[envelopes.c]
+name = "C"
+matches = [{ category = "Home", sub_category = "Energy" }]
+estimate = "1000.00"
+[envelopes.d]
+name = "D"
+matches = [{ category = "Home", sub_category = "Energy" }]
+estimate = "1000.00"
+`,
+      });
+    } catch (error) {
+      message = (error as ConfigError).message;
+    }
+    expect(message).toMatch(/"a" and "b"/);
+    expect(message).toMatch(/"c" and "d"/);
+    expect(message).toMatch(/has 2 problems:/);
+  });
+
+  it('reports one overlap per pair of envelopes, not one per claim', () => {
+    // A whole-category matcher overlaps every sub-category matcher beneath it,
+    // so listing each would bury one mistake under a pile of lines.
+    let message = '';
+    try {
+      parse({
+        envelopes: `
+[envelopes.all_food]
+name = "All food"
+matches = [{ category = "Food" }]
+estimate = "1000.00"
+[envelopes.groceries]
+name = "Groceries"
+matches = [
+  { category = "Food", sub_category = "Supermarket" },
+  { category = "Food", sub_category = "Market" },
+  { category = "Food", sub_category = "Bakery" },
+]
+estimate = "1000.00"
+`,
+      });
+    } catch (error) {
+      message = (error as ConfigError).message;
+    }
+    expect(message).toMatch(/has 1 problem:/);
+  });
+
+  it('reports every colliding pair of labels, not only the first', () => {
+    let message = '';
+    try {
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["MARTIN", "DUPONT"]
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.bruno]
+name = "Bruno"
+transfer_labels = ["MARTIN BRUNO", "DUPONT B"]
+[[people.bruno.income]]
+label = "Salary"
+monthly = "2450.00"
+`,
+      });
+    } catch (error) {
+      message = (error as ConfigError).message;
+    }
+    expect(message).toMatch(/"MARTIN"/);
+    expect(message).toMatch(/"DUPONT"/);
+    expect(message).toMatch(/has 2 problems:/);
+  });
+
   it('does not complain about the meaning of a value it could not read', () => {
     // A shape problem must not cascade into a domain complaint about a figure
     // that was never parsed — that would send the reader after the wrong thing.

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -59,10 +59,11 @@ monthly = "3200.00"
 [envelopes.leisure]
 name = "Leisure"
 matches = [{ category = "Leisure" }]
-
+estimate = "1000.00"
 [envelopes.groceries]
 name = "Groceries"
 matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "1000.00"
 `,
     });
     expect(config.envelopes[0]?.matches[0]).toEqual({ kind: 'category', category: 'Leisure' });
@@ -73,16 +74,36 @@ matches = [{ category = "Food", sub_category = "Supermarket" }]
     });
   });
 
-  it('leaves an envelope with no figures on the derived plan', () => {
+  it('takes an estimate without a goal, for an envelope nobody is optimising', () => {
     const config = parse({
       envelopes: `
 [envelopes.leisure]
 name = "Leisure"
 matches = [{ category = "Leisure" }]
+estimate = "2400.00"
 `,
     });
-    expect(config.envelopes[0]?.plan).toEqual({ kind: 'derived' });
+    expect(config.envelopes[0]?.estimate).toBe(240000);
+    expect(config.envelopes[0]?.goal).toBeNull();
     expect(config.envelopes[0]?.seasonal).toBeNull();
+  });
+
+  it('keeps the estimate as written rather than deriving it', () => {
+    // The estimate is a commitment, not a derivation. One that re-derived itself
+    // from last year's actuals would agree with reality by construction, and the
+    // drift this product exists to catch would never show: spending could grow
+    // every year with the plan silently growing to match.
+    const config = parse({
+      envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "7800.00"
+goal = "7200.00"
+`,
+    });
+    expect(config.envelopes[0]?.estimate).toBe(780000);
+    expect(config.envelopes[0]?.goal).toBe(720000);
   });
 
   it('expands the months shorthand into twelve weights', () => {
@@ -92,6 +113,7 @@ matches = [{ category = "Leisure" }]
 name = "Insurance"
 matches = [{ category = "Home", sub_category = "Insurance" }]
 seasonal = { months = [6] }
+estimate = "1000.00"
 `,
     });
     expect(config.envelopes[0]?.seasonal).toEqual([0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0]);
@@ -106,6 +128,7 @@ seasonal = { months = [6] }
 name = "Heating"
 matches = [{ category = "Home", sub_category = "Energy" }]
 seasonal = { weights = [3, 3, 2, 1, 1, 1, 1, 1, 1, 2, 3, 3] }
+estimate = "1000.00"
 `,
     });
     expect(config.envelopes[0]?.seasonal).toEqual([3, 3, 2, 1, 1, 1, 1, 1, 1, 2, 3, 3]);
@@ -162,10 +185,11 @@ goal = "7800.00"
 [envelopes.groceries]
 name = "Groceries"
 matches = [{ category = "Food", sub_category = "Supermarket" }]
-
+estimate = "1000.00"
 [envelopes.food]
 name = "Food"
 matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "1000.00"
 `,
       });
     expect(bad).toThrow(ConfigError);
@@ -179,10 +203,11 @@ matches = [{ category = "Food", sub_category = "Supermarket" }]
 [envelopes.all_food]
 name = "All food"
 matches = [{ category = "Food" }]
-
+estimate = "1000.00"
 [envelopes.groceries]
 name = "Groceries"
 matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "1000.00"
 `,
       });
     expect(bad).toThrow(/count it twice/);
@@ -195,6 +220,7 @@ matches = [{ category = "Food", sub_category = "Supermarket" }]
 [envelopes.cards]
 name = "Cards"
 matches = [{ category = "Transaction exclue", sub_category = "Transaction differee" }]
+estimate = "1000.00"
 `,
       });
     expect(bad).toThrow(ConfigError);
@@ -208,6 +234,7 @@ matches = [{ category = "Transaction exclue", sub_category = "Transaction differ
 [envelopes.moves]
 name = "Moves"
 matches = [{ category = "Transaction exclue", sub_category = "Virement interne" }]
+estimate = "1000.00"
 `,
       });
     expect(bad).toThrow(/not spending/);
@@ -261,6 +288,7 @@ label = "Salary"
 name = "Heating"
 matches = [{ category = "Home", sub_category = "Energy" }]
 seasonal = { weights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] }
+estimate = "1000.00"
 `,
       });
     expect(bad).toThrow(/stops setting money aside for/);
@@ -274,6 +302,7 @@ seasonal = { weights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] }
 name = "Heating"
 matches = [{ category = "Home", sub_category = "Energy" }]
 seasonal = { weights = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+estimate = "1000.00"
 `,
       });
     expect(bad).toThrow(/no total to divide by/);
@@ -287,6 +316,7 @@ seasonal = { weights = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
 name = "Heating"
 matches = [{ category = "Home", sub_category = "Energy" }]
 seasonal = { weights = [1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1, 1] }
+estimate = "1000.00"
 `,
       });
     expect(bad).toThrow(/take money back out of a month/);
@@ -300,6 +330,7 @@ seasonal = { weights = [1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1, 1] }
 name = "Heating"
 matches = [{ category = "Home", sub_category = "Energy" }]
 seasonal = { months = [6], weights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] }
+estimate = "1000.00"
 `,
       });
     expect(bad).toThrow(/Give one/);
@@ -313,6 +344,7 @@ seasonal = { months = [6], weights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] }
 name = "Insurance"
 matches = [{ category = "Home", sub_category = "Insurance" }]
 seasonal = { months = [13] }
+estimate = "1000.00"
 `,
       });
     expect(bad).toThrow(/Months are 1 to 12/);
@@ -320,21 +352,27 @@ seasonal = { months = [13] }
 
   it('refuses an envelope that claims nothing', () => {
     const bad = () =>
-      parse({ envelopes: '[envelopes.groceries]\nname = "Groceries"\nmatches = []\n' });
+      parse({
+        envelopes: '[envelopes.groceries]\nname = "Groceries"\nmatches = []\nestimate = "1000.00"\n',
+      });
     expect(bad).toThrow(/budgeted for spending that is also counted/);
   });
 
-  it('refuses an envelope with one of estimate and goal', () => {
+  it('refuses a declared envelope with no estimate', () => {
+    // Declaring an envelope is an act of planning. Without a figure there is
+    // nothing for the year's actuals to be compared against, so the envelope
+    // could drift indefinitely and never register as drifting.
     const bad = () =>
       parse({
         envelopes: `
 [envelopes.groceries]
 name = "Groceries"
 matches = [{ category = "Food", sub_category = "Supermarket" }]
-estimate = "7800.00"
+goal = "7200.00"
 `,
       });
-    expect(bad).toThrow(/Give both or neither/);
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/estimate" is missing/);
   });
 
   it('refuses an empty transfer label', () => {
@@ -448,10 +486,12 @@ describe('envelopeIndex', () => {
 [envelopes.groceries]
 name = "Groceries"
 matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "7800.00"
 
 [envelopes.leisure]
 name = "Leisure"
 matches = [{ category = "Leisure" }]
+estimate = "2400.00"
 `,
   });
   const index = envelopeIndex(config);

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1,0 +1,499 @@
+import { describe, expect, it } from 'vitest';
+import { ConfigError, envelopeIndex, parseConfig, peopleMatching } from './schema.ts';
+import { configToml, EXAMPLE_TOML } from './__fixtures__/build.ts';
+
+const parse = (parts: Parameters<typeof configToml>[0] = {}) =>
+  parseConfig(configToml(parts), 'sluice.toml');
+
+describe('parseConfig — a config that is right', () => {
+  it('reads the minimal file', () => {
+    const config = parse();
+    expect(config.exportsDirectory).toBe('./exports');
+    expect(config.bufferTarget).toBe(250000);
+    expect(config.fundingCutoffDay).toBe(25);
+    expect(config.people).toHaveLength(1);
+    expect(config.envelopes).toHaveLength(0);
+  });
+
+  it('reads amounts as whole cents, never as floats', () => {
+    const config = parse({ buffer: '[buffer]\ntarget = "2500.10"\n' });
+    expect(config.bufferTarget).toBe(250010);
+    expect(Number.isInteger(config.bufferTarget)).toBe(true);
+  });
+
+  it('keeps a monthly and an annual income source apart', () => {
+    const config = parse({
+      people: `
+[people.alice]
+name = "Alice"
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+[[people.alice.income]]
+label = "Bonus"
+annual = "4800.00"
+`,
+    });
+    expect(config.people[0]?.income).toEqual([
+      { cadence: 'monthly', label: 'Salary', net: 320000 },
+      { cadence: 'annual', label: 'Bonus', net: 480000 },
+    ]);
+  });
+
+  it('gives a person with no declared labels an empty list, not a missing one', () => {
+    const config = parse({
+      people: `
+[people.alice]
+name = "Alice"
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+`,
+    });
+    expect(config.people[0]?.transferLabels).toEqual([]);
+  });
+
+  it('reads a whole-category matcher and a single-pair one as different claims', () => {
+    const config = parse({
+      envelopes: `
+[envelopes.leisure]
+name = "Leisure"
+matches = [{ category = "Leisure" }]
+
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+`,
+    });
+    expect(config.envelopes[0]?.matches[0]).toEqual({ kind: 'category', category: 'Leisure' });
+    expect(config.envelopes[1]?.matches[0]).toEqual({
+      kind: 'sub-category',
+      category: 'Food',
+      subCategory: 'Supermarket',
+    });
+  });
+
+  it('leaves an envelope with no figures on the derived plan', () => {
+    const config = parse({
+      envelopes: `
+[envelopes.leisure]
+name = "Leisure"
+matches = [{ category = "Leisure" }]
+`,
+    });
+    expect(config.envelopes[0]?.plan).toEqual({ kind: 'derived' });
+    expect(config.envelopes[0]?.seasonal).toBeNull();
+  });
+
+  it('expands the months shorthand into twelve weights', () => {
+    const config = parse({
+      envelopes: `
+[envelopes.insurance]
+name = "Insurance"
+matches = [{ category = "Home", sub_category = "Insurance" }]
+seasonal = { months = [6] }
+`,
+    });
+    expect(config.envelopes[0]?.seasonal).toEqual([0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it('takes twelve relative weights as written, without normalising them', () => {
+    // Relative on purpose: normalising here would force a rounding rule into the
+    // parser, and the allocation that needs one belongs where the pot is split.
+    const config = parse({
+      envelopes: `
+[envelopes.heating]
+name = "Heating"
+matches = [{ category = "Home", sub_category = "Energy" }]
+seasonal = { weights = [3, 3, 2, 1, 1, 1, 1, 1, 1, 2, 3, 3] }
+`,
+    });
+    expect(config.envelopes[0]?.seasonal).toEqual([3, 3, 2, 1, 1, 1, 1, 1, 1, 2, 3, 3]);
+  });
+
+  it('parses the example that documents the format', () => {
+    // The example is a fixture so the documentation and the parser cannot drift.
+    const config = parseConfig(EXAMPLE_TOML, 'sluice.toml');
+    expect(config.people).toHaveLength(2);
+    expect(config.envelopes).toHaveLength(4);
+  });
+});
+
+describe('parseConfig — refusals that would otherwise be a wrong number', () => {
+  it('refuses a key it does not know, rather than ignoring it', () => {
+    // The highest-value check here: a misspelling leaves the key it was meant to
+    // set at its default, so the figure that comes out is wrong, not missing.
+    const bad = () => parse({ funding: '[funding]\ncuttoff_day = 25\n' });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/not a key sluice knows/);
+  });
+
+  it('refuses an amount written as a number rather than a quoted string', () => {
+    const bad = () => parse({ buffer: '[buffer]\ntarget = 2500.10\n' });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/binary float/);
+  });
+
+  it('refuses a bare TOML date anywhere', () => {
+    const bad = () => parse({ people: '[people.alice]\nname = 2026-01-01\n' });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/Nothing in sluice\.toml is a date/);
+  });
+
+  it('refuses a goal above its estimate', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "7200.00"
+goal = "7800.00"
+`,
+      });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/optimised plan asks for more money/);
+  });
+
+  it('refuses two envelopes claiming the same pair', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+`,
+      });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/count it twice/);
+  });
+
+  it('refuses a category matcher that swallows another envelope’s sub-category', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.all_food]
+name = "All food"
+matches = [{ category = "Food" }]
+
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+`,
+      });
+    expect(bad).toThrow(/count it twice/);
+  });
+
+  it('refuses an envelope claiming the card settlement sub-category', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.cards]
+name = "Cards"
+matches = [{ category = "Transaction exclue", sub_category = "Transaction differee" }]
+`,
+      });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/already itemised on the card exports/);
+  });
+
+  it('refuses an envelope claiming the internal transfer sub-category', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.moves]
+name = "Moves"
+matches = [{ category = "Transaction exclue", sub_category = "Virement interne" }]
+`,
+      });
+    expect(bad).toThrow(/not spending/);
+  });
+
+  it('refuses a person with no income', () => {
+    const bad = () => parse({ people: '[people.alice]\nname = "Alice"\nincome = []\n' });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/asked to fund the whole household/);
+  });
+
+  it('refuses an income entry giving both monthly and annual', () => {
+    const bad = () =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+annual = "38400.00"
+`,
+      });
+    expect(bad).toThrow(/counted twice/);
+  });
+
+  it('refuses an income entry giving neither', () => {
+    const bad = () =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+[[people.alice.income]]
+label = "Salary"
+`,
+      });
+    expect(bad).toThrow(/multiplied by twelve/);
+  });
+
+  it('refuses a funding cutoff that does not exist in every month', () => {
+    const bad = () => parse({ funding: '[funding]\ncutoff_day = 30\n' });
+    expect(bad).toThrow(ConfigError);
+    expect(bad).toThrow(/between 1 and 28/);
+  });
+
+  it('refuses a seasonal shape that is not twelve months long', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.heating]
+name = "Heating"
+matches = [{ category = "Home", sub_category = "Energy" }]
+seasonal = { weights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] }
+`,
+      });
+    expect(bad).toThrow(/stops setting money aside for/);
+  });
+
+  it('refuses an all-zero seasonal shape', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.heating]
+name = "Heating"
+matches = [{ category = "Home", sub_category = "Energy" }]
+seasonal = { weights = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+`,
+      });
+    expect(bad).toThrow(/no total to divide by/);
+  });
+
+  it('refuses a negative seasonal weight', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.heating]
+name = "Heating"
+matches = [{ category = "Home", sub_category = "Energy" }]
+seasonal = { weights = [1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1, 1] }
+`,
+      });
+    expect(bad).toThrow(/take money back out of a month/);
+  });
+
+  it('refuses a seasonal shape giving both forms', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.heating]
+name = "Heating"
+matches = [{ category = "Home", sub_category = "Energy" }]
+seasonal = { months = [6], weights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] }
+`,
+      });
+    expect(bad).toThrow(/Give one/);
+  });
+
+  it('refuses a month outside the year', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.insurance]
+name = "Insurance"
+matches = [{ category = "Home", sub_category = "Insurance" }]
+seasonal = { months = [13] }
+`,
+      });
+    expect(bad).toThrow(/Months are 1 to 12/);
+  });
+
+  it('refuses an envelope that claims nothing', () => {
+    const bad = () =>
+      parse({ envelopes: '[envelopes.groceries]\nname = "Groceries"\nmatches = []\n' });
+    expect(bad).toThrow(/budgeted for spending that is also counted/);
+  });
+
+  it('refuses an envelope with one of estimate and goal', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = "7800.00"
+`,
+      });
+    expect(bad).toThrow(/Give both or neither/);
+  });
+
+  it('refuses an empty transfer label', () => {
+    const bad = () =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["  "]
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+`,
+      });
+    expect(bad).toThrow(/credit every inbound transfer/);
+  });
+
+  it('refuses one person’s label containing another’s', () => {
+    const bad = () =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["MARTIN"]
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.bruno]
+name = "Bruno"
+transfer_labels = ["MARTIN BRUNO"]
+[[people.bruno.income]]
+label = "Salary"
+monthly = "2450.00"
+`,
+      });
+    expect(bad).toThrow(/credited to neither/);
+  });
+
+  it('refuses a negative buffer', () => {
+    const bad = () => parse({ buffer: '[buffer]\ntarget = "-500.00"\n' });
+    expect(bad).toThrow(/reduce every contribution/);
+  });
+
+  it('refuses a file declaring no people', () => {
+    const bad = () => parseConfig(configToml({ people: '[people]\n' }), 'sluice.toml');
+    expect(bad).toThrow(/nobody to compute it for/);
+  });
+
+  it('refuses a file with no exports directory', () => {
+    const bad = () => parse({ exports: '[exports]\n' });
+    expect(bad).toThrow(/exports\.directory/);
+  });
+
+  it('refuses TOML it cannot parse, naming the file and keeping the cause', () => {
+    let caught: unknown;
+    try {
+      parseConfig('[exports\ndirectory = "x"', 'sluice.toml');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConfigError);
+    expect((caught as ConfigError).message).toMatch(/not valid TOML/);
+    expect((caught as ConfigError).cause).toBeDefined();
+  });
+});
+
+describe('parseConfig — reporting', () => {
+  it('reports every problem in the file at once, not one per run', () => {
+    // The file is hand-edited once a year. Five runs to find five typos works
+    // against the reason this product exists.
+    let message = '';
+    try {
+      parse({
+        buffer: '[buffer]\ntarget = 2500\n',
+        funding: '[funding]\ncutoff_day = 30\n',
+      });
+    } catch (error) {
+      message = (error as ConfigError).message;
+    }
+    expect(message).toMatch(/binary float/);
+    expect(message).toMatch(/between 1 and 28/);
+    expect(message).toMatch(/has 2 problems/);
+  });
+
+  it('does not complain about the meaning of a value it could not read', () => {
+    // A shape problem must not cascade into a domain complaint about a figure
+    // that was never parsed — that would send the reader after the wrong thing.
+    let message = '';
+    try {
+      parse({
+        envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+estimate = 7800
+goal = "7200.00"
+`,
+      });
+    } catch (error) {
+      message = (error as ConfigError).message;
+    }
+    expect(message).toMatch(/binary float/);
+    expect(message).not.toMatch(/optimised plan asks for more/);
+  });
+});
+
+describe('envelopeIndex', () => {
+  const config = parse({
+    envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Food", sub_category = "Supermarket" }]
+
+[envelopes.leisure]
+name = "Leisure"
+matches = [{ category = "Leisure" }]
+`,
+  });
+  const index = envelopeIndex(config);
+
+  it('finds the envelope claiming a pair', () => {
+    expect(index.find('Food', 'Supermarket')?.id).toBe('groceries');
+  });
+
+  it('falls back to a whole-category claim', () => {
+    expect(index.find('Leisure', 'Cinema')?.id).toBe('leisure');
+  });
+
+  it('returns null for a pair nobody claimed, so it gets an envelope of its own', () => {
+    expect(index.find('Food', 'Restaurant')).toBeNull();
+    expect(index.find('Transport', 'Fuel')).toBeNull();
+  });
+});
+
+describe('peopleMatching', () => {
+  const config = parse({
+    people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["ALICE MARTIN"]
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.bruno]
+name = "Bruno"
+transfer_labels = ["B DUPONT"]
+[[people.bruno.income]]
+label = "Salary"
+monthly = "2450.00"
+`,
+  });
+
+  it('credits a transfer to the person whose label catches it', () => {
+    expect(peopleMatching(config, 'VIR RECU ALICE MARTIN').map((p) => p.id)).toEqual(['alice']);
+  });
+
+  it('credits nobody when no label catches it', () => {
+    expect(peopleMatching(config, 'VIR VERS COMPTE CHEQUE')).toEqual([]);
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,516 @@
+import { parse, TomlError } from 'smol-toml';
+import { formatEur, type Cents } from '../core/money.ts';
+import { INTERNAL_TRANSFER_SUBCATEGORY, SETTLEMENT_SUBCATEGORY } from '../ingest/ledger.ts';
+import { labelMatches, matchersOverlap, normaliseLabel, type EnvelopeMatcher } from './match.ts';
+import { Problems, Reader } from './values.ts';
+
+/**
+ * `sluice.toml` — everything sluice cannot read out of the bank exports, and
+ * nothing it can.
+ *
+ * No property here is optional. A key that may be absent from the file becomes
+ * either a union variant or `| null`, the way `Source` does in the ingest: it
+ * keeps `exactOptionalPropertyTypes` from reaching every consumer, and it forces
+ * the question "what does absent mean here" to be answered once, at the parse,
+ * rather than at each use.
+ */
+
+export type { EnvelopeMatcher } from './match.ts';
+
+/** Twelve relative weights, January to December. */
+export type SeasonalWeights = readonly [
+  number, number, number, number, number, number,
+  number, number, number, number, number, number,
+];
+
+export type IncomeSource =
+  | { readonly cadence: 'monthly'; readonly label: string; readonly net: Cents }
+  | { readonly cadence: 'annual'; readonly label: string; readonly net: Cents };
+
+export interface Person {
+  readonly id: string;
+  readonly name: string;
+  /** At least one. */
+  readonly income: readonly IncomeSource[];
+  /** May be empty: someone whose transfers never carry a name. */
+  readonly transferLabels: readonly string[];
+}
+
+/**
+ * Both figures or neither, so an optimised scenario is never shown against a
+ * realistic one nobody chose.
+ */
+export type EnvelopePlan =
+  | { readonly kind: 'derived' }
+  | { readonly kind: 'planned'; readonly estimate: Cents; readonly goal: Cents };
+
+export interface EnvelopeConfig {
+  readonly id: string;
+  readonly name: string;
+  /** At least one. */
+  readonly matches: readonly EnvelopeMatcher[];
+  readonly plan: EnvelopePlan;
+  /** `null` means take the shape from the envelope's own history. */
+  readonly seasonal: SeasonalWeights | null;
+}
+
+export interface Config {
+  /** As written. Resolved to an absolute path by `loadConfig`. */
+  readonly exportsDirectory: string;
+  readonly bufferTarget: Cents;
+  /** 1–28. A contribution on or after this day funds the following month. */
+  readonly fundingCutoffDay: number;
+  readonly people: readonly Person[];
+  readonly envelopes: readonly EnvelopeConfig[];
+}
+
+export class ConfigError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ConfigError';
+  }
+}
+
+// ── reading ───────────────────────────────────────────────────────────────
+
+function twelve(weights: readonly number[]): SeasonalWeights {
+  // Length is checked by the caller; the cast is what turns a checked array into
+  // the tuple that spares every consumer a `?? 0` on an index that cannot miss.
+  return weights as unknown as SeasonalWeights;
+}
+
+function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
+  const before = problems.count;
+  const hasMonths = r.has('months');
+  const hasWeights = r.has('weights');
+
+  if (hasMonths && hasWeights) {
+    problems.add(
+      r.where,
+      `"${r.where}" gives both "months" and "weights". Give one: "months" is the ` +
+        `shorthand for a pot that falls evenly across the months you list, "weights" ` +
+        `is the general form.`,
+    );
+    return null;
+  }
+  if (!hasMonths && !hasWeights) {
+    problems.add(
+      r.where,
+      `"${r.where}" gives neither "months" nor "weights". Remove it to take the ` +
+        `shape from this envelope's own history, or say which months the money falls in.`,
+    );
+    return null;
+  }
+
+  if (hasMonths) {
+    const months = r.integerArray('months');
+    r.done();
+    if (months === null || problems.count !== before) return null;
+    if (months.length === 0) {
+      problems.add(r.where, `"${r.where}.months" is empty. List the months the money falls in.`);
+      return null;
+    }
+    const weights = Array.from({ length: 12 }, () => 0);
+    for (const m of months) {
+      if (m < 1 || m > 12) {
+        problems.add(
+          r.where,
+          `"${r.where}.months" contains ${m}. Months are 1 to 12, January to December.`,
+        );
+        return null;
+      }
+      weights[m - 1] = 1;
+    }
+    return twelve(weights);
+  }
+
+  const weights = r.integerArray('weights');
+  r.done();
+  if (weights === null || problems.count !== before) return null;
+
+  if (weights.length !== 12) {
+    problems.add(
+      r.where,
+      `"${r.where}.weights" has ${weights.length} entries. It needs exactly 12, ` +
+        `January to December: with fewer, whichever month was dropped is the one the ` +
+        `plan stops setting money aside for.`,
+    );
+    return null;
+  }
+  const negative = weights.findIndex((w) => w < 0);
+  if (negative !== -1) {
+    problems.add(
+      r.where,
+      `"${r.where}.weights" entry ${negative + 1} is ${weights[negative]}. A weight is ` +
+        `a share of the year, and a negative share would take money back out of a ` +
+        `month that has already been budgeted.`,
+    );
+    return null;
+  }
+  if (weights.every((w) => w === 0)) {
+    problems.add(
+      r.where,
+      `"${r.where}.weights" are all zero. They are relative and are normalised by ` +
+        `their own total, so an all-zero shape has no total to divide by and the ` +
+        `envelope would be spread across no month at all. Twelve 1s is a flat year.`,
+    );
+    return null;
+  }
+  return twelve(weights);
+}
+
+function readMatcher(r: Reader, problems: Problems): EnvelopeMatcher | null {
+  const before = problems.count;
+  const category = r.string('category');
+  const subCategory = r.optionalString('sub_category');
+  const declaredSub = r.has('sub_category');
+  r.done();
+  if (category === null || problems.count !== before) return null;
+
+  if (!declaredSub) return { kind: 'category', category };
+  if (subCategory === null) return null;
+  return { kind: 'sub-category', category, subCategory };
+}
+
+const RESERVED: Record<string, string> = {
+  [SETTLEMENT_SUBCATEGORY]:
+    `is the deferred cards' monthly charge to the account, and the purchases behind ` +
+    `it are already itemised on the card exports — budgeting both would inflate the ` +
+    `year by roughly a third`,
+  [INTERNAL_TRANSFER_SUBCATEGORY]:
+    `is the household's own transfers between its own accounts — the funding side of ` +
+    `this whole exercise, not spending — so budgeting it would count money as spent ` +
+    `on the way in`,
+};
+
+function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig | null {
+  const before = problems.count;
+  const name = r.string('name');
+  const matchReaders = r.tableArray('matches');
+  const matches = (matchReaders ?? [])
+    .map((m) => readMatcher(m, problems))
+    .filter((m): m is EnvelopeMatcher => m !== null);
+  const declaredEstimate = r.has('estimate');
+  const declaredGoal = r.has('goal');
+  const estimate = r.optionalMoney('estimate');
+  const goal = r.optionalMoney('goal');
+  const seasonalReader = r.optionalTable('seasonal');
+  const seasonal = seasonalReader === null ? null : readSeasonal(seasonalReader, problems);
+  r.done();
+  if (name === null || problems.count !== before) return null;
+
+  if (matches.length === 0) {
+    problems.add(
+      r.where,
+      `Envelope "${id}" claims nothing. An envelope matching no category holds no ` +
+        `transactions, but its estimate still enters the plan — so the year is ` +
+        `budgeted for spending that is also counted under whatever envelope those ` +
+        `transactions really land in.`,
+    );
+    return null;
+  }
+
+  for (const m of matches) {
+    if (m.kind !== 'sub-category') continue;
+    const why = RESERVED[m.subCategory];
+    if (why === undefined) continue;
+    problems.add(
+      r.where,
+      `Envelope "${id}" claims "${m.subCategory}", which ${why}. sluice classifies ` +
+        `those rows before any envelope sees them.`,
+    );
+    return null;
+  }
+
+  if (declaredEstimate !== declaredGoal) {
+    const given = declaredEstimate ? 'estimate' : 'goal';
+    const missing = declaredEstimate ? 'goal' : 'estimate';
+    problems.add(
+      r.where,
+      `Envelope "${id}" sets "${given}" but not "${missing}". Give both or neither: ` +
+        `they are the realistic and optimised scenarios shown side by side, and one ` +
+        `alone would be compared against a figure taken from history that nobody chose.`,
+    );
+    return null;
+  }
+
+  let plan: EnvelopePlan = { kind: 'derived' };
+  if (declaredEstimate && declaredGoal) {
+    if (estimate === null || goal === null) return null;
+    if (goal > estimate) {
+      problems.add(
+        r.where,
+        `Envelope "${id}" has a goal of ${formatEur(goal)} above its estimate of ` +
+          `${formatEur(estimate)}. The goal is the optimised scenario and the estimate ` +
+          `the realistic one, so the goal is never the larger — as written, the ` +
+          `optimised plan asks for more money than the realistic one.`,
+      );
+      return null;
+    }
+    plan = { kind: 'planned', estimate, goal };
+  }
+
+  return { id, name, matches, plan, seasonal };
+}
+
+function readIncome(r: Reader, problems: Problems): IncomeSource | null {
+  const before = problems.count;
+  const label = r.string('label');
+  const declaredMonthly = r.has('monthly');
+  const declaredAnnual = r.has('annual');
+  const monthly = r.optionalMoney('monthly');
+  const annual = r.optionalMoney('annual');
+  r.done();
+  if (label === null || problems.count !== before) return null;
+
+  if (declaredMonthly && declaredAnnual) {
+    problems.add(
+      r.where,
+      `"${r.where}" gives both "monthly" and "annual". A source is one or the other ` +
+        `— write two entries if the salary and the bonus are both real, or the same ` +
+        `money is counted twice.`,
+    );
+    return null;
+  }
+  if (!declaredMonthly && !declaredAnnual) {
+    problems.add(
+      r.where,
+      `"${r.where}" gives neither "monthly" nor "annual". Say which the figure is: a ` +
+        `bonus read as a monthly salary is multiplied by twelve, and the split moves ` +
+        `with it.`,
+    );
+    return null;
+  }
+
+  const net = declaredMonthly ? monthly : annual;
+  if (net === null) return null;
+  if (net < 0) {
+    problems.add(r.where, `"${r.where}" is ${formatEur(net)}. Income cannot be negative.`);
+    return null;
+  }
+  return declaredMonthly
+    ? { cadence: 'monthly', label, net }
+    : { cadence: 'annual', label, net };
+}
+
+function readPerson(id: string, r: Reader, problems: Problems): Person | null {
+  const before = problems.count;
+  const name = r.string('name');
+  const declaredLabels = r.has('transfer_labels');
+  const rawLabels = r.optionalStringArray('transfer_labels');
+  const incomeReaders = r.tableArray('income');
+  const income = (incomeReaders ?? [])
+    .map((entry) => readIncome(entry, problems))
+    .filter((entry): entry is IncomeSource => entry !== null);
+  r.done();
+  if (name === null || problems.count !== before) return null;
+
+  if (income.length === 0) {
+    problems.add(
+      r.where,
+      `Person "${id}" has no income. The split is each person's net over the ` +
+        `household's, so a person with none is given a zero share and everyone else ` +
+        `is asked to fund the whole household.`,
+    );
+    return null;
+  }
+
+  const labels: string[] = [];
+  for (const [i, raw] of (declaredLabels ? (rawLabels ?? []) : []).entries()) {
+    const label = normaliseLabel(raw);
+    if (label === '') {
+      problems.add(
+        r.where,
+        `"${r.where}.transfer_labels" entry ${i + 1} is empty. An empty label is ` +
+          `contained in every string, so it would credit every inbound transfer in the ` +
+          `ledger to "${id}".`,
+      );
+      return null;
+    }
+    labels.push(label);
+  }
+
+  return { id, name, income, transferLabels: labels };
+}
+
+// ── cross-record rules ────────────────────────────────────────────────────
+
+function checkEnvelopesDoNotOverlap(envelopes: readonly EnvelopeConfig[], problems: Problems): void {
+  for (let i = 0; i < envelopes.length; i++) {
+    for (let j = i + 1; j < envelopes.length; j++) {
+      const a = envelopes[i]!;
+      const b = envelopes[j]!;
+      for (const ma of a.matches) {
+        for (const mb of b.matches) {
+          if (!matchersOverlap(ma, mb)) continue;
+          const what =
+            ma.kind === 'category' ? `"${ma.category}"` : `"${ma.category} / ${ma.subCategory}"`;
+          problems.add(
+            `envelopes.${a.id}`,
+            `Envelopes "${a.id}" and "${b.id}" both claim ${what}. Every transaction ` +
+              `belongs to exactly one envelope: two claims on the same spending count ` +
+              `it twice, once in each, and inflate the year by the size of the overlap.`,
+          );
+          return;
+        }
+      }
+    }
+  }
+}
+
+function checkLabelsDoNotCollide(people: readonly Person[], problems: Problems): void {
+  for (const person of people) {
+    for (const other of people) {
+      if (other.id === person.id) continue;
+      for (const mine of person.transferLabels) {
+        for (const theirs of other.transferLabels) {
+          if (!labelMatches(mine, theirs)) continue;
+          problems.add(
+            `people.${person.id}`,
+            `"${mine}" attributes to "${person.id}", but "${other.id}" declares ` +
+              `"${theirs}", which contains it. Every transfer matching the longer label ` +
+              `matches the shorter one too, so those transfers match two people and can ` +
+              `be credited to neither — they fall into the unattributed band while ` +
+              `looking configured.`,
+          );
+          return;
+        }
+      }
+    }
+  }
+}
+
+// ── the parse ─────────────────────────────────────────────────────────────
+
+export function parseConfig(text: string, path: string): Config {
+  let document: Record<string, unknown>;
+  try {
+    document = parse(text, {}) as Record<string, unknown>;
+  } catch (cause) {
+    if (cause instanceof TomlError) {
+      throw new ConfigError(
+        `"${path}" is not valid TOML: ${cause.message}. Nothing was loaded — sluice ` +
+          `reads the whole plan or none of it, because a half-read plan produces a ` +
+          `transfer figure that looks reasonable and is not.`,
+        { cause },
+      );
+    }
+    throw cause;
+  }
+
+  const problems = new Problems();
+  const root = new Reader(document, '', problems);
+
+  const exportsTable = root.table('exports');
+  const exportsDirectory = exportsTable === null ? null : exportsTable.string('directory');
+  exportsTable?.done();
+
+  const bufferTable = root.table('buffer');
+  const bufferTarget = bufferTable === null ? null : bufferTable.money('target');
+  bufferTable?.done();
+
+  const fundingTable = root.table('funding');
+  const fundingCutoffDay = fundingTable === null ? null : fundingTable.integer('cutoff_day', 1, 28);
+  fundingTable?.done();
+
+  const peopleTables = root.namedTables('people');
+  const people = [...(peopleTables ?? new Map())]
+    .map(([id, reader]) => readPerson(id, reader, problems))
+    .filter((p): p is Person => p !== null);
+
+  const envelopeTables = root.has('envelopes') ? root.namedTables('envelopes') : new Map();
+  const envelopes = [...(envelopeTables ?? new Map())]
+    .map(([id, reader]) => readEnvelope(id, reader, problems))
+    .filter((e): e is EnvelopeConfig => e !== null);
+
+  root.done();
+
+  if (bufferTarget !== null && bufferTarget < 0) {
+    problems.add(
+      'buffer.target',
+      `"buffer.target" is ${formatEur(bufferTarget)}. The buffer is a cushion the ` +
+        `account holds, so it cannot be negative — a negative target would reduce ` +
+        `every contribution by its size.`,
+    );
+  }
+
+  if (peopleTables !== null && peopleTables.size === 0) {
+    problems.add(
+      'people',
+      `sluice.toml declares no people. The whole output is "how much should each of ` +
+        `us transfer", so there is nobody to compute it for.`,
+    );
+  }
+
+  checkEnvelopesDoNotOverlap(envelopes, problems);
+  checkLabelsDoNotCollide(people, problems);
+
+  if (problems.count > 0) {
+    const listed = problems.list.map((p) => `  • ${p.message}`).join('\n');
+    throw new ConfigError(
+      `"${path}" has ${problems.count} problem${problems.count === 1 ? '' : 's'}:\n\n` +
+        `${listed}\n\n` +
+        `Nothing was loaded — sluice reads the whole plan or none of it, because a ` +
+        `half-read plan produces a transfer figure that looks reasonable and is not.`,
+    );
+  }
+
+  return {
+    exportsDirectory: exportsDirectory!,
+    bufferTarget: bufferTarget!,
+    fundingCutoffDay: fundingCutoffDay!,
+    people,
+    envelopes,
+  };
+}
+
+// ── lookups ───────────────────────────────────────────────────────────────
+
+export interface EnvelopeIndex {
+  /** The declared envelope claiming this pair, or `null` — meaning it gets one of its own. */
+  find(category: string, subCategory: string): EnvelopeConfig | null;
+}
+
+/**
+ * Built once, queried per transaction.
+ *
+ * Two levels rather than one flat key, because a category matcher claims
+ * sub-categories that only the ledger knows about — so a single flat map could
+ * not be built from the config alone.
+ */
+export function envelopeIndex(config: Config): EnvelopeIndex {
+  const byCategory = new Map<string, { whole: EnvelopeConfig | null; bySub: Map<string, EnvelopeConfig> }>();
+
+  for (const envelope of config.envelopes) {
+    for (const matcher of envelope.matches) {
+      let entry = byCategory.get(matcher.category);
+      if (entry === undefined) {
+        entry = { whole: null, bySub: new Map() };
+        byCategory.set(matcher.category, entry);
+      }
+      if (matcher.kind === 'category') entry.whole = envelope;
+      else entry.bySub.set(matcher.subCategory, envelope);
+    }
+  }
+
+  return {
+    find(category, subCategory) {
+      const entry = byCategory.get(category);
+      if (entry === undefined) return null;
+      return entry.bySub.get(subCategory) ?? entry.whole;
+    },
+  };
+}
+
+/**
+ * Everyone whose declared labels catch this transfer.
+ *
+ * Returns every match rather than the first. More than one is ambiguous, and a
+ * transfer that could be either person's is credited to neither — guessing here
+ * would move real money between two people's totals.
+ */
+export function peopleMatching(config: Config, label: string): readonly Person[] {
+  return config.people.filter((person) =>
+    person.transferLabels.some((pattern) => labelMatches(pattern, label)),
+  );
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -36,20 +36,30 @@ export interface Person {
   readonly transferLabels: readonly string[];
 }
 
-/**
- * Both figures or neither, so an optimised scenario is never shown against a
- * realistic one nobody chose.
- */
-export type EnvelopePlan =
-  | { readonly kind: 'derived' }
-  | { readonly kind: 'planned'; readonly estimate: Cents; readonly goal: Cents };
-
 export interface EnvelopeConfig {
   readonly id: string;
   readonly name: string;
   /** At least one. */
   readonly matches: readonly EnvelopeMatcher[];
-  readonly plan: EnvelopePlan;
+  /**
+   * What this envelope is expected to cost over a year. Required.
+   *
+   * Written down rather than derived, and that is the whole point. Its first
+   * value comes from last year's actuals — the generator hands you the figure —
+   * but from then on it is a commitment you own, and last year's actuals are a
+   * separate number it is compared against.
+   *
+   * An estimate that re-derived itself each year would track reality by
+   * construction and always agree with it, which would make the drift this
+   * product exists to catch invisible: spending could grow every year and the
+   * plan would silently grow with it, reporting no problem at any point.
+   */
+  readonly estimate: Cents;
+  /**
+   * An optimisation target, when there is one. `null` when this envelope is
+   * simply expected to cost what it costs.
+   */
+  readonly goal: Cents | null;
   /** `null` means take the shape from the envelope's own history. */
   readonly seasonal: SeasonalWeights | null;
 }
@@ -190,9 +200,7 @@ function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig
   const matches = (matchReaders ?? [])
     .map((m) => readMatcher(m, problems))
     .filter((m): m is EnvelopeMatcher => m !== null);
-  const declaredEstimate = r.has('estimate');
-  const declaredGoal = r.has('goal');
-  const estimate = r.optionalMoney('estimate');
+  const estimate = r.money('estimate');
   const goal = r.optionalMoney('goal');
   const seasonalReader = r.optionalTable('seasonal');
   const seasonal = seasonalReader === null ? null : readSeasonal(seasonalReader, problems);
@@ -222,35 +230,25 @@ function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig
     return null;
   }
 
-  if (declaredEstimate !== declaredGoal) {
-    const given = declaredEstimate ? 'estimate' : 'goal';
-    const missing = declaredEstimate ? 'goal' : 'estimate';
+  if (estimate === null) return null;
+
+  if (estimate < 0) {
+    problems.add(r.where, `Envelope "${id}" has an estimate of ${formatEur(estimate)}.`);
+    return null;
+  }
+
+  if (goal !== null && goal > estimate) {
     problems.add(
       r.where,
-      `Envelope "${id}" sets "${given}" but not "${missing}". Give both or neither: ` +
-        `they are the realistic and optimised scenarios shown side by side, and one ` +
-        `alone would be compared against a figure taken from history that nobody chose.`,
+      `Envelope "${id}" has a goal of ${formatEur(goal)} above its estimate of ` +
+        `${formatEur(estimate)}. The goal is the optimised scenario and the estimate ` +
+        `the realistic one, so the goal is never the larger — as written, the ` +
+        `optimised plan asks for more money than the realistic one.`,
     );
     return null;
   }
 
-  let plan: EnvelopePlan = { kind: 'derived' };
-  if (declaredEstimate && declaredGoal) {
-    if (estimate === null || goal === null) return null;
-    if (goal > estimate) {
-      problems.add(
-        r.where,
-        `Envelope "${id}" has a goal of ${formatEur(goal)} above its estimate of ` +
-          `${formatEur(estimate)}. The goal is the optimised scenario and the estimate ` +
-          `the realistic one, so the goal is never the larger — as written, the ` +
-          `optimised plan asks for more money than the realistic one.`,
-      );
-      return null;
-    }
-    plan = { kind: 'planned', estimate, goal };
-  }
-
-  return { id, name, matches, plan, seasonal };
+  return { id, name, matches, estimate, goal, seasonal };
 }
 
 function readIncome(r: Reader, problems: Problems): IncomeSource | null {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -74,10 +74,27 @@ export interface Config {
   readonly envelopes: readonly EnvelopeConfig[];
 }
 
+export interface ConfigErrorOptions extends ErrorOptions {
+  /** Every problem found, one per entry, unformatted. */
+  readonly problems?: readonly string[];
+}
+
 export class ConfigError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
+  /**
+   * The problems as a list, alongside the joined message.
+   *
+   * The message is for a terminal; the list is for anything that wants to render
+   * one problem per row. Without it a caller's only route is to split the message
+   * back apart on its bullet characters — re-parsing text this module already had
+   * structured. `AmountParseError` and `DateParseError` carry their fields the
+   * same way, for the same reason.
+   */
+  readonly problems: readonly string[];
+
+  constructor(message: string, options?: ConfigErrorOptions) {
     super(message, options);
     this.name = 'ConfigError';
+    this.problems = options?.problems ?? [];
   }
 }
 
@@ -95,6 +112,9 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
   const hasWeights = r.has('weights');
 
   if (hasMonths && hasWeights) {
+    r.skip('months');
+    r.skip('weights');
+    r.done();
     problems.add(
       `"${r.where}" gives both "months" and "weights". Give one: "months" is the ` +
         `shorthand for a pot that falls evenly across the months you list, "weights" ` +
@@ -103,10 +123,17 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
     return null;
   }
   if (!hasMonths && !hasWeights) {
-    problems.add(
-      `"${r.where}" gives neither "months" nor "weights". Remove it to take the ` +
-        `shape from this envelope's own history, or say which months the money falls in.`,
-    );
+    // Unknown keys first. Arriving here usually means a key was misspelt, and
+    // naming the misspelling is the whole answer — where advising the user to
+    // delete the table, which is all this branch could otherwise say, sends them
+    // to throw away the thing they got nearly right.
+    r.done();
+    if (problems.count === before) {
+      problems.add(
+        `"${r.where}" gives neither "months" nor "weights". Remove it to take the ` +
+          `shape from this envelope's own history, or say which months the money falls in.`,
+      );
+    }
     return null;
   }
 
@@ -176,16 +203,23 @@ function readMatcher(r: Reader, problems: Problems): EnvelopeMatcher | null {
   return { kind: 'sub-category', category, subCategory };
 }
 
-const RESERVED: Record<string, string> = {
-  [SETTLEMENT_SUBCATEGORY]:
+// A Map, not an object literal: an object lookup walks the prototype chain, so a
+// sub-category legitimately named "constructor" or "toString" would be refused as
+// reserved, with a stringified function as the explanation.
+const RESERVED = new Map<string, string>([
+  [
+    SETTLEMENT_SUBCATEGORY,
     `is the deferred cards' monthly charge to the account, and the purchases behind ` +
-    `it are already itemised on the card exports — budgeting both would inflate the ` +
-    `year by roughly a third`,
-  [INTERNAL_TRANSFER_SUBCATEGORY]:
+      `it are already itemised on the card exports — budgeting both would inflate the ` +
+      `year by roughly a third`,
+  ],
+  [
+    INTERNAL_TRANSFER_SUBCATEGORY,
     `is the household's own transfers between its own accounts — the funding side of ` +
-    `this whole exercise, not spending — so budgeting it would count money as spent ` +
-    `on the way in`,
-};
+      `this whole exercise, not spending — so budgeting it would count money as spent ` +
+      `on the way in`,
+  ],
+]);
 
 function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig | null {
   const before = problems.count;
@@ -213,7 +247,7 @@ function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig
 
   for (const m of matches) {
     if (m.kind !== 'sub-category') continue;
-    const why = RESERVED[m.subCategory];
+    const why = RESERVED.get(m.subCategory);
     if (why === undefined) continue;
     problems.add(
       `Envelope "${id}" claims "${m.subCategory}", which ${why}. sluice classifies ` +
@@ -226,6 +260,15 @@ function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig
 
   if (estimate < 0) {
     problems.add(`Envelope "${id}" has an estimate of ${formatEur(estimate)}.`);
+    return null;
+  }
+
+  if (goal !== null && goal < 0) {
+    // The estimate has this floor already. Without the same one here, "not above
+    // the estimate" is the only constraint on the goal, and any negative value
+    // satisfies it — leaving an optimised scenario that asks the household to set
+    // money aside in reverse.
+    problems.add(`Envelope "${id}" has a goal of ${formatEur(goal)}. A goal cannot be negative.`);
     return null;
   }
 
@@ -359,18 +402,29 @@ function checkEnvelopesDoNotOverlap(envelopes: readonly EnvelopeConfig[], proble
  * would cost a run per label.
  */
 function checkLabelsDoNotCollide(people: readonly Person[], problems: Problems): void {
-  for (const person of people) {
-    for (const other of people) {
-      if (other.id === person.id) continue;
-      for (const mine of person.transferLabels) {
-        for (const theirs of other.transferLabels) {
-          if (!labelMatches(mine, theirs)) continue;
+  // Unordered pairs. Both containment directions still have to be tested — which
+  // label is the shorter one depends on the order they happen to be declared in —
+  // but each pair is examined once, so a symmetric collision (two labels equal
+  // but for case or spacing) is one problem rather than the same problem twice
+  // with the roles swapped.
+  for (let i = 0; i < people.length; i++) {
+    for (let j = i + 1; j < people.length; j++) {
+      const a = people[i]!;
+      const b = people[j]!;
+      for (const inA of a.transferLabels) {
+        for (const inB of b.transferLabels) {
+          const found = labelMatches(inA, inB)
+            ? { shortId: a.id, short: inA, longId: b.id, long: inB }
+            : labelMatches(inB, inA)
+              ? { shortId: b.id, short: inB, longId: a.id, long: inA }
+              : null;
+          if (found === null) continue;
           problems.add(
-            `"${mine}" attributes to "${person.id}", but "${other.id}" declares ` +
-              `"${theirs}", which contains it. Every transfer matching the longer label ` +
-              `matches the shorter one too, so those transfers match two people and can ` +
-              `be credited to neither — they fall into the unattributed band while ` +
-              `looking configured.`,
+            `"${found.short}" attributes to "${found.shortId}", but "${found.longId}" ` +
+              `declares "${found.long}", which contains it. Every transfer matching the ` +
+              `longer label matches the shorter one too, so those transfers match two ` +
+              `people and can be credited to neither — they fall into the unattributed ` +
+              `band while looking configured.`,
           );
         }
       }
@@ -448,6 +502,7 @@ export function parseConfig(text: string, path: string): Config {
         `${listed}\n\n` +
         `Nothing was loaded — sluice reads the whole plan or none of it, because a ` +
         `half-read plan produces a transfer figure that looks reasonable and is not.`,
+      { problems: problems.list },
     );
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -96,7 +96,6 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
 
   if (hasMonths && hasWeights) {
     problems.add(
-      r.where,
       `"${r.where}" gives both "months" and "weights". Give one: "months" is the ` +
         `shorthand for a pot that falls evenly across the months you list, "weights" ` +
         `is the general form.`,
@@ -105,7 +104,6 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
   }
   if (!hasMonths && !hasWeights) {
     problems.add(
-      r.where,
       `"${r.where}" gives neither "months" nor "weights". Remove it to take the ` +
         `shape from this envelope's own history, or say which months the money falls in.`,
     );
@@ -117,14 +115,13 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
     r.done();
     if (months === null || problems.count !== before) return null;
     if (months.length === 0) {
-      problems.add(r.where, `"${r.where}.months" is empty. List the months the money falls in.`);
+      problems.add(`"${r.where}.months" is empty. List the months the money falls in.`);
       return null;
     }
     const weights = Array.from({ length: 12 }, () => 0);
     for (const m of months) {
       if (m < 1 || m > 12) {
         problems.add(
-          r.where,
           `"${r.where}.months" contains ${m}. Months are 1 to 12, January to December.`,
         );
         return null;
@@ -140,7 +137,6 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
 
   if (weights.length !== 12) {
     problems.add(
-      r.where,
       `"${r.where}.weights" has ${weights.length} entries. It needs exactly 12, ` +
         `January to December: with fewer, whichever month was dropped is the one the ` +
         `plan stops setting money aside for.`,
@@ -150,7 +146,6 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
   const negative = weights.findIndex((w) => w < 0);
   if (negative !== -1) {
     problems.add(
-      r.where,
       `"${r.where}.weights" entry ${negative + 1} is ${weights[negative]}. A weight is ` +
         `a share of the year, and a negative share would take money back out of a ` +
         `month that has already been budgeted.`,
@@ -159,7 +154,6 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
   }
   if (weights.every((w) => w === 0)) {
     problems.add(
-      r.where,
       `"${r.where}.weights" are all zero. They are relative and are normalised by ` +
         `their own total, so an all-zero shape has no total to divide by and the ` +
         `envelope would be spread across no month at all. Twelve 1s is a flat year.`,
@@ -209,7 +203,6 @@ function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig
 
   if (matches.length === 0) {
     problems.add(
-      r.where,
       `Envelope "${id}" claims nothing. An envelope matching no category holds no ` +
         `transactions, but its estimate still enters the plan — so the year is ` +
         `budgeted for spending that is also counted under whatever envelope those ` +
@@ -223,7 +216,6 @@ function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig
     const why = RESERVED[m.subCategory];
     if (why === undefined) continue;
     problems.add(
-      r.where,
       `Envelope "${id}" claims "${m.subCategory}", which ${why}. sluice classifies ` +
         `those rows before any envelope sees them.`,
     );
@@ -233,13 +225,12 @@ function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig
   if (estimate === null) return null;
 
   if (estimate < 0) {
-    problems.add(r.where, `Envelope "${id}" has an estimate of ${formatEur(estimate)}.`);
+    problems.add(`Envelope "${id}" has an estimate of ${formatEur(estimate)}.`);
     return null;
   }
 
   if (goal !== null && goal > estimate) {
     problems.add(
-      r.where,
       `Envelope "${id}" has a goal of ${formatEur(goal)} above its estimate of ` +
         `${formatEur(estimate)}. The goal is the optimised scenario and the estimate ` +
         `the realistic one, so the goal is never the larger — as written, the ` +
@@ -263,7 +254,6 @@ function readIncome(r: Reader, problems: Problems): IncomeSource | null {
 
   if (declaredMonthly && declaredAnnual) {
     problems.add(
-      r.where,
       `"${r.where}" gives both "monthly" and "annual". A source is one or the other ` +
         `— write two entries if the salary and the bonus are both real, or the same ` +
         `money is counted twice.`,
@@ -272,7 +262,6 @@ function readIncome(r: Reader, problems: Problems): IncomeSource | null {
   }
   if (!declaredMonthly && !declaredAnnual) {
     problems.add(
-      r.where,
       `"${r.where}" gives neither "monthly" nor "annual". Say which the figure is: a ` +
         `bonus read as a monthly salary is multiplied by twelve, and the split moves ` +
         `with it.`,
@@ -283,7 +272,7 @@ function readIncome(r: Reader, problems: Problems): IncomeSource | null {
   const net = declaredMonthly ? monthly : annual;
   if (net === null) return null;
   if (net < 0) {
-    problems.add(r.where, `"${r.where}" is ${formatEur(net)}. Income cannot be negative.`);
+    problems.add(`"${r.where}" is ${formatEur(net)}. Income cannot be negative.`);
     return null;
   }
   return declaredMonthly
@@ -305,7 +294,6 @@ function readPerson(id: string, r: Reader, problems: Problems): Person | null {
 
   if (income.length === 0) {
     problems.add(
-      r.where,
       `Person "${id}" has no income. The split is each person's net over the ` +
         `household's, so a person with none is given a zero share and everyone else ` +
         `is asked to fund the whole household.`,
@@ -318,7 +306,6 @@ function readPerson(id: string, r: Reader, problems: Problems): Person | null {
     const label = normaliseLabel(raw);
     if (label === '') {
       problems.add(
-        r.where,
         `"${r.where}.transfer_labels" entry ${i + 1} is empty. An empty label is ` +
           `contained in every string, so it would credit every inbound transfer in the ` +
           `ledger to "${id}".`,
@@ -333,29 +320,44 @@ function readPerson(id: string, r: Reader, problems: Problems): Person | null {
 
 // ── cross-record rules ────────────────────────────────────────────────────
 
+/**
+ * Reported once per pair of envelopes, not once per overlapping matcher.
+ *
+ * Every pair is examined — stopping at the first would leave a file with three
+ * overlaps taking three runs to clean up, which is exactly the one-problem-per-run
+ * behaviour this parser was built to avoid. But a whole-category matcher overlaps
+ * every sub-category matcher beneath it, so reporting each of those separately
+ * would bury one mistake under a dozen lines. The pair is the mistake; the first
+ * overlapping claim is the evidence for it.
+ */
 function checkEnvelopesDoNotOverlap(envelopes: readonly EnvelopeConfig[], problems: Problems): void {
   for (let i = 0; i < envelopes.length; i++) {
     for (let j = i + 1; j < envelopes.length; j++) {
       const a = envelopes[i]!;
       const b = envelopes[j]!;
-      for (const ma of a.matches) {
-        for (const mb of b.matches) {
-          if (!matchersOverlap(ma, mb)) continue;
-          const what =
-            ma.kind === 'category' ? `"${ma.category}"` : `"${ma.category} / ${ma.subCategory}"`;
-          problems.add(
-            `envelopes.${a.id}`,
-            `Envelopes "${a.id}" and "${b.id}" both claim ${what}. Every transaction ` +
-              `belongs to exactly one envelope: two claims on the same spending count ` +
-              `it twice, once in each, and inflate the year by the size of the overlap.`,
-          );
-          return;
-        }
-      }
+      const clash = a.matches
+        .flatMap((ma) => b.matches.map((mb) => [ma, mb] as const))
+        .find(([ma, mb]) => matchersOverlap(ma, mb));
+      if (clash === undefined) continue;
+
+      const [ma] = clash;
+      const what =
+        ma.kind === 'category' ? `"${ma.category}"` : `"${ma.category} / ${ma.subCategory}"`;
+      problems.add(
+        `Envelopes "${a.id}" and "${b.id}" both claim ${what}. Every transaction ` +
+          `belongs to exactly one envelope: two claims on the same spending count ` +
+          `it twice, once in each, and inflate the year by the size of the overlap.`,
+      );
     }
   }
 }
 
+/**
+ * Every colliding pair of labels, not just the first.
+ *
+ * Each one is a distinct edit the user has to make, so reporting one at a time
+ * would cost a run per label.
+ */
 function checkLabelsDoNotCollide(people: readonly Person[], problems: Problems): void {
   for (const person of people) {
     for (const other of people) {
@@ -364,14 +366,12 @@ function checkLabelsDoNotCollide(people: readonly Person[], problems: Problems):
         for (const theirs of other.transferLabels) {
           if (!labelMatches(mine, theirs)) continue;
           problems.add(
-            `people.${person.id}`,
             `"${mine}" attributes to "${person.id}", but "${other.id}" declares ` +
               `"${theirs}", which contains it. Every transfer matching the longer label ` +
               `matches the shorter one too, so those transfers match two people and can ` +
               `be credited to neither — they fall into the unattributed band while ` +
               `looking configured.`,
           );
-          return;
         }
       }
     }
@@ -425,7 +425,6 @@ export function parseConfig(text: string, path: string): Config {
 
   if (bufferTarget !== null && bufferTarget < 0) {
     problems.add(
-      'buffer.target',
       `"buffer.target" is ${formatEur(bufferTarget)}. The buffer is a cushion the ` +
         `account holds, so it cannot be negative — a negative target would reduce ` +
         `every contribution by its size.`,
@@ -434,7 +433,6 @@ export function parseConfig(text: string, path: string): Config {
 
   if (peopleTables !== null && peopleTables.size === 0) {
     problems.add(
-      'people',
       `sluice.toml declares no people. The whole output is "how much should each of ` +
         `us transfer", so there is nobody to compute it for.`,
     );
@@ -444,7 +442,7 @@ export function parseConfig(text: string, path: string): Config {
   checkLabelsDoNotCollide(people, problems);
 
   if (problems.count > 0) {
-    const listed = problems.list.map((p) => `  • ${p.message}`).join('\n');
+    const listed = problems.list.map((message) => `  • ${message}`).join('\n');
     throw new ConfigError(
       `"${path}" has ${problems.count} problem${problems.count === 1 ? '' : 's'}:\n\n` +
         `${listed}\n\n` +

--- a/src/config/values.ts
+++ b/src/config/values.ts
@@ -1,0 +1,255 @@
+import { parseAmount, AmountParseError, type Cents } from '../core/money.ts';
+
+/**
+ * Typed reading of a parsed TOML document, accumulating problems instead of
+ * throwing on the first one.
+ *
+ * `sluice.toml` is hand-edited about once a year, and this product exists
+ * because that yearly rebuild was expensive enough to skip. Reporting one typo
+ * per run works directly against that, so every accessor here records what is
+ * wrong and returns `null`, and the caller collects a whole file's worth of
+ * problems before giving up.
+ *
+ * The rule that keeps that honest: **a record with any missing part is not
+ * built.** Returning `null` never means "carry on with a default" — it means
+ * the caller skips constructing the thing, so a shape problem can never cascade
+ * into a misleading complaint about the meaning of a value that was never read.
+ */
+
+export interface Problem {
+  /** Dotted path into the file, e.g. `envelopes.groceries.estimate`. */
+  readonly where: string;
+  readonly message: string;
+}
+
+export class Problems {
+  private readonly items: Problem[] = [];
+
+  add(where: string, message: string): void {
+    this.items.push({ where, message });
+  }
+
+  get count(): number {
+    return this.items.length;
+  }
+
+  get list(): readonly Problem[] {
+    return this.items;
+  }
+}
+
+function isTable(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date);
+}
+
+/**
+ * A view over one TOML table.
+ *
+ * Tracks which keys have been asked for so `done()` can refuse the ones nobody
+ * wanted — the single highest-value check in the file. An unrecognised key is
+ * almost always a misspelling, and a misspelling leaves the key it was meant to
+ * set at its default: the figure that comes out is wrong rather than missing.
+ */
+export class Reader {
+  private readonly raw: Record<string, unknown>;
+  private readonly read = new Set<string>();
+
+  constructor(
+    table: Record<string, unknown>,
+    readonly where: string,
+    private readonly problems: Problems,
+  ) {
+    this.raw = table;
+  }
+
+  private path(key: string): string {
+    return this.where === '' ? key : `${this.where}.${key}`;
+  }
+
+  private fail(key: string, message: string): null {
+    this.problems.add(this.path(key), message);
+    return null;
+  }
+
+  /** Present, not a TOML date, and marked as read. `undefined` if absent. */
+  private take(key: string): unknown {
+    this.read.add(key);
+    const value = this.raw[key];
+    if (value instanceof Date) {
+      // Nothing in sluice.toml is a date. An unquoted TOML date becomes a
+      // timezone-bearing instant, which reads back a day earlier west of UTC —
+      // the exact hazard the rest of the codebase avoids by never using Date.
+      return this.fail(
+        key,
+        `"${this.path(key)}" is a date. Nothing in sluice.toml is a date, and an ` +
+          `unquoted one becomes a moment in time rather than text. Put quotes around it.`,
+      );
+    }
+    return value;
+  }
+
+  has(key: string): boolean {
+    return this.raw[key] !== undefined;
+  }
+
+  string(key: string): string | null {
+    const value = this.take(key);
+    if (value === undefined) {
+      return this.fail(key, `"${this.path(key)}" is missing.`);
+    }
+    if (typeof value !== 'string') {
+      return this.fail(key, `"${this.path(key)}" must be text, in quotes.`);
+    }
+    return value;
+  }
+
+  optionalString(key: string): string | null {
+    if (!this.has(key)) {
+      this.read.add(key);
+      return null;
+    }
+    return this.string(key);
+  }
+
+  stringArray(key: string): string[] | null {
+    const value = this.take(key);
+    if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
+    if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
+      return this.fail(key, `"${this.path(key)}" must be a list of quoted strings.`);
+    }
+    return value as string[];
+  }
+
+  optionalStringArray(key: string): string[] | null {
+    if (!this.has(key)) {
+      this.read.add(key);
+      return null;
+    }
+    return this.stringArray(key);
+  }
+
+  /**
+   * An amount, written as a quoted string.
+   *
+   * A bare TOML number is an IEEE double, and money here is integer cents so the
+   * card settlement check can be exact to the cent. The refusal is explicit
+   * rather than a silent conversion because the difference only shows up as a
+   * rounding error in a total nobody is checking by hand.
+   */
+  money(key: string): Cents | null {
+    const value = this.take(key);
+    if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
+    if (typeof value === 'number' || typeof value === 'bigint') {
+      return this.fail(
+        key,
+        `"${this.path(key)}" is the number ${String(value)}. Amounts are quoted — ` +
+          `${key} = "${String(value)}.00" — because a bare number here is a binary ` +
+          `float, and sluice holds money as whole cents so the card settlement ` +
+          `check can be exact.`,
+      );
+    }
+    if (typeof value !== 'string') {
+      return this.fail(key, `"${this.path(key)}" must be an amount in quotes, like "1200.00".`);
+    }
+    try {
+      return parseAmount(value, this.path(key));
+    } catch (cause) {
+      if (cause instanceof AmountParseError) {
+        return this.fail(key, `"${this.path(key)}" is "${value}", which is not an amount.`);
+      }
+      throw cause;
+    }
+  }
+
+  optionalMoney(key: string): Cents | null {
+    if (!this.has(key)) {
+      this.read.add(key);
+      return null;
+    }
+    return this.money(key);
+  }
+
+  integer(key: string, min: number, max: number): number | null {
+    const value = this.take(key);
+    if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
+    if (typeof value !== 'number' || !Number.isInteger(value)) {
+      return this.fail(key, `"${this.path(key)}" must be a whole number.`);
+    }
+    if (value < min || value > max) {
+      return this.fail(key, `"${this.path(key)}" is ${value}. It must be between ${min} and ${max}.`);
+    }
+    return value;
+  }
+
+  integerArray(key: string): number[] | null {
+    const value = this.take(key);
+    if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
+    if (!Array.isArray(value) || value.some((v) => typeof v !== 'number' || !Number.isInteger(v))) {
+      return this.fail(key, `"${this.path(key)}" must be a list of whole numbers.`);
+    }
+    return value as number[];
+  }
+
+  table(key: string): Reader | null {
+    const value = this.take(key);
+    if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
+    if (!isTable(value)) return this.fail(key, `"${this.path(key)}" must be a section.`);
+    return new Reader(value, this.path(key), this.problems);
+  }
+
+  optionalTable(key: string): Reader | null {
+    if (!this.has(key)) {
+      this.read.add(key);
+      return null;
+    }
+    return this.table(key);
+  }
+
+  /** `[people.alice]`, `[people.bruno]` — a table whose keys are ids. */
+  namedTables(key: string): Map<string, Reader> | null {
+    const parent = this.table(key);
+    if (parent === null) return null;
+    const out = new Map<string, Reader>();
+    for (const id of Object.keys(parent.raw)) {
+      const child = parent.take(id);
+      if (!isTable(child)) {
+        parent.fail(id, `"${parent.path(id)}" must be a section.`);
+        continue;
+      }
+      out.set(id, new Reader(child, parent.path(id), this.problems));
+    }
+    return out;
+  }
+
+  /** `[[people.alice.income]]` — an array of tables. */
+  tableArray(key: string): Reader[] | null {
+    const value = this.take(key);
+    if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
+    if (!Array.isArray(value) || !value.every(isTable)) {
+      return this.fail(key, `"${this.path(key)}" must be a list of sections.`);
+    }
+    return value.map((entry, i) => new Reader(entry, `${this.path(key)}[${i}]`, this.problems));
+  }
+
+  /**
+   * Refuse every key nobody asked for.
+   *
+   * Deliberately not a warning. A key sluice does not recognise is nearly always
+   * a misspelling of one it does, and the misspelt key leaves the real one
+   * unset — so the run produces a confident wrong number rather than an obvious
+   * absence. That is the failure this whole module exists to prevent.
+   */
+  done(): void {
+    for (const key of Object.keys(this.raw)) {
+      if (this.read.has(key)) continue;
+      const known = [...this.read].sort().join(', ');
+      this.problems.add(
+        this.path(key),
+        `"${this.path(key)}" is not a key sluice knows${known === '' ? '' : `. The keys here are: ${known}`}. ` +
+          `It is refused rather than ignored, because a misspelt key leaves the one ` +
+          `it was meant to set at its default and the figure that comes out is wrong ` +
+          `rather than missing.`,
+      );
+    }
+  }
+}

--- a/src/config/values.ts
+++ b/src/config/values.ts
@@ -107,6 +107,17 @@ export class Reader {
     return this.raw[key] !== undefined;
   }
 
+  /**
+   * Mark a key handled without reading it, so `done()` does not call it unknown.
+   *
+   * For the branches that reject a *combination* of keys — giving two forms of
+   * the same thing, or neither — where the keys themselves need no validation but
+   * still have to be accounted for before unknown keys can be reported.
+   */
+  skip(key: string): void {
+    this.read.add(key);
+  }
+
   string(key: string): string | null {
     const value = this.take(key);
     if (value === REFUSED) return null;
@@ -168,6 +179,19 @@ export class Reader {
     }
     if (typeof value !== 'string') {
       return this.fail(key, `"${this.path(key)}" must be an amount in quotes, like "1200.00".`);
+    }
+    if (value.trim() === '') {
+      // `parseAmount` reads an empty string as zero, which is right for the bank's
+      // CSV — debit and credit share a row and the unused one is blank. It is
+      // wrong for a file someone edits by hand: a half-finished edit would become
+      // a confident zero. A blank income gives that person a zero share of the
+      // split and asks everyone else to fund the whole household.
+      return this.fail(
+        key,
+        `"${this.path(key)}" is empty. Give the amount, or remove the line — an ` +
+          `empty amount would be read as zero euros and quietly change the figures ` +
+          `that come out.`,
+      );
     }
     try {
       return parseAmount(value, this.path(key));
@@ -233,6 +257,10 @@ export class Reader {
     const out = new Map<string, Reader>();
     for (const id of Object.keys(parent.raw)) {
       const child = parent.take(id);
+      // Already refused and reported — saying anything more about it would be a
+      // second complaint about one fault, which is the cascade this reader exists
+      // to prevent. Every other accessor guards this; this one did not.
+      if (child === REFUSED) continue;
       if (!isTable(child)) {
         parent.fail(id, `"${parent.path(id)}" must be a section.`);
         continue;

--- a/src/config/values.ts
+++ b/src/config/values.ts
@@ -16,27 +16,38 @@ import { parseAmount, AmountParseError, type Cents } from '../core/money.ts';
  * into a misleading complaint about the meaning of a value that was never read.
  */
 
-export interface Problem {
-  /** Dotted path into the file, e.g. `envelopes.groceries.estimate`. */
-  readonly where: string;
-  readonly message: string;
-}
-
+/**
+ * Every message locates itself — each one names the dotted path, the envelope or
+ * the person it is about. A separate location field was carried alongside for a
+ * while and rendered nowhere, which is how it was found: structure nothing reads
+ * is structure that will drift away from the thing it claims to describe.
+ */
 export class Problems {
-  private readonly items: Problem[] = [];
+  private readonly items: string[] = [];
 
-  add(where: string, message: string): void {
-    this.items.push({ where, message });
+  add(message: string): void {
+    this.items.push(message);
   }
 
   get count(): number {
     return this.items.length;
   }
 
-  get list(): readonly Problem[] {
+  get list(): readonly string[] {
     return this.items;
   }
 }
+
+/**
+ * Stands for a value the reader has already refused.
+ *
+ * Without it, refusing a value once and returning `null` let the next check
+ * treat the `null` as a *second* fault and record a second, misleading message —
+ * one mistake in the file, two complaints in the report, the later one naming
+ * the wrong problem. That is the cascade this module is built to prevent, so it
+ * has to be prevented here first.
+ */
+const REFUSED = Symbol('refused');
 
 function isTable(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date);
@@ -71,7 +82,7 @@ export class Reader {
   }
 
   private fail(key: string, message: string): null {
-    this.problems.add(this.path(key), message);
+    this.problems.add(message);
     return null;
   }
 
@@ -83,11 +94,11 @@ export class Reader {
       // Nothing in sluice.toml is a date. An unquoted TOML date becomes a
       // timezone-bearing instant, which reads back a day earlier west of UTC —
       // the exact hazard the rest of the codebase avoids by never using Date.
-      return this.fail(
-        key,
+      this.problems.add(
         `"${this.path(key)}" is a date. Nothing in sluice.toml is a date, and an ` +
           `unquoted one becomes a moment in time rather than text. Put quotes around it.`,
       );
+      return REFUSED;
     }
     return value;
   }
@@ -98,6 +109,7 @@ export class Reader {
 
   string(key: string): string | null {
     const value = this.take(key);
+    if (value === REFUSED) return null;
     if (value === undefined) {
       return this.fail(key, `"${this.path(key)}" is missing.`);
     }
@@ -117,6 +129,7 @@ export class Reader {
 
   stringArray(key: string): string[] | null {
     const value = this.take(key);
+    if (value === REFUSED) return null;
     if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
     if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
       return this.fail(key, `"${this.path(key)}" must be a list of quoted strings.`);
@@ -142,6 +155,7 @@ export class Reader {
    */
   money(key: string): Cents | null {
     const value = this.take(key);
+    if (value === REFUSED) return null;
     if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
     if (typeof value === 'number' || typeof value === 'bigint') {
       return this.fail(
@@ -175,6 +189,7 @@ export class Reader {
 
   integer(key: string, min: number, max: number): number | null {
     const value = this.take(key);
+    if (value === REFUSED) return null;
     if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
     if (typeof value !== 'number' || !Number.isInteger(value)) {
       return this.fail(key, `"${this.path(key)}" must be a whole number.`);
@@ -187,6 +202,7 @@ export class Reader {
 
   integerArray(key: string): number[] | null {
     const value = this.take(key);
+    if (value === REFUSED) return null;
     if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
     if (!Array.isArray(value) || value.some((v) => typeof v !== 'number' || !Number.isInteger(v))) {
       return this.fail(key, `"${this.path(key)}" must be a list of whole numbers.`);
@@ -196,6 +212,7 @@ export class Reader {
 
   table(key: string): Reader | null {
     const value = this.take(key);
+    if (value === REFUSED) return null;
     if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
     if (!isTable(value)) return this.fail(key, `"${this.path(key)}" must be a section.`);
     return new Reader(value, this.path(key), this.problems);
@@ -228,6 +245,7 @@ export class Reader {
   /** `[[people.alice.income]]` — an array of tables. */
   tableArray(key: string): Reader[] | null {
     const value = this.take(key);
+    if (value === REFUSED) return null;
     if (value === undefined) return this.fail(key, `"${this.path(key)}" is missing.`);
     if (!Array.isArray(value) || !value.every(isTable)) {
       return this.fail(key, `"${this.path(key)}" must be a list of sections.`);
@@ -248,7 +266,6 @@ export class Reader {
       if (this.read.has(key)) continue;
       const known = [...this.read].sort().join(', ');
       this.problems.add(
-        this.path(key),
         `"${this.path(key)}" is not a key sluice knows${known === '' ? '' : `. The keys here are: ${known}`}. ` +
           `It is refused rather than ignored, because a misspelt key leaves the one ` +
           `it was meant to set at its default and the figure that comes out is wrong ` +

--- a/src/config/values.ts
+++ b/src/config/values.ts
@@ -53,13 +53,17 @@ function isTable(value: unknown): value is Record<string, unknown> {
 export class Reader {
   private readonly raw: Record<string, unknown>;
   private readonly read = new Set<string>();
+  private readonly problems: Problems;
+  readonly where: string;
 
-  constructor(
-    table: Record<string, unknown>,
-    readonly where: string,
-    private readonly problems: Problems,
-  ) {
+  // Plain fields rather than constructor parameter properties: node executes
+  // this file's TypeScript directly, in strip-only mode, which does not support
+  // them. The test runner transforms instead of stripping and would accept them,
+  // which is how one got in here unnoticed — see src/runnable.test.ts.
+  constructor(table: Record<string, unknown>, where: string, problems: Problems) {
     this.raw = table;
+    this.where = where;
+    this.problems = problems;
   }
 
   private path(key: string): string {

--- a/src/runnable.test.ts
+++ b/src/runnable.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Every module must load under bare `node`, not only under the test runner.
+ *
+ * Imports carry explicit `.ts` extensions precisely so a module can be run or
+ * probed straight from a terminal, and node executes TypeScript in strip-only
+ * mode — which rejects a few constructs the type checker is perfectly happy
+ * with, constructor parameter properties chief among them.
+ *
+ * Vitest transforms rather than strips, so it accepts all of them. That gap let
+ * a parameter property into a new module unnoticed, with a green suite and a
+ * module that would not load. This closes it.
+ */
+
+const SRC = resolve(import.meta.dirname);
+
+function modulesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...modulesUnder(path));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe('every module', () => {
+  it('loads under bare node, not just under the test runner', () => {
+    const imports = modulesUnder(SRC)
+      .map((path) => `import(${JSON.stringify(pathToFileURL(path).href)})`)
+      .join(',\n');
+
+    expect(() =>
+      execFileSync(process.execPath, ['--input-type=module', '-e', `await Promise.all([\n${imports}\n])`], {
+        stdio: 'pipe',
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Step 2 of 5 towards #296. Draft — opened early so the plan is reviewable before
the code lands. Stacked on #297, now merged to `main`.

Household figures stay out of this repo. This describes structure and mechanism.

## Why

Step 1 gave us a reconciled ledger. It knows what was spent and when, and
nothing else. Every number the product exists to produce needs facts the bank
does not hold: who lives here, what they earn, which spending belongs in which
pot, how big a cushion to keep.

`sluice.toml` is the only thing maintained by hand, so it is also the only place
a typo can silently change a household's monthly transfer. That shapes the whole
step: **the interesting work is refusing bad input, not reading good input.**

Two contracts already exist and are asserted by a test in `src/ingest/load.test.ts` —
the file is named `sluice.toml`, and it carries `exports.directory`.

## Scope

Schema, parser, validation. **No budget maths** (step 3), **no page** (step 4).
It defines the types those steps consume and stops.

## Decisions

| decision | choice | why |
|---|---|---|
| Envelope default | one per **sub-category**, derived from the ledger; config groups them | the bank separates an annual insurance from a monthly internet bill at sub-category level. Defaulting to the parent re-creates the "lumpy spending" artefact that misled this project once already |
| Income | **monthly net** per source, **annual net** entries listed separately | reads straight off a payslip; bonuses stay honest without hand-amortising |
| Uncategorised rows | ingested normally, **warned about, never an error** | they are ordinary movement rows. Re-filed at the bank and re-exported; the `mergeLedger` recency fix from #297 makes the correction stick |
| Money in TOML | **quoted strings** | a bare `7800.10` is an IEEE double; `×100` gives `780009.9999999999`. Integer cents is what makes the settlement check exact |
| Seasonal shape | twelve relative integer weights, **per envelope** | holidays empty in July, school charges in September, insurance in June — a household-wide shape is meaningless |
| Validation | accumulate every problem, throw **one** error listing them all | see below |
| Schema library | **none**, hand-rolled | see below |

### Why no schema library

zod or valibot would do the boring half — is this a string, an array of tables —
in a fraction of the code. They cannot do the half that matters: a goal above
its estimate, two envelopes claiming one sub-category, an envelope claiming the
card-settlement sub-category. Those are domain rules, hand-written either way.
The house error style explains *consequences*, which no library generates, so
every message would need remapping regardless.

**The cost is real and named**: shape-checking is being hand-rolled, which is
where bugs hide, and part of the test budget goes on testing the validator
rather than the product. Mitigated by keeping the reader to a thin set of
accessors and by mutation-checking every rule.

### Why accumulate errors instead of throwing on the first

This departs from the ingest, deliberately. The ingest parses machine-generated
files, where the first error means the format changed and one error is the whole
story. `sluice.toml` is hand-edited once a year — and this product exists
because that yearly rebuild was painful enough to skip. Five runs to find five
typos works directly against its purpose.

Mechanically: a collector is threaded through the reader; accessors record a
problem and return `null` rather than throwing; the builder skips any record
whose parts came back `null`; domain rules then run only over what parsed. A
shape error therefore never cascades into a misleading domain error.

## The refusals that matter

Ordered by how silently each would otherwise produce a wrong number.

1. **Unknown key, anywhere.** The highest-value check here. A misspelt
   `cuttoff_day` leaves the real one unset and moves a whole month's contribution.
2. An amount written as a TOML number rather than a quoted string.
3. Any TOML date or time value — nothing here is a date, and a bare TOML date
   becomes a timezone-bearing instant.
4. **A goal above its estimate** — makes sluice argue for the opposite of what it
   is for.
5. **Two envelopes claiming the same pair** — counts that spending twice.
6. **An envelope claiming the card-settlement or internal-transfer sub-category** —
   the first is already itemised on the card exports, the second is the
   household's own funding.
7. A person with no income — given a zero share, so their partner is asked to
   fund everything.
8. An income entry with both, or neither, of `monthly`/`annual`.
9. A funding cutoff day outside 1–28 — the 30th does not exist in February.
10. Seasonal shapes: not exactly twelve weights, all zero, any negative, both
    forms at once, a month outside 1–12.
11. An envelope with no matchers, or with one of estimate/goal.
12. An empty transfer label — a substring of everything, so it would claim every
    inbound transfer — or one label containing another person's.
13. A negative buffer target; no people at all; no exports directory.

The exports directory is **not** stat-ed here. The ingest already fails with a
good message naming the folder, and checking twice reports it from the place
with worse locality.

## Deliberately not here

- **No default attribution for unnamed transfers.** Roughly half of inbound
  transfers carry no payer name, and assigning them to the likely person is
  exactly the assumption the data cannot support. Unmatched stays unattributed
  and visible.
- **No additions to `src/core/`.** The funding cutoff is a day-of-month integer,
  not a calendar date; `dayOfMonth()` already exists to compare against it.
- **No ledger-aware checks.** They had no consumer until step 4 — the same
  orphan-code shape as the reconciliation having no caller, which was a real
  finding on #297. They move to step 3, where something renders them.

## Verification

`npm run check`. Roughly 45 tests. The load-bearing ones are the refusals above,
plus:

- several problems in one file reported **together**, not one at a time
- a relative exports directory resolving against the config file, not the cwd
- the loader looking for exactly `sluice.toml`, pinning the cross-module contract
- **end to end**: a temp `sluice.toml` pointing at a temp folder of synthetic
  exports, asserting the config's directory reaches the ingest — the only check
  that the two halves meet, and previously the one thing CI would not have run
- **the documented example config is the test fixture**, so the docs and the
  parser cannot drift

**Mutation discipline**: for each refusal, delete the rule and confirm a test
goes red. #297 shipped two tests that could not fail for the reasons they named;
this is the cheap check that catches that class.

## Handed to step 3

**A generator that emits the envelope block from history** — read the ledger,
emit a ready-to-paste `[envelopes.*]` section with estimates from last year's
actuals and seasonal weights from its month-by-month distribution. The user
edits rather than authors. Given that the yearly rebuild being expensive is the
reason this project exists, that generator *is* the rebuild, and it is the
highest-value thing in step 3 rather than an afterthought.

Also: the ledger-aware checks above, and the largest-remainder allocation
invariant — distributing an annual pot across twelve months by weight must sum
exactly to the pot, not twelve independent roundings.

Refs #282, #296.


---

# Plan fidelity — six departures

A record of where this implementation diverged from its approved plan, kept for
`dev-loop`. The plan is the control; the diff is the measurement.

| | |
|---|---|
| Departures from the approved plan | **6** |
| Changed by the pre-approval review | **5** |
| Defects found during the build | **2** |
| Tests shipped | **171** (planned ~45) |

## How the loop ran

A plan was written, critically reviewed twice — once as an engineer, once as a
quality engineer — revised, approved, then implemented in four commits.

The self-review before approval is the part that paid. It changed five things,
one of which was a repeat of a defect fixed in the *previous* pull request: a
module computing findings with no consumer until two steps later, the same shape
as shipping a check nobody calls. That had already cost a review round once.

## The departures

### 1 · The planned lookup structure could not be built — *corrected*

> Plan: "a prebuilt `Map` keyed on category/subCategory"

A category-level matcher claims sub-categories that only the ledger knows about,
so a single flat map cannot be built from configuration alone. It became a
two-level structure behind a `find()` interface. A plan error, found the moment
it met real types.

### 2 · An unplanned test guarding how modules load — *added*

A constructor parameter property was reintroduced during the build. The test
runner transforms TypeScript and accepted it; bare `node` strips types and
refuses it. Green suite, module that would not load. `src/runnable.test.ts` now
imports every module under bare node, and was verified by putting the construct
back.

### 3 · The reader is three times the size the plan budgeted — *overshot*

> Plan: "roughly 80 lines, not a framework"

That line was the plan's own mitigation for choosing to hand-roll validation
rather than use a schema library. It shipped at about 250. Each accessor is small
and the shape is flat, but the budget was set for a reason and was missed without
anyone noticing until this review.

### 4 · A recommendation built on a measurement of the wrong thing — *reversed*

The plan declined to scan a secondary field for transfer senders. Mid-build it
was argued back in, citing "about 7% of rows carry a sender the primary field
does not". Measured properly, the marginal gain was **zero** — every such row
already carried the name in the primary field. The original decision stood; the
argument for changing it had been tested against the wrong question.

### 5 · An estimate is a commitment, not a derivation — *redesigned*

> Plan: estimate and goal, both or neither

Raised after approval, on reading a worked example. An estimate re-derived each
year from actuals would agree with reality by construction: spending could grow
annually, the plan would grow silently to match, and drift would never report.
The estimate became required and owned; the goal became optional.

**This survived a written plan and two review passes.**

### 6 · A planned method was redundant on contact — *trimmed*

One accessor in the plan was an alias for another; removed while typechecking.
Noted only because a fidelity record that lists solely the interesting departures
is not a fidelity record.

## What the loop got right

- Every architectural decision in the plan — module boundaries, error
  accumulation, no schema library, no additions to the shared core — survived
  contact unchanged.
- The mutation check the plan mandated found no gap in the validation rules,
  which is the answer it was supposed to be able to give.
- The worked example was made a test fixture, so documentation and parser cannot
  drift. That came from the pre-approval review, not the build.
- A suite passing on its first run was treated as a reason for suspicion. That
  habit is what surfaced the module-loading defect.

## Six changes for `dev-loop`

- [ ] **Make critical review a required plan stage, and check it against the last
      one.** It changed five things here, one repeating a defect fixed in the
      previous PR. Reviews are catching the same shapes twice because nothing
      carries the last round's findings forward.
      → *Add to the review prompt: "does this plan repeat any finding from the
      previous review?"*

- [ ] **Flag any plan sentence that states a behaviour without a mechanism.** The
      weakest section was the one hand-waved — "collect every problem in one
      pass", with no account of how. The review found exactly that, which suggests
      the pattern is detectable rather than lucky.
      → *Treat verbs without mechanisms as a review checklist item.*

- [ ] **Put a worked example in every plan that defines a user-authored format.**
      The strongest signal in this record: the estimate redesign survived a
      written plan, two self-review passes and an approval, then surfaced within
      minutes of a human reading a concrete example with real keys in it. Prose
      describes intent; examples expose consequences.
      → *Review the example as the primary artifact, not as an illustration.*

- [ ] **Treat a first-run-green suite as a trigger, not a finish.** Sixty-five
      tests passed on first execution. That prompted a mutation pass, which
      cleared the rules but incidentally exposed a module that could not load
      outside the test runner.
      → *On first-run-green, run the mutation check before calling the step done.*

- [ ] **Never mutate uncommitted code.** The hand-rolled mutation pass broke twice
      in twenty minutes: mutations stacked because `git checkout` cannot restore
      untracked files, then a later checkout silently reverted a fix by restoring
      a pre-fix commit. Both caught only because someone was watching.
      → *Commit first; automate the pass — tracked in #299.*

- [ ] **State the counterfactual before measuring, not after.** The reversed
      recommendation came from measuring something adjacent to the question:
      "does this field contain a sender" rather than "does it contain one the
      other field lacks". The number was real and the inference was wrong.
      → *Before measuring, write down what the result would be if the answer were
      no.*


---

# Code review — twenty findings, none of which crashed

Two rounds: Copilot, then a multi-angle review (line-by-line correctness, test
quality with adversarial input, and simplification with cross-module fit).
Recorded for `dev-loop` alongside the plan-fidelity record above.

| | |
|---|---|
| Copilot findings | **4** — 3 valid, 1 a question that found a real gap |
| Multi-angle findings | **15**, all confirmed |
| Reached independently by 2+ angles | **4** |
| Regressions introduced by an earlier fix | **1** |
| Tests added across both rounds | **26** (171 → 197) |

## Round 1 — Copilot

| finding | outcome |
|---|---|
| A refused value was reported twice — `take()` refused a TOML date, the type check that followed reported it again as "must be text" | fixed: a `REFUSED` sentinel every accessor bails on |
| Both cross-record checks returned after the first find, so a file with three overlaps took three runs to clean | fixed: every pair examined |
| `Problem.where` was collected and rendered nowhere | removed rather than rendered — every message already names its own location |
| *(question)* should `__fixtures__` be gitignored? | no — but it found that the ignore-negation covered only `src/ingest`, so a stored fixture under `src/config` would have been ignored silently and failed only in CI |

**All three findings were in code whose own comments claimed the opposite
behaviour** — a module header promising no cascading faults that cascaded at the
first opportunity, and two functions documenting accumulation that returned after
one find. That is a checkable pattern and my pre-approval review did not look for
it, because the comment and the code were written in the same pass and read as
one thing.

## Round 2 — multi-angle

### Wrong answers waiting to happen

| finding | why it mattered |
|---|---|
| **A blank amount read as zero** | `monthly = ""` gave that person a zero share and asked their partner to fund the entire household — passing the "has no income" refusal on the way. Reported nothing. |
| A misspelt seasonal key told the user to delete the table | two branches returned before the unknown-key check, on precisely the path a misspelling arrives at |
| `namedTables` lacked the guard every other accessor had | one date produced three problems, one of them false |
| A negative goal accepted | "not above the estimate" is satisfied by any negative value |
| Symmetric label collisions reported twice | **a regression from fixing Copilot's finding** — removing the early return exposed a both-directions loop it had masked |
| A sub-category named `constructor` refused | the reserved lookup walked the prototype chain and printed a stringified function as the reason |

### The systemic one

**Nine of the reader's type refusals had no test at all** — found by removing 26
rules one at a time and watching the suite stay green. `name = 5`,
`estimate = "twelve"`, `cutoff_day = 25.5`, `transfer_labels = [5]`, and five
more, all accepted.

The cause sat upstream of the tests. **The fixture builder could not express a
root-level value**: fragments are concatenated after `[exports]`, so anything not
opening its own table was swallowed by whichever table preceded it. A test
written as `envelopes = 5` landed inside the last income entry and passed on an
unknown-key error from an entirely different rule. Three refusals were
*structurally untestable*, and nothing indicated it, because the tests were green.

### Design and reach

| finding | outcome |
|---|---|
| `ConfigError` discarded the problem list it had just built | now carries `problems` alongside the joined message, as the two core parse errors carry their fields |
| `matcherMatches` shipped dead — exported, tested, no callers, not re-exported | now exported; step 3 could not have reached it and would have reimplemented the comparison, which is the drift its own file warns about |
| `EnvelopeIndex` type not re-exported | step 3 could call `envelopeIndex()` and not name what it returns |
| The ambiguous-attribution path is reachable and untested | validation only refuses labels that *contain* each other, so `"ALICE"` and `"MARTIN"` pass — and a transfer naming both matches both |
| README promised four things and listed five | the portfolio-facing page, first sentence of the config section |

## Four changes for `dev-loop`

- [ ] **Check the code against its own comments, as a distinct review pass.** All
      three Copilot findings were behaviour contradicting a doc comment two lines
      above it. Writing prose and code in one pass makes them read as one thing;
      reading them as separate claims is a different act and catches a different
      class.
      → *Add to the review prompt: "for each doc comment asserting a behaviour,
      verify the code does it."*

- [ ] **Ask what the test fixtures cannot express.** The nine untested refusals
      were not an oversight of diligence — three of them could not be tested
      through the builder at all. A fixture design silently bounds the test suite,
      and a green suite says nothing about what lies outside those bounds.
      → *When reviewing a fixture builder, enumerate the inputs it cannot produce.*

- [ ] **Re-review the code a fix touched, not just the fix.** Removing an early
      return to fix "only reports the first collision" exposed a both-directions
      loop the return had been masking. The fix was correct and introduced a bug
      one line away.
      → *After applying review fixes, re-run the angle that found them.*

- [ ] **Mutation-check on committed code, always.** Two operational failures in
      one session: mutations stacked because `git checkout` cannot restore
      untracked files, and a later checkout silently reverted a fix by restoring
      a pre-fix commit. Committing first made the same procedure clean.
      → *Already tracked as #299; this is the interim discipline.*

## Left for step 3, deliberately

- **An exact-sum allocator.** Seasonal weights are relative integers, and
  distributing an annual pot across twelve months must sum to exactly the pot —
  a largest-remainder allocation over integer cents, needed at four call sites.
  Config's own all-zero refusal already establishes the precondition
  (`sum(weights) > 0`) and its message asserts normalisation that no code yet
  backs. It belongs beside `sum` in `core/money.ts`, before step 3 writes its own.
- **The ledger-aware checks** — matcher-matches-nothing, label-matches-nothing,
  label-matches-two-people, and the uncategorised-rows warning — which have no
  consumer until something renders them.
