### PR TITLE
MVP step 3c · numbers: the checks

### DIFF
--- a/src/numbers/audit.test.ts
+++ b/src/numbers/audit.test.ts
@@ -120,10 +120,6 @@ describe('auditPlan — uncategorised-rows', () => {
 describe('auditPlan — order', () => {
   it('is stated: grouped by kind, uncategorised-rows last', () => {
     const config = numbersConfig();
-    // No groceries spending (matcher-matches-nothing), no transfers at all
-    // (label-matches-nothing), plus an uncategorised row — three different
-    // kinds, deliberately built in a ledger that would produce them in a
-    // different order if `warnings` were left in encounter order.
     const ledger = ledgerOf([
       tx({ occurredOn: '2026-01-05', amount: -3000, category: UNCATEGORISED_OUTGOING, subCategory: 'Virement emis - a categoriser' }),
     ]);
@@ -134,5 +130,33 @@ describe('auditPlan — order', () => {
       'label-matches-nothing',
       'uncategorised-rows',
     ]);
+  });
+
+  it('sorts within a kind by its own key, not by declaration order', () => {
+    // "zoe" is declared before "alice" — encounter order (a no-op sort
+    // would preserve it, since Array.sort is stable) would put zoe's
+    // warning first. The sorted contract puts alice's first.
+    const config = numbersConfig({
+      people: `
+[people.zoe]
+name = "Zoe"
+transfer_labels = ["VIR ZOE"]
+
+[[people.zoe.income]]
+label = "Salary"
+monthly = "3000.00"
+
+[people.alice]
+name = "Alice"
+transfer_labels = ["VIR ALICE"]
+
+[[people.alice.income]]
+label = "Salary"
+monthly = "3000.00"
+`,
+    });
+    const ledger = ledgerOf([]); // neither label ever fires
+    const warnings = auditPlan(config, ledger).filter((w) => w.kind === 'label-matches-nothing');
+    expect(warnings.map((w) => (w.kind === 'label-matches-nothing' ? w.personId : null))).toEqual(['alice', 'zoe']);
   });
 });

--- a/src/numbers/audit.test.ts
+++ b/src/numbers/audit.test.ts
@@ -116,3 +116,23 @@ describe('auditPlan — uncategorised-rows', () => {
     expect(warnings.some((w) => w.kind === 'uncategorised-rows')).toBe(false);
   });
 });
+
+describe('auditPlan — order', () => {
+  it('is stated: grouped by kind, uncategorised-rows last', () => {
+    const config = numbersConfig();
+    // No groceries spending (matcher-matches-nothing), no transfers at all
+    // (label-matches-nothing), plus an uncategorised row — three different
+    // kinds, deliberately built in a ledger that would produce them in a
+    // different order if `warnings` were left in encounter order.
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -3000, category: UNCATEGORISED_OUTGOING, subCategory: 'Virement emis - a categoriser' }),
+    ]);
+    const warnings = auditPlan(config, ledger);
+    expect(warnings.map((w) => w.kind)).toEqual([
+      'matcher-matches-nothing',
+      'label-matches-nothing',
+      'label-matches-nothing',
+      'uncategorised-rows',
+    ]);
+  });
+});

