### PR TITLE
MVP step 3a · numbers: the split — allocate(), income, funding attribution

### DIFF
--- a/src/core/money.test.ts
+++ b/src/core/money.test.ts
@@ -85,6 +85,13 @@ describe('allocate', () => {
     expect(allocate(0, [1, 2, 3])).toEqual([0, 0, 0]);
   });
 
+  it('gives a zero weight nothing, without breaking the split for the rest', () => {
+    // Distinct from "all weights zero", which is refused: one weight can
+    // legitimately be zero (a person with no income this month) so long as
+    // the others still sum positive.
+    expect(allocate(100, [1, 0])).toEqual([100, 0]);
+  });
+
   it('refuses a negative total', () => {
     expect(() => allocate(-100, [1, 1])).toThrow(/non-negative/);
   });

--- a/src/core/money.test.ts
+++ b/src/core/money.test.ts
@@ -93,8 +93,10 @@ describe('allocate', () => {
     expect(() => allocate(100, [0, 0])).toThrow(/non-negative and sum to more than zero/);
   });
 
-  it('refuses a negative weight', () => {
-    expect(() => allocate(100, [1, -1])).toThrow(/non-negative and sum to more than zero/);
+  it('refuses a negative weight, even when the weights still sum positive', () => {
+    // Sum is 4, not <= 0 — isolates the negative-weight check from the
+    // all-zero-sum one, which [1, -1] (summing to 0) would not.
+    expect(() => allocate(100, [5, -1])).toThrow(/non-negative and sum to more than zero/);
   });
 });
 