--- a/src/numbers/audit.test.ts
+++ b/src/numbers/audit.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { auditPlan, UNCATEGORISED_INCOMING, UNCATEGORISED_OUTGOING } from './audit.ts';
+import { ledgerOf, numbersConfig, tx } from './__fixtures__/build.ts';
+
+describe('auditPlan — matcher-matches-nothing', () => {
+  it('flags a matcher that never fires against a real transaction', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([]); // no groceries spending at all
+    const warnings = auditPlan(config, ledger);
+    expect(warnings).toContainEqual({
+      kind: 'matcher-matches-nothing',
+      envelopeId: 'groceries',
+      matcher: { kind: 'sub-category', category: 'Alimentation', subCategory: 'Supermarche' },
+    });
+  });
+
+  it('does not flag a matcher that does fire', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+    const warnings = auditPlan(config, ledger);
+    expect(warnings.some((w) => w.kind === 'matcher-matches-nothing')).toBe(false);
+  });
+
+  it('flags each dead matcher of a multi-matcher envelope independently — one fires, one does not', () => {
+    const config = numbersConfig({
+      envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [
+  { category = "Alimentation", sub_category = "Supermarche" },
+  { category = "Alimentation", sub_category = "Marche" },
+]
+estimate = "1200.00"
+`,
+    });
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+    const warnings = auditPlan(config, ledger).filter((w) => w.kind === 'matcher-matches-nothing');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({ matcher: { subCategory: 'Marche' } });
+  });
+});
+
+describe('auditPlan — label-matches-nothing', () => {
+  it('flags a transfer label that never catches a real transfer', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([]); // no transfers at all
+    const warnings = auditPlan(config, ledger);
+    expect(warnings).toContainEqual({
+      kind: 'label-matches-nothing',
+      personId: 'alice',
+      label: 'VIR ALICE MARTIN',
+    });
+  });
+
+  it('does not flag a label that does catch a transfer', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+    ]);
+    const warnings = auditPlan(config, ledger).filter((w) => w.kind === 'label-matches-nothing');
+    expect(warnings.some((w) => w.kind === 'label-matches-nothing' && w.personId === 'alice')).toBe(false);
+  });
+});
+
+describe('auditPlan — transfer-matches-two-people', () => {
+  it('flags a real transfer whose label satisfies two people at once', () => {
+    const config = numbersConfig({
+      people: `
+[people.alice]
+name = "Alice"
+transfer_labels = ["ALICE"]
+
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+
+[people.carol]
+name = "Carol"
+transfer_labels = ["CAROL"]
+
+[[people.carol.income]]
+label = "Salary"
+monthly = "2000.00"
+`,
+    });
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE CAROL JOINT', amount: 50000 }),
+    ]);
+    const warnings = auditPlan(config, ledger).filter((w) => w.kind === 'transfer-matches-two-people');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({ people: expect.arrayContaining([expect.objectContaining({ id: 'alice' }), expect.objectContaining({ id: 'carol' })]) });
+  });
+});
+
+describe('auditPlan — uncategorised-rows', () => {
+  it('counts and totals rows the bank has not filed under a real category yet', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -3000, category: UNCATEGORISED_OUTGOING, subCategory: 'Virement emis - a categoriser' }),
+      tx({ occurredOn: '2026-01-06', amount: 5000, category: UNCATEGORISED_INCOMING, subCategory: 'Virement recu - a categoriser' }),
+    ]);
+    const warnings = auditPlan(config, ledger);
+    expect(warnings).toContainEqual({ kind: 'uncategorised-rows', count: 2, total: 2000 });
+  });
+
+  it('says nothing when there are no uncategorised rows', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+    const warnings = auditPlan(config, ledger);
+    expect(warnings.some((w) => w.kind === 'uncategorised-rows')).toBe(false);
+  });
+});

--- a/src/numbers/audit.ts
+++ b/src/numbers/audit.ts
@@ -1,0 +1,81 @@
+import { sum, type Cents } from '../core/money.ts';
+import { labelMatches } from '../config/match.ts';
+import { matcherMatches, type Config, type EnvelopeMatcher, type Person } from '../config/load.ts';
+import type { Ledger } from '../ingest/load.ts';
+import type { Transaction } from '../ingest/ledger.ts';
+import { attributeContributions } from './funding.ts';
+
+/**
+ * The bank's own markers for a row nobody has filed under a real category
+ * yet — measured against the real exports, not assumed. Nothing here is
+ * blank: an uncategorised row carries one of these two categories, each
+ * with its own `… - a categoriser` sub-categories.
+ */
+export const UNCATEGORISED_OUTGOING = "A categoriser - sortie d'argent";
+export const UNCATEGORISED_INCOMING = "A categoriser - rentree d'argent";
+
+/**
+ * Runtime findings a static read of `sluice.toml` cannot see — every one a
+ * warning, never thrown, the same non-throwing shape `ReconciliationReport`
+ * already uses. A shape problem in the config is refused at parse time; an
+ * audit finding here means the file parsed fine and still doesn't match
+ * this household's real data.
+ */
+export type PlanWarning =
+  /** A matcher shaped correctly but never firing against a real transaction — almost always the bank's wording moved. */
+  | { readonly kind: 'matcher-matches-nothing'; readonly envelopeId: string; readonly matcher: EnvelopeMatcher }
+  /** A transfer label that never catches a real inbound transfer. */
+  | { readonly kind: 'label-matches-nothing'; readonly personId: string; readonly label: string }
+  /**
+   * One real transfer whose label happens to satisfy two people's patterns
+   * at once — distinct from the config-time collision check, which only
+   * catches two *declared* labels containing one another. Two otherwise
+   * unrelated labels can both appear in one label no static check sees.
+   */
+  | { readonly kind: 'transfer-matches-two-people'; readonly transaction: Transaction; readonly people: readonly Person[] }
+  | { readonly kind: 'uncategorised-rows'; readonly count: number; readonly total: Cents };
+
+export function auditPlan(config: Config, ledger: Ledger): readonly PlanWarning[] {
+  const warnings: PlanWarning[] = [];
+
+  for (const envelope of config.envelopes) {
+    for (const matcher of envelope.matches) {
+      const fires = ledger.transactions.some(
+        (t) => t.kind === 'movement' && matcherMatches(matcher, t.category, t.subCategory),
+      );
+      if (!fires) warnings.push({ kind: 'matcher-matches-nothing', envelopeId: envelope.id, matcher });
+    }
+  }
+
+  for (const person of config.people) {
+    for (const label of person.transferLabels) {
+      const fires = ledger.transactions.some((t) => t.kind === 'transfer-in' && labelMatches(label, t.label));
+      if (!fires) warnings.push({ kind: 'label-matches-nothing', personId: person.id, label });
+    }
+  }
+
+  // Reuses attributeContributions rather than re-matching labels: the same
+  // reason 3a itself uses peopleMatching() instead of reimplementing the
+  // comparison — the meaning of a label match must never drift between the
+  // two places that check it.
+  for (const c of attributeContributions(config, ledger)) {
+    if (c.people.length >= 2) {
+      warnings.push({ kind: 'transfer-matches-two-people', transaction: c.transaction, people: c.people });
+    }
+  }
+
+  const uncategorised = ledger.transactions.filter(
+    (t) =>
+      t.kind === 'movement' &&
+      (t.category === UNCATEGORISED_OUTGOING || t.category === UNCATEGORISED_INCOMING),
+  );
+  if (uncategorised.length > 0) {
+    warnings.push({
+      kind: 'uncategorised-rows',
+      count: uncategorised.length,
+      total: sum(uncategorised.map((t) => t.amount)),
+    });
+  }
+
+  return warnings;
+}

--- a/src/numbers/audit.ts
+++ b/src/numbers/audit.ts
@@ -35,6 +35,20 @@ export type PlanWarning =
   | { readonly kind: 'transfer-matches-two-people'; readonly transaction: Transaction; readonly people: readonly Person[] }
   | { readonly kind: 'uncategorised-rows'; readonly count: number; readonly total: Cents };
 
+/** Groups by kind, then by a natural key within it — a stated order rather than however the checks below happen to run. */
+function sortKey(w: PlanWarning): string {
+  switch (w.kind) {
+    case 'matcher-matches-nothing':
+      return `0-${w.envelopeId}`;
+    case 'label-matches-nothing':
+      return `1-${w.personId}-${w.label}`;
+    case 'transfer-matches-two-people':
+      return `2-${w.transaction.id}`;
+    case 'uncategorised-rows':
+      return '3';
+  }
+}
+
 export function auditPlan(config: Config, ledger: Ledger): readonly PlanWarning[] {
   const warnings: PlanWarning[] = [];
 
@@ -77,5 +91,9 @@ export function auditPlan(config: Config, ledger: Ledger): readonly PlanWarning[
     });
   }
 
-  return warnings;
+  return warnings.sort((a, b) => {
+    const ka = sortKey(a);
+    const kb = sortKey(b);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
 }

--- a/src/numbers/checks.test.ts
+++ b/src/numbers/checks.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import type { Day } from '../core/dates.ts';
+import { checkPlan } from './checks.ts';
+import { resolveEnvelopes } from './envelopes.ts';
+import { computeConsumption } from './consumption.ts';
+import { ledgerOf, numbersConfig, tx } from './__fixtures__/build.ts';
+
+function check(configOverrides: Parameters<typeof numbersConfig>[0], transactions: Parameters<typeof tx>[0][], referenceDay: string) {
+  const config = numbersConfig(configOverrides);
+  const ledger = ledgerOf(transactions.map(tx));
+  const resolved = resolveEnvelopes(config, ledger);
+  const consumption = computeConsumption(ledger, resolved, referenceDay as Day);
+  return checkPlan(config, ledger, consumption, referenceDay as Day);
+}
+
+describe('checkPlan — goal status', () => {
+  const GOAL_ENVELOPE = `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Alimentation", sub_category = "Supermarche" }]
+estimate = "1200.00"
+goal = "1000.00"
+seasonal = { weights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] }
+`;
+
+  it('is no-goal when the envelope declares none', () => {
+    const result = check({}, [], '2026-06-01');
+    const envelope = result.envelopes.find((e) => e.envelope.kind === 'configured');
+    expect(envelope?.goalStatus).toBe('no-goal');
+    expect(envelope?.projectedFullYear).toBeNull();
+  });
+
+  it('is too-early when the reference month has no expected pace yet', () => {
+    // Seasonal weight entirely in December: as of June, paceExpected is 0.
+    const result = check(
+      { envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Alimentation", sub_category = "Supermarche" }]
+estimate = "1200.00"
+goal = "1000.00"
+seasonal = { months = [12] }
+` },
+      [],
+      '2026-06-01',
+    );
+    const envelope = result.envelopes.find((e) => e.envelope.kind === 'configured');
+    expect(envelope?.goalStatus).toBe('too-early');
+    expect(envelope?.projectedFullYear).toBeNull();
+  });
+
+  it('is on-track when the projection lands exactly on the goal — the boundary is inclusive', () => {
+    // Flat weights, estimate 1200.00 (120000c) => 10000/month. Reference
+    // June (month 6): paceExpected = 60000. Spend exactly 50000 so far:
+    // projectedFullYear = 50000 * 120000 / 60000 = 100000 = goal exactly.
+    const result = check(
+      { envelopes: GOAL_ENVELOPE },
+      [{ occurredOn: '2026-03-01', amount: -50000, category: 'Alimentation', subCategory: 'Supermarche' }],
+      '2026-06-01',
+    );
+    const envelope = result.envelopes.find((e) => e.envelope.kind === 'configured');
+    expect(envelope?.projectedFullYear).toBe(100000);
+    expect(envelope?.goalStatus).toBe('on-track');
+  });
+
+  it('is at-risk the moment the projection is one cent above the goal', () => {
+    const result = check(
+      { envelopes: GOAL_ENVELOPE },
+      [{ occurredOn: '2026-03-01', amount: -50001, category: 'Alimentation', subCategory: 'Supermarche' }],
+      '2026-06-01',
+    );
+    const envelope = result.envelopes.find((e) => e.envelope.kind === 'configured');
+    expect(envelope?.goalStatus).toBe('at-risk');
+  });
+
+  it('marks an envelope past pace only once spending exceeds what was expected, not at equality', () => {
+    // Flat, estimate 120000: paceExpected through June = 60000.
+    const atPace = check({ envelopes: GOAL_ENVELOPE }, [
+      { occurredOn: '2026-03-01', amount: -60000, category: 'Alimentation', subCategory: 'Supermarche' },
+    ], '2026-06-01');
+    expect(atPace.envelopes.find((e) => e.envelope.kind === 'configured')?.pastPace).toBe(false);
+
+    const overPace = check({ envelopes: GOAL_ENVELOPE }, [
+      { occurredOn: '2026-03-01', amount: -60001, category: 'Alimentation', subCategory: 'Supermarche' },
+    ], '2026-06-01');
+    expect(overPace.envelopes.find((e) => e.envelope.kind === 'configured')?.pastPace).toBe(true);
+  });
+});
+
+describe('checkPlan — plannedTotal, trailingYearActual, drift', () => {
+  it('plannedTotal sums only configured envelopes’ estimates, never a derived one’s spending', () => {
+    const result = check({}, [
+      { occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' },
+      { occurredOn: '2026-01-06', amount: -999999, category: 'Loisirs et vacances', subCategory: 'Cinema' },
+    ], '2026-06-01');
+    expect(result.plannedTotal).toBe(120000); // groceries' estimate only
+  });
+
+  it('trailingYearActual sums the 12 months ending on the reference day, worked by hand', () => {
+    const result = check({}, [
+      { id: 'too-old', occurredOn: '2025-06-20', amount: -1000, category: 'Alimentation', subCategory: 'Supermarche' }, // excluded: before the window
+      { id: 'window-start', occurredOn: '2025-07-01', amount: -2000, category: 'Alimentation', subCategory: 'Supermarche' }, // included: exactly 12 months back
+      { id: 'in-range', occurredOn: '2026-06-15', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }, // included: the reference day itself
+      { id: 'too-new', occurredOn: '2026-06-20', amount: -4000, category: 'Alimentation', subCategory: 'Supermarche' }, // excluded: after the reference day
+    ], '2026-06-15');
+    expect(result.trailingYearActual).toBe(5000);
+  });
+
+  it('drift is trailingYearActual minus plannedTotal', () => {
+    const result = check({}, [
+      { occurredOn: '2026-06-01', amount: -150000, category: 'Alimentation', subCategory: 'Supermarche' },
+    ], '2026-06-15');
+    expect(result.trailingYearActual).toBe(150000);
+    expect(result.plannedTotal).toBe(120000);
+    expect(result.drift).toBe(30000);
+  });
+});
+
+describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
+  it('counts a card settlement at settlesOn, not the card purchase at occurredOn', () => {
+    // If the card purchase counted directly, January would be -81000 —
+    // worse than February's settlement — and this would fail.
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-10', amount: -1000, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({
+        occurredOn: '2026-01-15',
+        settlesOn: '2026-01-15',
+        amount: -80000,
+        source: { kind: 'card', id: 'carte_1111', cardNumber: '1111' },
+      }),
+      tx({
+        kind: 'settlement',
+        occurredOn: '2026-02-04',
+        settlesOn: '2026-02-04',
+        amount: -80000,
+        category: 'Transaction exclue',
+        subCategory: 'Transaction differee',
+      }),
+    ]);
+    const resolved = resolveEnvelopes(config, ledger);
+    const consumption = computeConsumption(ledger, resolved, '2026-02-15' as Day);
+    const result = checkPlan(config, ledger, consumption, '2026-02-15' as Day);
+    expect(result.worstObservedMonth).toBe(-80000);
+  });
+
+  it('counts a contribution in the month it funds, not the month it posts', () => {
+    // Posted Jan 26, after the cutoff day (25) — funds February, not January.
+    // If wrongly attributed to January, the worst month would be 0 instead
+    // of -20000.
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-10', amount: -20000, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-26', label: 'VIR ALICE MARTIN', amount: 50000 }),
+    ]);
+    const resolved = resolveEnvelopes(config, ledger);
+    const consumption = computeConsumption(ledger, resolved, '2026-02-15' as Day);
+    const result = checkPlan(config, ledger, consumption, '2026-02-15' as Day);
+    expect(result.worstObservedMonth).toBe(-20000);
+  });
+
+  it('counts a transfer-out immediately, the mirror of a transfer-in', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-out', occurredOn: '2026-01-20', amount: -15000 }),
+    ]);
+    const resolved = resolveEnvelopes(config, ledger);
+    const consumption = computeConsumption(ledger, resolved, '2026-01-25' as Day);
+    const result = checkPlan(config, ledger, consumption, '2026-01-25' as Day);
+    expect(result.worstObservedMonth).toBe(-15000);
+  });
+
+  it('is sufficient exactly at the boundary, insufficient one cent past it', () => {
+    // Default buffer.target is 2500.00 (250000c).
+    const config = numbersConfig();
+    const atBoundary = ledgerOf([tx({ kind: 'transfer-out', occurredOn: '2026-01-05', amount: -250000 })]);
+    const resolvedA = resolveEnvelopes(config, atBoundary);
+    const resultA = checkPlan(
+      config,
+      atBoundary,
+      computeConsumption(atBoundary, resolvedA, '2026-01-10' as Day),
+      '2026-01-10' as Day,
+    );
+    expect(resultA.worstObservedMonth).toBe(-250000);
+    expect(resultA.bufferSufficient).toBe(true);
+
+    const overBoundary = ledgerOf([tx({ kind: 'transfer-out', occurredOn: '2026-01-05', amount: -250001 })]);
+    const resolvedB = resolveEnvelopes(config, overBoundary);
+    const resultB = checkPlan(
+      config,
+      overBoundary,
+      computeConsumption(overBoundary, resolvedB, '2026-01-10' as Day),
+      '2026-01-10' as Day,
+    );
+    expect(resultB.bufferSufficient).toBe(false);
+  });
+});