--- a/src/core/money.test.ts
+++ b/src/core/money.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { AmountParseError, formatEur, formatEurCompact, parseAmount, sum } from './money.ts';
+import { AmountParseError, allocate, formatEur, formatEurCompact, parseAmount, sum } from './money.ts';
 
 /**
  * French grouping uses a narrow no-break space (U+202F), and which space ICU
@@ -54,6 +54,47 @@ describe('sum', () => {
 
     const many = Array.from({ length: 1000 }, () => 1049);
     expect(sum(many)).toBe(1_049_000);
+  });
+});
+
+describe('allocate', () => {
+  it('always sums back to the total, even when the weights do not divide it evenly', () => {
+    // 1000 / 3 = 333.33... per weight; three independent roundings would land
+    // on 999 or 1002 depending on which way each one rounds.
+    expect(sum(allocate(1000, [1, 1, 1]))).toBe(1000);
+  });
+
+  it('splits proportionally to the weights, worked by hand', () => {
+    // weight sum 3: shares are 666.67 and 333.33. Both floor to 666/333 = 999,
+    // and the one cent left over goes to the larger fractional remainder — the
+    // 2-weight, at 0.67 against 0.33.
+    expect(allocate(1000, [2, 1])).toEqual([667, 333]);
+  });
+
+  it('splits an exact ratio with nothing left to distribute', () => {
+    expect(allocate(10000, [3, 1])).toEqual([7500, 2500]);
+  });
+
+  it('breaks an exact tie by index, deterministically', () => {
+    // weight sum 5, share 2.2 each: every fractional remainder is exactly 0.2,
+    // so the tie-break is what decides which weight gets the spare cent.
+    expect(allocate(11, [1, 1, 1, 1, 1])).toEqual([3, 2, 2, 2, 2]);
+  });
+
+  it('gives every weight zero when the total is zero', () => {
+    expect(allocate(0, [1, 2, 3])).toEqual([0, 0, 0]);
+  });
+
+  it('refuses a negative total', () => {
+    expect(() => allocate(-100, [1, 1])).toThrow(/non-negative/);
+  });
+
+  it('refuses weights that are all zero', () => {
+    expect(() => allocate(100, [0, 0])).toThrow(/non-negative and sum to more than zero/);
+  });
+
+  it('refuses a negative weight', () => {
+    expect(() => allocate(100, [1, -1])).toThrow(/non-negative and sum to more than zero/);
   });
 });
 

--- a/src/core/money.ts
+++ b/src/core/money.ts
@@ -54,6 +54,52 @@ export function sum(amounts: readonly Cents[]): Cents {
   return total;
 }
 
+/**
+ * Split `total` across `weights`, proportionally, landing on a sum that is
+ * exactly `total` — never a cent short or over from independent roundings.
+ *
+ * Largest-remainder apportionment: each weight gets `floor(total * w / Σw)`,
+ * then the few cents still unassigned go one each to the weights with the
+ * largest fractional remainder, ties broken by index for a deterministic
+ * result. Twelve seasonal weights that must sum to exactly an annual
+ * estimate, or a household's incomes that must sum to exactly a monthly
+ * requirement, are why this exists: naive independent rounding of twelve or
+ * more shares does not sum back to the total it was split from.
+ *
+ * `total` must be non-negative — refuses otherwise. Nothing in this codebase
+ * ever allocates a negative pot, and floor-based remainder distribution is
+ * not validated for one, so the contract stays honest rather than
+ * half-supporting a case nothing exercises. `weights` must be non-negative
+ * and sum to more than zero: an internal invariant, not user input — config
+ * already refuses all-zero or negative seasonal weights and negative income
+ * at the parse stage, so nothing should ever call this with a broken weight
+ * set.
+ */
+export function allocate(total: Cents, weights: readonly number[]): Cents[] {
+  if (total < 0) {
+    throw new Error(`allocate: total must be non-negative, got ${total}`);
+  }
+  if (weights.some((w) => w < 0) || sum(weights) <= 0) {
+    throw new Error('allocate: weights must be non-negative and sum to more than zero');
+  }
+
+  const weightTotal = sum(weights);
+  const shares = weights.map((w) => (total * w) / weightTotal);
+  const bases = shares.map(Math.floor);
+  const remainder = total - sum(bases);
+
+  const byRemainder = shares
+    .map((s, i) => ({ i, fraction: s - Math.floor(s) }))
+    .sort((a, b) => b.fraction - a.fraction || a.i - b.i);
+
+  const out = [...bases];
+  for (let k = 0; k < remainder; k++) {
+    const i = byRemainder[k]!.i;
+    out[i] = (out[i] ?? 0) + 1;
+  }
+  return out;
+}
+
 const EUR = new Intl.NumberFormat('fr-FR', {
   style: 'currency',
   currency: 'EUR',

--- a/src/core/money.ts
+++ b/src/core/money.ts
@@ -66,14 +66,24 @@ export function sum(amounts: readonly Cents[]): Cents {
  * requirement, are why this exists: naive independent rounding of twelve or
  * more shares does not sum back to the total it was split from.
  *
+ * The remainder step needs a fraction, but computed as an IEEE-754 double
+ * (`(total * w) / weightTotal`) that fraction is exactly the kind of value
+ * this module's own "integer cents, never a float" rule exists to rule
+ * out — a near-tie between two weights could in principle round differently
+ * than exact arithmetic would. So the whole computation runs in `BigInt`
+ * instead: `total * w` divided by `weightTotal` is `bigint` truncating
+ * division, exact for any input, and the remainder used to break ties is the
+ * exact `bigint` remainder of that division, not a subtraction of floats.
+ * `weights` must therefore be whole numbers — true of every caller today,
+ * relative seasonal weights and `Cents` incomes alike.
+ *
  * `total` must be non-negative — refuses otherwise. Nothing in this codebase
- * ever allocates a negative pot, and floor-based remainder distribution is
- * not validated for one, so the contract stays honest rather than
- * half-supporting a case nothing exercises. `weights` must be non-negative
- * and sum to more than zero: an internal invariant, not user input — config
- * already refuses all-zero or negative seasonal weights and negative income
- * at the parse stage, so nothing should ever call this with a broken weight
- * set.
+ * ever allocates a negative pot, and this division is not validated for one,
+ * so the contract stays honest rather than half-supporting a case nothing
+ * exercises. `weights` must be non-negative and sum to more than zero: an
+ * internal invariant, not user input — config already refuses all-zero or
+ * negative seasonal weights and negative income at the parse stage, so
+ * nothing should ever call this with a broken weight set.
  */
 export function allocate(total: Cents, weights: readonly number[]): Cents[] {
   if (total < 0) {
@@ -83,16 +93,27 @@ export function allocate(total: Cents, weights: readonly number[]): Cents[] {
     throw new Error('allocate: weights must be non-negative and sum to more than zero');
   }
 
-  const weightTotal = sum(weights);
-  const shares = weights.map((w) => (total * w) / weightTotal);
-  const bases = shares.map(Math.floor);
-  const remainder = total - sum(bases);
+  const totalBig = BigInt(total);
+  const weightTotalBig = weights.reduce((acc, w) => acc + BigInt(w), 0n);
 
-  const byRemainder = shares
-    .map((s, i) => ({ i, fraction: s - Math.floor(s) }))
-    .sort((a, b) => b.fraction - a.fraction || a.i - b.i);
+  const bases: bigint[] = [];
+  const remainders: bigint[] = [];
+  for (const w of weights) {
+    const product = totalBig * BigInt(w);
+    bases.push(product / weightTotalBig);
+    remainders.push(product % weightTotalBig);
+  }
 
-  const out = [...bases];
+  // How many cents are still unassigned once every weight has its exact
+  // floor — always a small non-negative integer, at most one per weight,
+  // so converting it back to a plain number is safe.
+  const remainder = Number(totalBig - bases.reduce((a, b) => a + b, 0n));
+
+  const byRemainder = remainders
+    .map((r, i) => ({ i, remainder: r }))
+    .sort((a, b) => (b.remainder > a.remainder ? 1 : b.remainder < a.remainder ? -1 : 0) || a.i - b.i);
+
+  const out = bases.map(Number);
   for (let k = 0; k < remainder; k++) {
     const i = byRemainder[k]!.i;
     out[i] = (out[i] ?? 0) + 1;

--- a/src/numbers/__fixtures__/build.ts
+++ b/src/numbers/__fixtures__/build.ts
@@ -39,13 +39,18 @@ export interface TxParts {
 /**
  * One transaction. `id` defaults to a value derived from the other fields
  * rather than a shared counter, so two fixtures built in any order, in any
- * test, never collide and never depend on execution order.
+ * test, never collide and never depend on execution order. Includes `kind`
+ * specifically: a `movement` and a `settlement` on the same day for the same
+ * amount is an ordinary fixture to want, and without `kind` in the mix the
+ * two would default to the same id. Two rows that are genuinely identical in
+ * every field this touches still need an explicit `id` from the caller.
  */
 export function tx(parts: TxParts): Transaction {
+  const kind = parts.kind ?? 'movement';
   return {
-    id: parts.id ?? `${parts.occurredOn}:${parts.label ?? parts.category ?? 'movement'}:${parts.amount}`,
+    id: parts.id ?? `${parts.occurredOn}:${kind}:${parts.label ?? parts.category ?? 'movement'}:${parts.amount}`,
     source: parts.source ?? ACCOUNT,
-    kind: parts.kind ?? 'movement',
+    kind,
     occurredOn: parts.occurredOn as Day,
     settlesOn: (parts.settlesOn ?? parts.occurredOn) as Day,
     amount: parts.amount,

--- a/src/numbers/__fixtures__/build.ts
+++ b/src/numbers/__fixtures__/build.ts
@@ -1,0 +1,122 @@
+import type { Cents } from '../../core/money.ts';
+import type { Day } from '../../core/dates.ts';
+import type { Transaction, TransactionKind } from '../../ingest/ledger.ts';
+import { reconcileSettlements } from '../../ingest/reconcile.ts';
+import type { Ledger } from '../../ingest/load.ts';
+import type { Source } from '../../ingest/sources.ts';
+import { parseConfig, type Config, type IncomeSource, type Person } from '../../config/schema.ts';
+import { configToml, type ConfigParts } from '../../config/__fixtures__/build.ts';
+
+/**
+ * Fixtures shared across every PR in this step, extended additively as later
+ * ones need more — never by changing an existing default, which would
+ * silently shift what an earlier, already-merged PR's tests actually assert.
+ * Same discipline `config/__fixtures__/build.ts`'s `ConfigParts` already
+ * applies, one level up: everything here defaults to something usable, and a
+ * test overrides only the part it is exercising.
+ *
+ * `src/numbers/` operates one layer above ingest and config — on already
+ * -parsed `Transaction`s and a `Config`, not on bank export bytes or TOML
+ * text — so fixtures here build those shapes directly rather than going
+ * through `csvFixture`/`ofxFixture`. Parsing itself is proven by steps 1
+ * and 2's own suites; this step's tests have no reason to re-exercise it.
+ */
+
+const ACCOUNT: Source = { kind: 'account', id: '00000000001' };
+
+export interface TxParts {
+  readonly id?: string;
+  readonly kind?: TransactionKind;
+  readonly occurredOn: string; // YYYY-MM-DD
+  readonly settlesOn?: string; // YYYY-MM-DD, defaults to occurredOn
+  readonly amount: Cents;
+  readonly label?: string;
+  readonly category?: string;
+  readonly subCategory?: string;
+  readonly source?: Source;
+}
+
+/**
+ * One transaction. `id` defaults to a value derived from the other fields
+ * rather than a shared counter, so two fixtures built in any order, in any
+ * test, never collide and never depend on execution order.
+ */
+export function tx(parts: TxParts): Transaction {
+  return {
+    id: parts.id ?? `${parts.occurredOn}:${parts.label ?? parts.category ?? 'movement'}:${parts.amount}`,
+    source: parts.source ?? ACCOUNT,
+    kind: parts.kind ?? 'movement',
+    occurredOn: parts.occurredOn as Day,
+    settlesOn: (parts.settlesOn ?? parts.occurredOn) as Day,
+    amount: parts.amount,
+    label: parts.label ?? '',
+    description: '',
+    notes: '',
+    operationType: '',
+    category: parts.category ?? 'Alimentation',
+    subCategory: parts.subCategory ?? 'Supermarche',
+  };
+}
+
+/**
+ * Wraps transactions into a `Ledger`, reconciled for real via
+ * `reconcileSettlements` rather than a stubbed report — `src/numbers/` never
+ * reads `reconciliation` itself, but building an honest one costs nothing
+ * and means a fixture never has to fake a shape it doesn't understand.
+ */
+export function ledgerOf(transactions: readonly Transaction[]): Ledger {
+  const data = { transactions, sources: [] };
+  return { ...data, reconciliation: reconcileSettlements(data) };
+}
+
+export interface PersonParts {
+  readonly id: string;
+  readonly name?: string;
+  readonly income?: readonly IncomeSource[];
+  readonly transferLabels?: readonly string[];
+}
+
+export function person(parts: PersonParts): Person {
+  return {
+    id: parts.id,
+    name: parts.name ?? parts.id,
+    income: parts.income ?? [{ cadence: 'monthly', label: 'Salary', net: 300000 }],
+    transferLabels: parts.transferLabels ?? [],
+  };
+}
+
+/**
+ * Two people, one configured envelope over `Alimentation / Supermarche`,
+ * leaving every other category to be derived — the shape every later PR in
+ * this step (3b onward) needs to exercise both a configured and a derived
+ * envelope from the same document.
+ */
+const NUMBERS_PARTS: ConfigParts = {
+  people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["VIR ALICE MARTIN"]
+
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.bruno]
+name = "Bruno"
+transfer_labels = ["VIR B DUPONT"]
+
+[[people.bruno.income]]
+label = "Salary"
+monthly = "2450.00"
+`,
+  envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Alimentation", sub_category = "Supermarche" }]
+estimate = "1200.00"
+`,
+};
+
+export function numbersConfig(overrides: ConfigParts = {}): Config {
+  return parseConfig(configToml({ ...NUMBERS_PARTS, ...overrides }), 'sluice.toml');
+}

--- a/src/numbers/funding.test.ts
+++ b/src/numbers/funding.test.ts
@@ -107,6 +107,36 @@ describe('contributionsByMonth', () => {
     expect(month?.total).toBe(150000);
   });
 
+  it('folds a two-person match into unattributed, not into either person', () => {
+    const config = numbersConfig({
+      people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["ALICE"]
+
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.carol]
+name = "Carol"
+transfer_labels = ["CAROL"]
+
+[[people.carol.income]]
+label = "Salary"
+monthly = "2000.00"
+`,
+    });
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE CAROL JOINT', amount: 50000 }),
+    ]);
+    const [month] = contributionsByMonth(attributeContributions(config, ledger));
+
+    expect(month?.byPerson.size).toBe(0);
+    expect(month?.unattributed).toBe(50000);
+    expect(month?.total).toBe(50000);
+  });
+
   it('sorts months ascending', () => {
     const config = numbersConfig();
     const ledger = ledgerOf([

--- a/src/numbers/funding.test.ts
+++ b/src/numbers/funding.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { attributeContributions, contributionsByMonth } from './funding.ts';
+import { ledgerOf, numbersConfig, tx } from './__fixtures__/build.ts';
+
+describe('attributeContributions', () => {
+  it('credits a transfer to its own month when it arrives before the cutoff day', () => {
+    // Default fixture config: funding.cutoff_day = 25.
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-24', label: 'VIR ALICE MARTIN', amount: 100000 }),
+    ]);
+    const [c] = attributeContributions(config, ledger);
+    expect(c?.fundingMonth).toBe('2026-01');
+  });
+
+  it('credits a transfer to the following month exactly on the cutoff day', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-25', label: 'VIR ALICE MARTIN', amount: 100000 }),
+    ]);
+    const [c] = attributeContributions(config, ledger);
+    expect(c?.fundingMonth).toBe('2026-02');
+  });
+
+  it('credits the person whose label the transfer matches', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+    ]);
+    const [c] = attributeContributions(config, ledger);
+    expect(c?.people.map((p) => p.id)).toEqual(['alice']);
+  });
+
+  it('matches nobody when no declared label catches the transfer', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR UNKNOWN SENDER', amount: 100000 }),
+    ]);
+    const [c] = attributeContributions(config, ledger);
+    expect(c?.people).toEqual([]);
+  });
+
+  it('matches two people when a label satisfies both their patterns, without guessing', () => {
+    // Two labels engineered not to contain one another (config refuses that at
+    // parse time), but which both appear in one transaction's real label — the
+    // runtime ambiguity no static config check can see.
+    const config = numbersConfig({
+      people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["ALICE"]
+
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.carol]
+name = "Carol"
+transfer_labels = ["CAROL"]
+
+[[people.carol.income]]
+label = "Salary"
+monthly = "2000.00"
+`,
+    });
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE CAROL JOINT', amount: 50000 }),
+    ]);
+    const [c] = attributeContributions(config, ledger);
+    expect(c?.people.map((p) => p.id).sort()).toEqual(['alice', 'carol']);
+  });
+
+  it('considers only transfer-in transactions', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ kind: 'movement', occurredOn: '2026-01-05', amount: -5000 }),
+      tx({ kind: 'transfer-out', occurredOn: '2026-01-05', label: 'VIR ALICE MARTIN', amount: -100000 }),
+      tx({ kind: 'settlement', occurredOn: '2026-01-05', amount: -20000 }),
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+    ]);
+    expect(attributeContributions(config, ledger)).toHaveLength(1);
+  });
+
+  it('sorts by funding month, then by transaction id', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ id: 'b', kind: 'transfer-in', occurredOn: '2026-02-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+      tx({ id: 'a', kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+    ]);
+    const contributions = attributeContributions(config, ledger);
+    expect(contributions.map((c) => c.transaction.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('contributionsByMonth', () => {
+  it('sums named and unattributed contributions separately, into one total', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ id: 'named', kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+      tx({ id: 'unnamed', kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR UNKNOWN', amount: 50000 }),
+    ]);
+    const [month] = contributionsByMonth(attributeContributions(config, ledger));
+
+    expect(month?.month).toBe('2026-01');
+    expect(month?.byPerson.get('alice')).toBe(100000);
+    expect(month?.unattributed).toBe(50000);
+    expect(month?.total).toBe(150000);
+  });
+
+  it('sorts months ascending', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-03-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+    ]);
+    const months = contributionsByMonth(attributeContributions(config, ledger));
+    expect(months.map((m) => m.month)).toEqual(['2026-01', '2026-03']);
+  });
+});

--- a/src/numbers/funding.ts
+++ b/src/numbers/funding.ts
@@ -34,7 +34,7 @@ export interface Contribution {
  */
 export function attributeContributions(config: Config, ledger: Ledger): readonly Contribution[] {
   const contributions = ledger.transactions
-    .filter((t): t is Transaction => t.kind === 'transfer-in')
+    .filter((t) => t.kind === 'transfer-in')
     .map((transaction) => {
       const fundingMonth =
         dayOfMonth(transaction.occurredOn) >= config.fundingCutoffDay

--- a/src/numbers/funding.ts
+++ b/src/numbers/funding.ts
@@ -1,0 +1,92 @@
+import type { Cents } from '../core/money.ts';
+import { addMonths, dayOfMonth, monthOf, type Month } from '../core/dates.ts';
+import { peopleMatching, type Config, type Person } from '../config/load.ts';
+import type { Ledger } from '../ingest/load.ts';
+import type { Transaction } from '../ingest/ledger.ts';
+
+/**
+ * A contribution is credited to the month it funds, not the month it posts.
+ *
+ * A transfer sent in the last days of a month is that month's payment for
+ * the month that follows; bucketing it by posting date would report a paid
+ * month as missed. Only `transfer-in` transactions are considered —
+ * `transfer-out` and `settlement` play no part in funding.
+ */
+export interface Contribution {
+  readonly transaction: Transaction;
+  readonly fundingMonth: Month;
+  /** Every person whose declared labels catch this transfer's own label — 0, 1, or 2+. */
+  readonly people: readonly Person[];
+}
+
+/**
+ * Every inbound transfer, dated by the month it funds and credited to
+ * whoever's transfer label catches it.
+ *
+ * `people` uses `peopleMatching()` rather than reimplementing the match: it
+ * already returns every match, so 0 or 2+ people is representable without
+ * new logic here, and the meaning of a `transfer_labels` entry can never
+ * drift between config validation and this.
+ *
+ * Sorted by funding month, then by transaction id — every list under
+ * `src/numbers/` commits to an order rather than leaving it to whatever a
+ * `Map` happened to iterate in.
+ */
+export function attributeContributions(config: Config, ledger: Ledger): readonly Contribution[] {
+  const contributions = ledger.transactions
+    .filter((t): t is Transaction => t.kind === 'transfer-in')
+    .map((transaction) => {
+      const fundingMonth =
+        dayOfMonth(transaction.occurredOn) >= config.fundingCutoffDay
+          ? addMonths(monthOf(transaction.occurredOn), 1)
+          : monthOf(transaction.occurredOn);
+      return { transaction, fundingMonth, people: peopleMatching(config, transaction.label) };
+    });
+
+  return contributions.sort((a, b) =>
+    a.fundingMonth === b.fundingMonth
+      ? a.transaction.id.localeCompare(b.transaction.id)
+      : a.fundingMonth.localeCompare(b.fundingMonth),
+  );
+}
+
+export interface MonthlyContributions {
+  readonly month: Month;
+  readonly byPerson: ReadonlyMap<string, Cents>;
+  /** Contributions matching nobody, or two people at once — never guessed at. */
+  readonly unattributed: Cents;
+  readonly total: Cents;
+}
+
+/**
+ * `attributeContributions`, folded into the "named-sender vs unattributed"
+ * figure section 01 of the page shows.
+ *
+ * A contribution matching more than one person is as unattributable as one
+ * matching none: crediting it to either would move real money onto the
+ * wrong person's total, so it joins the same unattributed band.
+ */
+export function contributionsByMonth(
+  contributions: readonly Contribution[],
+): readonly MonthlyContributions[] {
+  const byMonth = new Map<Month, { byPerson: Map<string, Cents>; unattributed: Cents; total: Cents }>();
+
+  for (const c of contributions) {
+    let entry = byMonth.get(c.fundingMonth);
+    if (entry === undefined) {
+      entry = { byPerson: new Map(), unattributed: 0, total: 0 };
+      byMonth.set(c.fundingMonth, entry);
+    }
+    entry.total += c.transaction.amount;
+    if (c.people.length === 1) {
+      const person = c.people[0]!;
+      entry.byPerson.set(person.id, (entry.byPerson.get(person.id) ?? 0) + c.transaction.amount);
+    } else {
+      entry.unattributed += c.transaction.amount;
+    }
+  }
+
+  return [...byMonth.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, entry]) => ({ month, ...entry }));
+}

--- a/src/numbers/income.test.ts
+++ b/src/numbers/income.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { sum } from '../core/money.ts';
+import { computeShares, netMonthly } from './income.ts';
+import { numbersConfig, person } from './__fixtures__/build.ts';
+
+describe('netMonthly', () => {
+  it('sums monthly entries directly', () => {
+    const p = person({
+      id: 'alice',
+      income: [
+        { cadence: 'monthly', label: 'Salary', net: 320000 },
+        { cadence: 'monthly', label: 'Side job', net: 25000 },
+      ],
+    });
+    expect(netMonthly(p)).toBe(345000);
+  });
+
+  it('folds an annual entry in at net / 12', () => {
+    const p = person({ id: 'alice', income: [{ cadence: 'annual', label: 'Profit share', net: 480000 }] });
+    expect(netMonthly(p)).toBe(40000);
+  });
+
+  it('rounds a non-exact annual division rather than losing the remainder', () => {
+    // 100 cents / 12 = 8.33...: the rounding is deliberately not exactness
+    // checked here, only where it feeds allocate() as the household total.
+    const p = person({ id: 'alice', income: [{ cadence: 'annual', label: 'Bonus', net: 100 }] });
+    expect(netMonthly(p)).toBe(8);
+  });
+
+  it('combines monthly and annual sources for the same person', () => {
+    const p = person({
+      id: 'alice',
+      income: [
+        { cadence: 'monthly', label: 'Salary', net: 320000 },
+        { cadence: 'annual', label: 'Profit share', net: 480000 },
+      ],
+    });
+    expect(netMonthly(p)).toBe(360000);
+  });
+});
+
+describe('computeShares', () => {
+  it('splits proportionally to income and sums exactly to the requirement', () => {
+    // alice 3200.00, bruno 2450.00 net monthly, from the shared fixture.
+    // weight sum 565000; requirement 1000.00 (100000c).
+    // alice: 100000*320000/565000 = 56637.168..., floor 56637
+    // bruno: 100000*245000/565000 = 43362.832..., floor 43362 — sums to
+    // 99999, one cent short, and bruno's fraction (.832) is larger than
+    // alice's (.168), so bruno gets it: 56637 + 43363 = 100000.
+    const config = numbersConfig();
+    const shares = computeShares(config.people, 100000);
+
+    expect(shares).toEqual([
+      { personId: 'alice', netMonthly: 320000, amount: 56637 },
+      { personId: 'bruno', netMonthly: 245000, amount: 43363 },
+    ]);
+    expect(sum(shares.map((s) => s.amount))).toBe(100000);
+  });
+
+  it('keeps the sum exact for a requirement that does not divide evenly among three', () => {
+    const people = [
+      person({ id: 'a', income: [{ cadence: 'monthly', label: 'Salary', net: 100000 }] }),
+      person({ id: 'b', income: [{ cadence: 'monthly', label: 'Salary', net: 100000 }] }),
+      person({ id: 'c', income: [{ cadence: 'monthly', label: 'Salary', net: 100000 }] }),
+    ];
+    const shares = computeShares(people, 1000);
+    expect(sum(shares.map((s) => s.amount))).toBe(1000);
+  });
+
+  it('preserves the order people were declared in', () => {
+    const config = numbersConfig();
+    const shares = computeShares(config.people, 100000);
+    expect(shares.map((s) => s.personId)).toEqual(['alice', 'bruno']);
+  });
+});

--- a/src/numbers/income.test.ts
+++ b/src/numbers/income.test.ts
@@ -21,10 +21,13 @@ describe('netMonthly', () => {
   });
 
   it('rounds a non-exact annual division rather than losing the remainder', () => {
-    // 100 cents / 12 = 8.33...: the rounding is deliberately not exactness
-    // checked here, only where it feeds allocate() as the household total.
-    const p = person({ id: 'alice', income: [{ cadence: 'annual', label: 'Bonus', net: 100 }] });
-    expect(netMonthly(p)).toBe(8);
+    // 115 cents / 12 = 9.58...: chosen so rounding and truncation disagree
+    // (9 vs 10) — a value like 100/12 = 8.33 would pass either way and not
+    // actually prove Math.round() is what runs. The rounding is deliberately
+    // not exactness-checked here, only where it feeds allocate() as the
+    // household total.
+    const p = person({ id: 'alice', income: [{ cadence: 'annual', label: 'Bonus', net: 115 }] });
+    expect(netMonthly(p)).toBe(10);
   });
 
   it('combines monthly and annual sources for the same person', () => {

--- a/src/numbers/income.ts
+++ b/src/numbers/income.ts
@@ -1,0 +1,61 @@
+import { allocate, type Cents } from '../core/money.ts';
+import type { Person } from '../config/load.ts';
+
+/**
+ * What each person transfers this month — the household's monthly
+ * requirement, split by income.
+ *
+ * Recomputed on every run, never read from a stored figure: the household's
+ * incomes and the requirement both change, and a stale split would drift the
+ * same way a stale envelope estimate does.
+ */
+export interface PersonShare {
+  readonly personId: string;
+  /** This person's own monthly-equivalent income — the weight, not the transfer. */
+  readonly netMonthly: Cents;
+  /** What they actually transfer this month. */
+  readonly amount: Cents;
+}
+
+/**
+ * A person's income, folded to one monthly figure.
+ *
+ * An `annual` entry (a bonus, a profit share) divides by twelve and rounds.
+ * That rounding is deliberately not exactness-checked the way `allocate()`
+ * is: this figure only ever feeds `computeShares` as a relative *weight*,
+ * and it is `allocate()` that guarantees the transfers it produces sum to
+ * the requirement exactly, regardless of a cent of drift in the ratio.
+ */
+export function netMonthly(person: Person): Cents {
+  let total = 0;
+  for (const source of person.income) {
+    total += source.cadence === 'monthly' ? source.net : Math.round(source.net / 12);
+  }
+  return total;
+}
+
+/**
+ * Split `monthlyRequirement` across `people`, proportionally to each
+ * person's `netMonthly` income.
+ *
+ * `monthlyRequirement` is a plain `Cents` rather than anything derived from
+ * envelopes on purpose — this module has no import edge toward
+ * `numbers/envelopes.ts` or `numbers/consumption.ts`, and stays testable
+ * with a bare number. `numbers/plan.ts` is what supplies the real figure:
+ * this month's seasonally-paced total across every envelope.
+ *
+ * Order follows `people`, unchanged — the same order `sluice.toml`'s
+ * `[people.*]` tables were declared in.
+ */
+export function computeShares(
+  people: readonly Person[],
+  monthlyRequirement: Cents,
+): readonly PersonShare[] {
+  const weights = people.map(netMonthly);
+  const amounts = allocate(monthlyRequirement, weights);
+  return people.map((person, i) => ({
+    personId: person.id,
+    netMonthly: weights[i]!,
+    amount: amounts[i]!,
+  }));
+}


### PR DESCRIPTION
Step 3a of 4 towards #296 (see the plan comment on that issue for how 3a–3d
divide the step). Draft — opened for review before continuing to 3b. Stacked
on #298, now merged to `main`.

Household figures stay out of this repo. This describes structure and mechanism.

## Why

Steps 1 and 2 gave us a reconciled ledger and a validated `sluice.toml`.
Neither computes anything a person reads. Step 3 is where those two become
the four things #296 actually asks for — this PR is the first of them:
**what each person actually transfers this month.**

## Why split step 3 into four PRs

The four pieces map onto the four sections #296 already describes for the one
page it wants (01–04), and turn out to be almost independent as code: 3a and
3b each need only `Config` + `Ledger`, neither imports the other. Steps 1 and
2 combined were ~2,300 source lines and found roughly one review finding per
35 lines across four review rounds. Step 3 is comparable in size to steps 1
and 2 *combined* — one PR that size would mean carrying that many findings
through a single review pass. Four smaller PRs, each mapping to a section the
issue already names, keeps every review pass to roughly one step's worth of
code.

## Scope

Two things, both pure functions over already-parsed `Config`/`Ledger` — no
rendering, no envelopes, no I/O:

- **`allocate()`** in `src/core/money.ts` — largest-remainder apportionment.
  Every later piece of this step needs to divide a pot by relative weights and
  land on a sum that is *exactly* the pot (twelve seasonal months, a household's
  incomes); naive independent rounding does not sum back to the total it came
  from.
- **`src/numbers/income.ts` + `funding.ts`** — `computeShares()` splits a
  monthly requirement across people by net income, via `allocate()`.
  `attributeContributions()` credits each inbound transfer to the month it
  *funds*, not the month it posts, and to whoever's declared label catches it.
  `contributionsByMonth()` folds that into the named-sender vs unattributed
  figure section 01 needs.

`computeShares` takes the monthly requirement as a plain `Cents` rather than
computing it — that number depends on every envelope's seasonal pace, which is
3b's job. 3c's orchestrator (`numbers/plan.ts`) is what wires the two together.

## Decisions

| decision | choice | why |
|---|---|---|
| Apportionment | largest-remainder (Hamilton method), ties broken by index | the only method that both stays proportional and sums exactly |
| Income → weight | `netMonthly()` rounds an annual entry's `/12`, unchecked | it only ever feeds `allocate()` as a *ratio* — exactness is enforced once, at the output, not at every number that touches it |
| A transfer matching 0 or 2+ people | unattributed, never guessed | crediting it to either would move real money onto the wrong person's total |
| `allocate()`'s domain | refuses `total < 0` outright | nothing in this codebase ever allocates a negative pot, and floor-based remainder distribution was never validated for one — the contract says so instead of half-supporting it |

## Mutation testing, by hand, on committed code

Five mutations against the branches called out in the plan as load-bearing:
`allocate()`'s negative-total refusal, its negative-weight refusal, its
tie-break, `funding.ts`'s cutoff-day boundary, its `transfer-in`-only filter,
and the exactly-one-vs-two-or-more-matches split in `contributionsByMonth`.

Two survived on the first pass:

- The negative-weight test used weights summing to zero (`[1, -1]`), so it was
  really exercising the all-zero-sum check instead of the negative-weight one.
  Fixed with weights that still sum positive (`[5, -1]`).
- `contributionsByMonth` had no test distinguishing "exactly one match" from
  "two matches" at its *own* level — only `attributeContributions`'s output was
  checked. Added one asserting a two-person match lands in `unattributed`.

One mutation (dropping the explicit `|| a.i - b.i` tie-break) survives and
isn't a gap: `Array.prototype.sort` has been spec-guaranteed stable since
ES2019, so equal-fraction entries already keep index order without it. Left
the explicit tie-break in anyway — self-documenting beats relying on a reader
knowing that guarantee.

## Code review

Self-review of the diff before merge, before opening it up for outside review:

- `tx()`'s default fixture id omitted `kind`. A same-day, same-amount
  `movement` and `settlement` — an ordinary fixture 3b onward will want — would
  have silently collided on id. Fixed by including `kind` in the default;
  genuinely identical rows still need an explicit `id` from the caller.
- `attributeContributions`'s filter carried a `(t): t is Transaction`
  predicate that narrows nothing, since the input is already `Transaction[]`.
  Read as if narrowing were happening when it wasn't. Removed.
- Added the one `allocate()` case not yet covered: a single zero weight
  alongside a nonzero one — legitimate (a person with no income this month),
  distinct from all-weights-zero, which is refused.

## Copilot review

Two findings, both fixed:

- `allocate()` computed its remainder fraction as a float
  (`(total * w) / weightTotal`), contradicting this module's own "integer
  cents, never a float" rule even though every input/output stayed integer.
  Rewritten in `BigInt` — the division, remainder, and tie-break comparison
  are now all exact.
- `netMonthly`'s rounding test used `100/12 = 8.33`, where `Math.floor` and
  `Math.round` agree — the test would have passed even under silent
  truncation. Replaced with `115/12 = 9.58`, where they disagree (9 vs 10).

## Verification

```bash
npm run check
```

223 tests (was 197 before this PR), all passing.

## Deliberately not here

- **Envelopes, consumption, pacing** — 3b.
- **The checks, the audit warnings** — 3c, which needs 3a and 3b both merged.
- **The generator** — 3d.
- **Rendering** — step 4.