--- a/src/numbers/checks.test.ts
+++ b/src/numbers/checks.test.ts
@@ -131,7 +131,10 @@ describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
       }),
       tx({
         kind: 'settlement',
-        occurredOn: '2026-02-04',
+        // Posted in January, settles in February — deliberately different
+        // months, so a mutation that used occurredOn instead of settlesOn
+        // would move -80000 into January and change which month is worst.
+        occurredOn: '2026-01-31',
         settlesOn: '2026-02-04',
         amount: -80000,
         category: 'Transaction exclue',
@@ -145,13 +148,17 @@ describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
   });
 
   it('counts a contribution in the month it funds, not the month it posts', () => {
-    // Posted Jan 26, after the cutoff day (25) — funds February, not January.
-    // If wrongly attributed to January, the worst month would be 0 instead
-    // of -20000.
+    // Posted Jan 26, after the cutoff day (25) — funds February, not
+    // January. Correct: Jan = -20000 (movement only), Feb = -60000 + 50000
+    // (the contribution) = -10000; worst is January, -20000. If the
+    // contribution were dropped, or wrongly attributed to January instead
+    // of February, February would be the worst month at -60000 either way
+    // — a different month *and* a different value, so both mistakes show.
     const config = numbersConfig();
     const ledger = ledgerOf([
-      tx({ occurredOn: '2026-01-10', amount: -20000, category: 'Alimentation', subCategory: 'Supermarche' }),
-      tx({ kind: 'transfer-in', occurredOn: '2026-01-26', label: 'VIR ALICE MARTIN', amount: 50000 }),
+      tx({ id: 'jan-spend', occurredOn: '2026-01-10', amount: -20000, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({ id: 'contribution', kind: 'transfer-in', occurredOn: '2026-01-26', label: 'VIR ALICE MARTIN', amount: 50000 }),
+      tx({ id: 'feb-spend', occurredOn: '2026-02-10', amount: -60000, category: 'Alimentation', subCategory: 'Supermarche' }),
     ]);
     const resolved = resolveEnvelopes(config, ledger);
     const consumption = computeConsumption(ledger, resolved, '2026-02-15' as Day);

--- a/src/numbers/checks.test.ts
+++ b/src/numbers/checks.test.ts
@@ -117,6 +117,20 @@ describe('checkPlan — plannedTotal, trailingYearActual, drift', () => {
 });
 
 describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
+  it('floors at zero when every observed month was net-positive, rather than reporting the smallest gain', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE MARTIN', amount: 20000 }),
+      tx({ kind: 'transfer-in', occurredOn: '2026-02-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+    ]);
+    const resolved = resolveEnvelopes(config, ledger);
+    const consumption = computeConsumption(ledger, resolved, '2026-02-15' as Day);
+    const result = checkPlan(config, ledger, consumption, '2026-02-15' as Day);
+    // Without the floor, this would be 20000 — the smallest gain — not 0.
+    expect(result.worstObservedMonth).toBe(0);
+    expect(result.bufferSufficient).toBe(true);
+  });
+
   it('counts a card settlement at settlesOn, not the card purchase at occurredOn', () => {
     // If the card purchase counted directly, January would be -81000 —
     // worse than February's settlement — and this would fail.

--- a/src/numbers/checks.ts
+++ b/src/numbers/checks.ts
@@ -32,7 +32,11 @@ export interface PlanCheck {
   readonly trailingYearActual: Cents;
   readonly drift: Cents;
   readonly bufferTarget: Cents;
-  /** The most negative single month of real cash flow observed in the whole ledger. */
+  /**
+   * The most negative single month of real cash flow observed in the whole
+   * ledger — never positive: a household whose worst month was still a net
+   * gain has a worst drawdown of zero, not the smallest of its gains.
+   */
   readonly worstObservedMonth: Cents;
   readonly bufferSufficient: boolean;
   readonly envelopes: readonly EnvelopeCheck[];
@@ -109,8 +113,11 @@ export function checkPlan(
     ),
   );
 
+  // Floored at zero, the same convention outflow() uses: if every observed
+  // month was net-positive, the worst drawdown the buffer ever had to
+  // absorb was none at all, not the smallest of several gains.
   const monthly = [...netFlowByMonth(config, ledger).values()];
-  const worstObservedMonth = monthly.length === 0 ? 0 : Math.min(...monthly);
+  const worstObservedMonth = Math.min(0, ...monthly);
 
   return {
     plannedTotal,

--- a/src/numbers/checks.ts
+++ b/src/numbers/checks.ts
@@ -1,0 +1,124 @@
+import type { Cents } from '../core/money.ts';
+import { addMonths, monthOf, type Day, type Month } from '../core/dates.ts';
+import type { Config } from '../config/load.ts';
+import type { Ledger } from '../ingest/load.ts';
+import { outflow } from './envelopes.ts';
+import type { EnvelopeConsumption } from './consumption.ts';
+import { attributeContributions, contributionsByMonth } from './funding.ts';
+
+/**
+ * Whether an envelope with a goal is still reachable, projected from how far
+ * through its seasonal pace the year is — not a flat `×12/months-elapsed`,
+ * which would mark a holiday envelope hopeless every January.
+ *
+ * `too-early` guards the one place that projection divides by the pace
+ * fraction: an envelope entirely weighted to a month not yet reached has
+ * `paceExpected === 0`, and nothing can be projected from zero.
+ */
+export type GoalStatus = 'no-goal' | 'too-early' | 'on-track' | 'at-risk';
+
+export interface EnvelopeCheck {
+  readonly envelope: EnvelopeConsumption['envelope'];
+  readonly pastPace: boolean;
+  readonly goalStatus: GoalStatus;
+  /** Year-to-date spend, extrapolated by the seasonal pace fraction. `null` unless a goal exists and it isn't too early to project. */
+  readonly projectedFullYear: Cents | null;
+}
+
+export interface PlanCheck {
+  /** Sum of every configured envelope's estimate. */
+  readonly plannedTotal: Cents;
+  /** Actual net outflow across the trailing 12 months ending on the reference day. */
+  readonly trailingYearActual: Cents;
+  readonly drift: Cents;
+  readonly bufferTarget: Cents;
+  /** The most negative single month of real cash flow observed in the whole ledger. */
+  readonly worstObservedMonth: Cents;
+  readonly bufferSufficient: boolean;
+  readonly envelopes: readonly EnvelopeCheck[];
+}
+
+function checkEnvelope(c: EnvelopeConsumption): EnvelopeCheck {
+  const pastPace = c.yearToDateSpent > c.paceExpected;
+
+  if (c.envelope.kind !== 'configured' || c.envelope.config.goal === null) {
+    return { envelope: c.envelope, pastPace, goalStatus: 'no-goal', projectedFullYear: null };
+  }
+  if (c.paceExpected === 0) {
+    return { envelope: c.envelope, pastPace, goalStatus: 'too-early', projectedFullYear: null };
+  }
+
+  const estimate = c.envelope.config.estimate;
+  const projectedFullYear = Math.round((c.yearToDateSpent * estimate) / c.paceExpected);
+  const goalStatus: GoalStatus = projectedFullYear <= c.envelope.config.goal ? 'on-track' : 'at-risk';
+  return { envelope: c.envelope, pastPace, goalStatus, projectedFullYear };
+}
+
+/**
+ * Real cash flow per calendar month across the whole ledger — the figure
+ * `bufferTarget` has to cover, not the plan.
+ *
+ * Not a plain sum of `movement` amounts by `occurredOn`: a card purchase is
+ * not yet cash leaving the account, its `settlement` is, at `settlesOn` —
+ * the same distinction `reconcile.ts` exists to enforce, re-derived here
+ * would risk disagreeing with it. Contributions count in the month they
+ * *fund* (3a's `contributionsByMonth`), not when they post, for the same
+ * reason 3a exists. A `transfer-out` is counted immediately, at
+ * `occurredOn`: it is real cash leaving the tracked position the moment it
+ * happens, the mirror image of a `transfer-in` funding it.
+ */
+function netFlowByMonth(config: Config, ledger: Ledger): ReadonlyMap<Month, Cents> {
+  const byMonth = new Map<Month, Cents>();
+  const add = (month: Month, amount: Cents) => byMonth.set(month, (byMonth.get(month) ?? 0) + amount);
+
+  for (const t of ledger.transactions) {
+    if (t.kind === 'movement' && t.source.kind === 'account') add(monthOf(t.occurredOn), t.amount);
+    else if (t.kind === 'settlement') add(monthOf(t.settlesOn), t.amount);
+    else if (t.kind === 'transfer-out') add(monthOf(t.occurredOn), t.amount);
+  }
+
+  for (const monthly of contributionsByMonth(attributeContributions(config, ledger))) {
+    add(monthly.month, monthly.total);
+  }
+
+  return byMonth;
+}
+
+/**
+ * How the plan compares to reality, as of `referenceDay`.
+ *
+ * `consumption` is supplied rather than recomputed, so this never disagrees
+ * with what section 02 is showing at the same moment — both come from the
+ * same call, in `numbers/plan.ts`.
+ */
+export function checkPlan(
+  config: Config,
+  ledger: Ledger,
+  consumption: readonly EnvelopeConsumption[],
+  referenceDay: Day,
+): PlanCheck {
+  const plannedTotal = consumption.reduce(
+    (total, c) => (c.envelope.kind === 'configured' ? total + c.envelope.config.estimate : total),
+    0,
+  );
+
+  const windowStart = addMonths(monthOf(referenceDay), -11);
+  const trailingYearActual = outflow(
+    ledger.transactions.filter(
+      (t) => t.kind === 'movement' && monthOf(t.occurredOn) >= windowStart && t.occurredOn <= referenceDay,
+    ),
+  );
+
+  const monthly = [...netFlowByMonth(config, ledger).values()];
+  const worstObservedMonth = monthly.length === 0 ? 0 : Math.min(...monthly);
+
+  return {
+    plannedTotal,
+    trailingYearActual,
+    drift: trailingYearActual - plannedTotal,
+    bufferTarget: config.bufferTarget,
+    worstObservedMonth,
+    bufferSufficient: config.bufferTarget + worstObservedMonth >= 0,
+    envelopes: consumption.map(checkEnvelope),
+  };
+}

--- a/src/numbers/plan.test.ts
+++ b/src/numbers/plan.test.ts
@@ -42,6 +42,28 @@ describe('computePlan', () => {
     expect(plan.warnings.some((w) => w.kind === 'matcher-matches-nothing')).toBe(false);
   });
 
+  it('picks the reference month\'s own cell of the plan, not any month\'s', () => {
+    // All 1200.00 lands in June (month index 5) by configured seasonal
+    // shape; every other month's cell is 0. A reference day outside June
+    // must see a monthlyRequirement of 0, not June's 120000.
+    const config = numbersConfig({
+      envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Alimentation", sub_category = "Supermarche" }]
+estimate = "1200.00"
+seasonal = { months = [6] }
+`,
+    });
+    const ledger = ledgerOf([]);
+
+    const inJanuary = computePlan(config, ledger, '2026-01-15' as Day);
+    expect(sum(inJanuary.shares.map((s) => s.amount))).toBe(0);
+
+    const inJune = computePlan(config, ledger, '2026-06-15' as Day);
+    expect(sum(inJune.shares.map((s) => s.amount))).toBe(120000);
+  });
+
   it('the monthly requirement excludes derived envelopes — nothing to fund yet', () => {
     // No configured envelopes at all: a configured one contributes its
     // planned amount regardless of whether it happens to have any

--- a/src/numbers/plan.test.ts
+++ b/src/numbers/plan.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { Day } from '../core/dates.ts';
+import { sum } from '../core/money.ts';
+import { computePlan } from './plan.ts';
+import { ledgerOf, numbersConfig, tx } from './__fixtures__/build.ts';
+
+describe('computePlan', () => {
+  it('wires 3a and 3b together end to end, worked by hand', () => {
+    // groceries: estimate 1200.00 (120000c), no configured seasonal.
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      // 2025 (prior year): 100.00 in each of Jan/Feb/Mar — derived shape
+      // [10000,10000,10000,0,...,0], sum 30000.
+      tx({ id: '25-jan', occurredOn: '2025-01-05', amount: -10000, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({ id: '25-feb', occurredOn: '2025-02-05', amount: -10000, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({ id: '25-mar', occurredOn: '2025-03-05', amount: -10000, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+
+    // 120000 split proportionally to [10000,10000,10000,0,...]: each of the
+    // first three months gets 120000*10000/30000 = 40000 exactly. Reference
+    // day is in March (index 2), so monthlyRequirement = 40000.
+    const referenceDay = '2026-03-15' as Day;
+    const plan = computePlan(config, ledger, referenceDay);
+
+    expect(plan.referenceDay).toBe(referenceDay);
+
+    // alice 3200.00, bruno 2450.00 net monthly (weight sum 565000):
+    // 40000*320000/565000 = 22654.86..., 40000*245000/565000 = 17345.13...
+    // — bases 22654 + 17345 = 39999, one cent short, alice's fraction
+    // (.867) beats bruno's (.132), so alice gets it.
+    expect(plan.shares).toEqual([
+      { personId: 'alice', netMonthly: 320000, amount: 22655 },
+      { personId: 'bruno', netMonthly: 245000, amount: 17345 },
+    ]);
+    expect(sum(plan.shares.map((s) => s.amount))).toBe(40000);
+
+    // Nothing else happened in the ledger, so there is nothing to report.
+    expect(plan.contributions).toEqual([]);
+    expect(plan.consumption).toHaveLength(1);
+    expect(plan.consumption[0]?.priorYearActual).toBe(30000);
+    expect(plan.check.plannedTotal).toBe(120000);
+    expect(plan.warnings.some((w) => w.kind === 'matcher-matches-nothing')).toBe(false);
+  });
+
+  it('the monthly requirement excludes derived envelopes — nothing to fund yet', () => {
+    // No configured envelopes at all: a configured one contributes its
+    // planned amount regardless of whether it happens to have any
+    // transactions in this ledger, so the only way to prove derived
+    // spending contributes nothing is to have no configured envelope to
+    // confound it with.
+    const config = numbersConfig({ envelopes: '' });
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -50000, category: 'Loisirs et vacances', subCategory: 'Cinema' }),
+    ]);
+    const plan = computePlan(config, ledger, '2026-06-01' as Day);
+    expect(plan.shares.every((s) => s.amount === 0)).toBe(true);
+  });
+
+  it('surfaces an audit warning end to end', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([]); // groceries' matcher never fires
+    const plan = computePlan(config, ledger, '2026-06-01' as Day);
+    expect(plan.warnings).toContainEqual(
+      expect.objectContaining({ kind: 'matcher-matches-nothing', envelopeId: 'groceries' }),
+    );
+  });
+});

--- a/src/numbers/plan.ts
+++ b/src/numbers/plan.ts
@@ -1,0 +1,47 @@
+import { sum } from '../core/money.ts';
+import { monthNumber, monthOf, type Day } from '../core/dates.ts';
+import type { Config } from '../config/load.ts';
+import type { Ledger } from '../ingest/load.ts';
+import { resolveEnvelopes } from './envelopes.ts';
+import { computeConsumption, type EnvelopeConsumption } from './consumption.ts';
+import { computeShares, type PersonShare } from './income.ts';
+import { attributeContributions, contributionsByMonth, type MonthlyContributions } from './funding.ts';
+import { checkPlan, type PlanCheck } from './checks.ts';
+import { auditPlan, type PlanWarning } from './audit.ts';
+
+/** Everything section 01 through 03 of the page renders, computed together so none of it can disagree. */
+export interface Plan {
+  readonly referenceDay: Day;
+  readonly shares: readonly PersonShare[];
+  readonly contributions: readonly MonthlyContributions[];
+  readonly consumption: readonly EnvelopeConsumption[];
+  readonly check: PlanCheck;
+  readonly warnings: readonly PlanWarning[];
+}
+
+/**
+ * The one function step 4's page calls.
+ *
+ * `monthlyRequirement` — what `computeShares` splits across people — is this
+ * reference month's cell of every configured envelope's `monthlyPlan`,
+ * summed. A derived envelope has no plan and contributes nothing: there is
+ * no estimate to fund yet, only spending already happening outside any plan,
+ * which is what the audit's uncategorised-rows and the check's drift figure
+ * are for.
+ */
+export function computePlan(config: Config, ledger: Ledger, referenceDay: Day): Plan {
+  const resolved = resolveEnvelopes(config, ledger);
+  const consumption = computeConsumption(ledger, resolved, referenceDay);
+
+  const monthIndex = monthNumber(monthOf(referenceDay)) - 1;
+  const monthlyRequirement = sum(
+    consumption.map((c) => (c.monthlyPlan === null ? 0 : (c.monthlyPlan[monthIndex] ?? 0))),
+  );
+
+  const shares = computeShares(config.people, monthlyRequirement);
+  const contributions = contributionsByMonth(attributeContributions(config, ledger));
+  const check = checkPlan(config, ledger, consumption, referenceDay);
+  const warnings = auditPlan(config, ledger);
+
+  return { referenceDay, shares, contributions, consumption, check, warnings };
+}

--- a/src/numbers/plan.ts
+++ b/src/numbers/plan.ts
@@ -25,9 +25,13 @@ export interface Plan {
  * `monthlyRequirement` — what `computeShares` splits across people — is this
  * reference month's cell of every configured envelope's `monthlyPlan`,
  * summed. A derived envelope has no plan and contributes nothing: there is
- * no estimate to fund yet, only spending already happening outside any plan,
- * which is what the audit's uncategorised-rows and the check's drift figure
- * are for.
+ * no estimate to fund yet, only spending already happening outside any
+ * plan, which is what `check.drift` reflects. That spending is *not* the
+ * same thing as the audit's `uncategorised-rows` warning — a derived
+ * envelope is usually just a category nobody has configured an envelope
+ * for yet, while `uncategorised-rows` is specifically the bank's own two
+ * "not yet filed" categories; most derived spending triggers no warning at
+ * all, only the drift figure.
  */
 export function computePlan(config: Config, ledger: Ledger, referenceDay: Day): Plan {
   const resolved = resolveEnvelopes(config, ledger);


### PR DESCRIPTION
Step 3c of 4 towards #296 (breakdown: issue comment on #296). Draft —
opened for review. **Stacked on #301 (3b), not yet merged** — based
against `claude/mvp-3b-consumption`, so this diff shows only 3c's own
changes; it'll retarget `main` once 3a and 3b merge.

Household figures stay out of this repo. This describes structure and mechanism.

## Why

3a produced what each person transfers; 3b produced what each envelope has
spent against its pot. This is section 03 — whether any of it still matches
reality — plus the runtime findings a static `sluice.toml` read cannot see,
and the one function (`computePlan`) that wires everything from 3a/3b/3c
into what step 4's page actually renders.

## Scope

Three modules, the last of the pure-function layer — step 4 is rendering,
next:

- **`numbers/checks.ts`** — `checkPlan()`: `plannedTotal` (configured
  envelopes only) vs `trailingYearActual` (last 12 months, actual) for
  `drift`; goal reachability projected from the seasonal *pace fraction*,
  not a flat `×12/months-elapsed` (which would mark a holiday envelope
  hopeless every January) — `too-early` guards the one division that would
  otherwise be by zero; `worstObservedMonth`, real cash flow per calendar
  month across the whole ledger, distinguishing a card purchase (not yet an
  outflow) from its settlement (the real one, at `settlesOn`) and crediting
  a contribution to the month it *funds* (3a), not the month it posts.
- **`numbers/audit.ts`** — `auditPlan()`: `matcher-matches-nothing`,
  `label-matches-nothing`, `transfer-matches-two-people` (a real transaction
  whose label happens to satisfy two people at once — distinct from the
  config-time collision check, which only catches two *declared* labels
  containing one another), and `uncategorised-rows` — measured against the
  real exports, not assumed: the bank's own `A categoriser - sortie/rentree
  d'argent` categories, not an empty string.
- **`numbers/plan.ts`** — `computePlan()`: resolves envelopes, computes
  consumption, sums this reference month's configured `monthlyPlan` cells
  into the requirement 3a's `computeShares` splits, and returns everything
  section 01–03 needs in one call.

## Decisions

| decision | choice | why |
|---|---|---|
| Goal projection | from the pace fraction (`yearToDateSpent * estimate / paceExpected`) | linear `×12/months-elapsed` marks every seasonal envelope hopeless in January |
| `worstObservedMonth` | account movement + settlement (at `settlesOn`) + `transfer-out` (immediate) + contributions (funding month) | re-derives nothing 3a/`reconcile.ts` already got right — a card purchase counted directly would double against the settlement |
| `transfer-out` | counted immediately, at `occurredOn` | real cash leaving the tracked position the moment it happens — the mirror of a `transfer-in` funding it. Not in the original plan text; added here since ignoring it would understate a bad month |
| `plannedTotal` | configured envelopes' estimates only | derived-envelope spending reads as permanent "drift" until configured — intentional pressure to configure, same as the unattributed-contributions band in section 01 |
| Audit warnings | never thrown | same non-throwing shape as `ReconciliationReport` — these are findings to show, not reasons to refuse |

## Mutation testing, by hand, on committed code

Fifteen mutations against the branches the plan calls load-bearing.
Thirteen caught on the first pass. Two didn't, both from a test whose
fixture didn't actually stress the thing it claimed to:

- The settlement-vs-purchase-date test had set `occurredOn` and
  `settlesOn` to the *same* date, so nothing distinguished which one
  `worstObservedMonth` used. Made them differ.
- The funding-month test's ledger happened to leave the same month "worst"
  whether or not the contribution was counted at all. Redesigned so the
  contribution's presence and month both change the answer.
- `plan.test.ts` had no case where the reference month's own plan cell
  differed from January's, so forcing `computePlan` to always read
  January's cell went uncaught. Added one where an envelope's entire
  seasonal weight sits in a single month.

## Code review

Self-review of the diff before merge:

- `auditPlan()`'s returned warnings had no stated sort order — an
  omission against this step's own convention, and something the design
  notes said would happen but never actually got implemented. Added a
  sort grouped by kind, then a natural key within it.
- `computePlan()`'s doc comment implied the audit's `uncategorised-rows`
  warning covers any derived envelope's spending. It only covers the
  bank's two specific "not yet filed" categories — a well-categorized but
  simply unconfigured category (most derived spending) triggers no
  warning at all, only the drift figure. Fixed the comment to say so.
- The first version of the sort-order test built warnings in an order
  that already happened to match the sorted order, so a no-op comparator
  passed it too (`Array.sort` is stable, so it preserved push order,
  which was coincidentally already correct). Added a case with people
  declared out of alphabetical order, which only a real sort reorders.

## Copilot review

One finding, fixed:

- `worstObservedMonth` was documented as "the most negative single month,"
  but `Math.min(...monthly)` could return a positive value when every
  observed month was net-positive — the smallest gain, not zero. Floored
  at zero with `Math.min(0, ...monthly)`, the same convention `outflow()`
  already uses: a household that never had a bad month has a worst
  drawdown of zero, not the smallest of its gains. `bufferSufficient`'s
  conclusion was already correct in this case; only the reported figure
  was misleading.

## Verification

```bash
npm run check
```

271 tests (up from 244 at the tip of 3b), all passing.

## Deliberately not here

- **Rendering** — step 4, the page.
- **The generator** — 3d, independent of this PR.


