### PR TITLE
MVP step 3d · numbers: the envelope generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ v0.2 is being built in steps, each its own pull request. The first version was d
 | | step | state |
 |---|---|---|
 | 1 | **ingest** — bank exports into one reconciled ledger | merged |
-| 2 | **config** — `sluice.toml`: income, envelopes, goals, buffer | in review |
-| 3 | the numbers — the split, envelope consumption, seasonal pacing, the checks | next |
-| 4 | the page — instalment strip and four sections | |
+| 2 | **config** — `sluice.toml`: income, envelopes, goals, buffer | merged |
+| 3 | the numbers — the split, envelope consumption, seasonal pacing, the checks, the envelope generator | in review |
+| 4 | the page — instalment strip and four sections | next |
 | 5 | `CLAUDE.md`, written once there is code to describe | |
 
 ## Running it

--- a/src/numbers/funding.ts
+++ b/src/numbers/funding.ts
@@ -7,10 +7,11 @@ import type { Transaction } from '../ingest/ledger.ts';
 /**
  * Plain code-point comparison, not `localeCompare()`: the latter's ordering
  * depends on the runtime's default locale, not guaranteed to agree between
- * two machines — the opposite of the deterministic order this module
- * promises for every list it returns.
+ * two machines — the opposite of the deterministic order `src/numbers/`
+ * promises for every list it returns. Exported rather than duplicated:
+ * `generate.ts` needs the identical comparison for the same reason.
  */
-function compare(a: string, b: string): number {
+export function compare(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 

--- a/src/numbers/generate.test.ts
+++ b/src/numbers/generate.test.ts
@@ -5,12 +5,22 @@ import { configToml } from '../config/__fixtures__/build.ts';
 import { ledgerOf, numbersConfig, tx } from './__fixtures__/build.ts';
 
 describe('generateEnvelopeBlock', () => {
-  it('emits an id slugified from the pair — accents stripped, lowercased, spaces folded', () => {
+  it('emits an id slugified from the pair — spaces folded to underscore', () => {
     const ledger = ledgerOf([
       tx({ occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
     ]);
     const block = generateEnvelopeBlock(ledger, null, 2026);
     expect(block).toContain('[envelopes.alimentation_supermarche]');
+  });
+
+  it('strips accents from the id, not just from the display name', () => {
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -3000, category: 'Énergie', subCategory: 'Électricité' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    expect(block).toContain('[envelopes.energie_electricite]');
+    // The display name keeps the accents — only the id is folded to ASCII.
+    expect(block).toContain('name = "Énergie / Électricité"');
   });
 
   it('sets estimate to the year’s net outflow, worked by hand', () => {

--- a/src/numbers/generate.test.ts
+++ b/src/numbers/generate.test.ts
@@ -67,6 +67,18 @@ describe('generateEnvelopeBlock', () => {
     expect(block).toContain('"groceries" had no spending in 2026');
   });
 
+  it('still notes it when the only transaction this year is a refund, not a purchase', () => {
+    // A transaction exists in 2026 — a `.some(...)` check on presence alone
+    // would miss this. Net outflow is what actually matters: a refund with
+    // no purchase behind it this year is zero real spending.
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-03-05', amount: 1500, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, config, 2026);
+    expect(block).toContain('"groceries" had no spending in 2026');
+  });
+
   it('orders new envelopes by (category, subCategory), not ledger encounter order', () => {
     const ledger = ledgerOf([
       // Built in reverse of the expected output order — "Z"'s transaction

--- a/src/numbers/generate.test.ts
+++ b/src/numbers/generate.test.ts
@@ -67,6 +67,20 @@ describe('generateEnvelopeBlock', () => {
     expect(block).toContain('"groceries" had no spending in 2026');
   });
 
+  it('orders new envelopes by (category, subCategory), not ledger encounter order', () => {
+    const ledger = ledgerOf([
+      // Built in reverse of the expected output order — "Z"'s transaction
+      // comes first in the ledger, "A"'s second.
+      tx({ occurredOn: '2026-01-06', amount: -1000, category: 'Z', subCategory: 'Z' }),
+      tx({ occurredOn: '2026-01-05', amount: -2000, category: 'A', subCategory: 'A' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    const aIndex = block.indexOf('[envelopes.a_a]');
+    const zIndex = block.indexOf('[envelopes.z_z]');
+    expect(aIndex).toBeGreaterThanOrEqual(0);
+    expect(zIndex).toBeGreaterThan(aIndex);
+  });
+
   it('disambiguates two pairs that would otherwise slugify to the same id', () => {
     const ledger = ledgerOf([
       tx({ id: 'a', occurredOn: '2026-01-05', amount: -1000, category: 'A B', subCategory: 'C' }),

--- a/src/numbers/generate.test.ts
+++ b/src/numbers/generate.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { generateEnvelopeBlock } from './generate.ts';
+import { parseConfig } from '../config/schema.ts';
+import { configToml } from '../config/__fixtures__/build.ts';
+import { ledgerOf, numbersConfig, tx } from './__fixtures__/build.ts';
+
+describe('generateEnvelopeBlock', () => {
+  it('emits an id slugified from the pair — accents stripped, lowercased, spaces folded', () => {
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    expect(block).toContain('[envelopes.alimentation_supermarche]');
+  });
+
+  it('sets estimate to the year’s net outflow, worked by hand', () => {
+    const ledger = ledgerOf([
+      tx({ id: 'a', occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({ id: 'b', occurredOn: '2026-02-05', amount: -1200, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({ id: 'refund', occurredOn: '2026-02-10', amount: 200, category: 'Alimentation', subCategory: 'Supermarche' }),
+      // A different year — must not be counted.
+      tx({ id: 'other-year', occurredOn: '2025-01-05', amount: -99999, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    // 3000 + 1200 - 200 (the refund nets it down) = 4000 = "40.00".
+    expect(block).toContain('estimate = "40.00"');
+  });
+
+  it('derives the seasonal shape from the SAME year, not the year before', () => {
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2025-06-05', amount: -99999, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({ occurredOn: '2026-03-05', amount: -1000, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    // If this used 2025 (year - 1) as the source year, the weight would be
+    // all in June (index 5); it must be all in March (index 2) instead.
+    expect(block).toContain('weights = [0, 0, 1000, 0, 0, 0, 0, 0, 0, 0, 0, 0]');
+  });
+
+  it('skips a pair a configured envelope already claims', () => {
+    const config = numbersConfig(); // declares groceries over Alimentation/Supermarche
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({ occurredOn: '2026-01-06', amount: -1500, category: 'Loisirs et vacances', subCategory: 'Cinema' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, config, 2026);
+    expect(block).not.toContain('alimentation_supermarche');
+    expect(block).toContain('loisirs_et_vacances_cinema');
+  });
+
+  it('notes a declared envelope with no spending this year, rather than staying silent', () => {
+    const config = numbersConfig(); // declares groceries
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2025-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }), // only in 2025
+    ]);
+    const block = generateEnvelopeBlock(ledger, config, 2026);
+    expect(block).toContain('"groceries" had no spending in 2026');
+  });
+
+  it('disambiguates two pairs that would otherwise slugify to the same id', () => {
+    const ledger = ledgerOf([
+      tx({ id: 'a', occurredOn: '2026-01-05', amount: -1000, category: 'A B', subCategory: 'C' }),
+      tx({ id: 'b', occurredOn: '2026-01-06', amount: -2000, category: 'A', subCategory: 'B C' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    expect(block).toContain('[envelopes.a_b_c]');
+    expect(block).toContain('[envelopes.a_b_c_2]');
+  });
+
+  it('says so when there is nothing new to configure', () => {
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, config, 2026);
+    expect(block).toContain('No new spending to configure for 2026');
+  });
+
+  it('produces text that is itself a valid sluice.toml, end to end', () => {
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -300000, category: 'Alimentation', subCategory: 'Supermarche' }),
+      tx({ occurredOn: '2026-06-05', amount: -50000, category: 'Loisirs et vacances', subCategory: 'Vacances' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    const config = parseConfig(configToml({ envelopes: block }), 'sluice.toml');
+
+    expect(config.envelopes.map((e) => e.id).sort()).toEqual([
+      'alimentation_supermarche',
+      'loisirs_et_vacances_vacances',
+    ]);
+    const groceries = config.envelopes.find((e) => e.id === 'alimentation_supermarche');
+    expect(groceries?.estimate).toBe(300000);
+  });
+});

--- a/src/numbers/generate.ts
+++ b/src/numbers/generate.ts
@@ -4,6 +4,7 @@ import { envelopeIndex, type Config } from '../config/load.ts';
 import type { Ledger } from '../ingest/load.ts';
 import { outflow, resolveEnvelopes, transactionsFor, type ResolvedEnvelope } from './envelopes.ts';
 import { resolveSeasonal, type SeasonalShape } from './seasonal.ts';
+import { compare } from './funding.ts';
 
 /**
  * The yearly rebuild, automated: read what actually happened in `year` and
@@ -41,31 +42,37 @@ export function generateEnvelopeBlock(ledger: Ledger, config: Config | null, yea
     subCategories.add(t.subCategory);
   }
 
+  // Every new pair, sorted by (category, subCategory) rather than left in
+  // ledger encounter order — the same "every list src/numbers/ produces
+  // commits to an order" discipline the rest of this step follows, using
+  // plain code-point comparison rather than localeCompare() for the same
+  // reason envelopes.ts and funding.ts do.
+  const pairs = [...byCategory.entries()]
+    .flatMap(([category, subCategories]) => [...subCategories].map((subCategory) => ({ category, subCategory })))
+    .filter(({ category, subCategory }) => index === null || index.find(category, subCategory) === null)
+    .sort((a, b) => compare(a.category, b.category) || compare(a.subCategory, b.subCategory));
+
   const usedIds = new Set<string>(config?.envelopes.map((e) => e.id) ?? []);
   const blocks: string[] = [];
 
-  for (const [category, subCategories] of byCategory) {
-    for (const subCategory of subCategories) {
-      if (index !== null && index.find(category, subCategory) !== null) continue;
+  for (const { category, subCategory } of pairs) {
+    const candidate: ResolvedEnvelope = {
+      kind: 'derived',
+      id: `${category} / ${subCategory}`,
+      category,
+      subCategory,
+    };
+    const transactions = transactionsFor(candidate, ledger);
+    const estimate = outflow(transactions.filter((t) => yearOf(t.occurredOn) === year));
+    // `priorYear = year`, not `year - 1`: unlike the runtime call in
+    // computeConsumption, which paces the year in progress against the
+    // one before it, the generator is summarising the year it just
+    // measured — the shape and the total it's paired with come from the
+    // same twelve months, with no lag.
+    const seasonal = resolveSeasonal(candidate, transactions, year);
 
-      const candidate: ResolvedEnvelope = {
-        kind: 'derived',
-        id: `${category} / ${subCategory}`,
-        category,
-        subCategory,
-      };
-      const transactions = transactionsFor(candidate, ledger);
-      const estimate = outflow(transactions.filter((t) => yearOf(t.occurredOn) === year));
-      // `priorYear = year`, not `year - 1`: unlike the runtime call in
-      // computeConsumption, which paces the year in progress against the
-      // one before it, the generator is summarising the year it just
-      // measured — the shape and the total it's paired with come from the
-      // same twelve months, with no lag.
-      const seasonal = resolveSeasonal(candidate, transactions, year);
-
-      const id = uniqueId(slugify(`${category}_${subCategory}`), usedIds);
-      blocks.push(envelopeToml(id, category, subCategory, estimate, seasonal));
-    }
+    const id = uniqueId(slugify(`${category}_${subCategory}`), usedIds);
+    blocks.push(envelopeToml(id, category, subCategory, estimate, seasonal));
   }
 
   const notes: string[] = [];

--- a/src/numbers/generate.ts
+++ b/src/numbers/generate.ts
@@ -1,0 +1,131 @@
+import type { Cents } from '../core/money.ts';
+import { yearOf } from '../core/dates.ts';
+import { envelopeIndex, type Config } from '../config/load.ts';
+import type { Ledger } from '../ingest/load.ts';
+import { outflow, resolveEnvelopes, transactionsFor, type ResolvedEnvelope } from './envelopes.ts';
+import { resolveSeasonal, type SeasonalShape } from './seasonal.ts';
+
+/**
+ * The yearly rebuild, automated: read what actually happened in `year` and
+ * emit a ready-to-paste `[envelopes.*]` block. This is the thing #296 was
+ * opened for — the household edits the result rather than authoring it from
+ * a blank page, and the spreadsheet it replaces stops being worth the
+ * afternoon it used to cost.
+ *
+ * `config` is read for context, not required: pairs it already claims are
+ * skipped (their `estimate` is a commitment the household owns, not
+ * something to silently regenerate every year — see `schema.ts`), and a
+ * declared envelope with nothing to show for `year` gets a note rather than
+ * being ignored. `null` means a first-ever run: everything is new.
+ *
+ * Returns TOML text, never writes a file — nothing under `src/numbers/`
+ * touches disk, and pasting the result into `sluice.toml` is meant to stay a
+ * deliberate act, the moment a person notices a number that looks wrong
+ * before it becomes the plan.
+ */
+export function generateEnvelopeBlock(ledger: Ledger, config: Config | null, year: number): string {
+  const index = config === null ? null : envelopeIndex(config);
+
+  // Two map levels, not one key joined from both — the same reason
+  // resolveEnvelopes() in envelopes.ts is two levels: several of the bank's
+  // real category names carry spaces, so a joined string risks two distinct
+  // pairs colliding onto one key.
+  const byCategory = new Map<string, Set<string>>();
+  for (const t of ledger.transactions) {
+    if (t.kind !== 'movement' || yearOf(t.occurredOn) !== year) continue;
+    let subCategories = byCategory.get(t.category);
+    if (subCategories === undefined) {
+      subCategories = new Set();
+      byCategory.set(t.category, subCategories);
+    }
+    subCategories.add(t.subCategory);
+  }
+
+  const usedIds = new Set<string>(config?.envelopes.map((e) => e.id) ?? []);
+  const blocks: string[] = [];
+
+  for (const [category, subCategories] of byCategory) {
+    for (const subCategory of subCategories) {
+      if (index !== null && index.find(category, subCategory) !== null) continue;
+
+      const candidate: ResolvedEnvelope = {
+        kind: 'derived',
+        id: `${category} / ${subCategory}`,
+        category,
+        subCategory,
+      };
+      const transactions = transactionsFor(candidate, ledger);
+      const estimate = outflow(transactions.filter((t) => yearOf(t.occurredOn) === year));
+      // `priorYear = year`, not `year - 1`: unlike the runtime call in
+      // computeConsumption, which paces the year in progress against the
+      // one before it, the generator is summarising the year it just
+      // measured — the shape and the total it's paired with come from the
+      // same twelve months, with no lag.
+      const seasonal = resolveSeasonal(candidate, transactions, year);
+
+      const id = uniqueId(slugify(`${category}_${subCategory}`), usedIds);
+      blocks.push(envelopeToml(id, category, subCategory, estimate, seasonal));
+    }
+  }
+
+  const notes: string[] = [];
+  if (config !== null) {
+    for (const envelope of resolveEnvelopes(config, ledger)) {
+      if (envelope.kind !== 'configured') continue;
+      const hadSpending = transactionsFor(envelope, ledger).some((t) => yearOf(t.occurredOn) === year);
+      if (!hadSpending) {
+        notes.push(`# "${envelope.config.id}" had no spending in ${year}.`);
+      }
+    }
+  }
+
+  if (blocks.length === 0 && notes.length === 0) {
+    return `# No new spending to configure for ${year}.\n`;
+  }
+  return [...blocks, ...notes].join('\n\n') + '\n';
+}
+
+function envelopeToml(
+  id: string,
+  category: string,
+  subCategory: string,
+  estimate: Cents,
+  seasonal: SeasonalShape,
+): string {
+  const euros = (estimate / 100).toFixed(2);
+  const weights = seasonal.weights.join(', ');
+  return [
+    `[envelopes.${id}]`,
+    `name = "${escapeToml(`${category} / ${subCategory}`)}"`,
+    `matches = [{ category = "${escapeToml(category)}", sub_category = "${escapeToml(subCategory)}" }]`,
+    `estimate = "${euros}"`,
+    `seasonal = { weights = [${weights}] }`,
+  ].join('\n');
+}
+
+function escapeToml(text: string): string {
+  return text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/** Diacritics stripped, lowercased, anything that isn't `[a-z0-9]` folded to a single `_`. */
+function slugify(text: string): string {
+  const base = text
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // combining diacritical marks, once NFD has split them off
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return base === '' ? 'envelope' : base;
+}
+
+/** Appends `_2`, `_3`, … until `base` no longer collides with an id already in `used`, marking the result used. */
+function uniqueId(base: string, used: Set<string>): string {
+  let id = base;
+  let suffix = 2;
+  while (used.has(id)) {
+    id = `${base}_${suffix}`;
+    suffix += 1;
+  }
+  used.add(id);
+  return id;
+}

--- a/src/numbers/generate.ts
+++ b/src/numbers/generate.ts
@@ -79,8 +79,8 @@ export function generateEnvelopeBlock(ledger: Ledger, config: Config | null, yea
   if (config !== null) {
     for (const envelope of resolveEnvelopes(config, ledger)) {
       if (envelope.kind !== 'configured') continue;
-      const hadSpending = transactionsFor(envelope, ledger).some((t) => yearOf(t.occurredOn) === year);
-      if (!hadSpending) {
+      const yearOutflow = outflow(transactionsFor(envelope, ledger).filter((t) => yearOf(t.occurredOn) === year));
+      if (yearOutflow === 0) {
         notes.push(`# "${envelope.config.id}" had no spending in ${year}.`);
       }
     }

--- a/src/source-hygiene.test.ts
+++ b/src/source-hygiene.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * No committed source file may contain a raw NUL byte.
+ *
+ * A NUL byte inside a string or regex literal is syntactically *valid*
+ * JavaScript — it does not throw, it silently becomes the wrong character.
+ * `runnable.test.ts`'s "loads under bare node" check would not catch this:
+ * the file still parses and runs, it just does something other than what
+ * its source reads as. Twice in this codebase's history a template literal
+ * meant to hold a plain space ended up holding a NUL byte instead — once in
+ * a `Map` key that silently merged two distinct entries, once in a sort
+ * comparator — and both were found only by a manual byte-level scan run out
+ * of suspicion, not by the test suite. This closes that gap.
+ */
+
+const SRC = resolve(import.meta.dirname);
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...tsFilesUnder(path));
+    } else if (entry.name.endsWith('.ts')) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe('every source file', () => {
+  it('contains no raw NUL byte', () => {
+    const withNulByte = tsFilesUnder(SRC).filter((path) => readFileSync(path).includes(0));
+    expect(withNulByte).toEqual([]);
+  });
+});


### PR DESCRIPTION
Step 3d of 4 towards #296 (breakdown: issue comment on #296) — the last of
step 3. Draft — opened for review. Independent of 3a/3b/3c and based
directly on `main`, since all three are already merged.

Household figures stay out of this repo. This describes structure and mechanism.

## Why

#296's whole premise is that the yearly rebuild — reverse-engineering next
year's envelopes from what actually happened — was expensive enough to skip,
and skipping it is what let the household's budget drift silently for two
years. This is that rebuild, automated: point it at a year's ledger and get
back a ready-to-paste `[envelopes.*]` block instead of an afternoon with a
spreadsheet.

## Scope

One module, still a pure function — no rendering, no I/O:

**`numbers/generate.ts`** — `generateEnvelopeBlock(ledger, config, year)`
returns TOML text for every `(category, subCategory)` pair with `movement`
spending in `year` that no configured envelope already claims. Reuses 3b's
`resolveSeasonal()` for the seasonal shape rather than a second
implementation of the same derivation.

## Decisions

| decision | choice | why |
|---|---|---|
| Already-configured pairs | skipped entirely | an envelope's `estimate` is a commitment the household owns (step 2's own correction) — regenerating it silently every year would make it track reality by construction and never show drift |
| A declared envelope with no spending this year | noted, not silent | staying quiet about it is indistinguishable from "everything's fine"; a category that vanished is worth a household's attention |
| Seasonal shape's source year | the SAME year the estimate comes from (`priorYear = year`), not `year - 1` | the runtime pacing call (`computeConsumption`) lags a year because it's pacing the year in progress; the generator is summarising a year that's already finished, so there's no lag to apply |
| Id | slugified — accents stripped, lowercased, non-alphanumeric folded to one `_` — with collision disambiguation | `sluice.toml` table keys must be valid identifiers; two different pairs slugifying to the same id get `_2`, `_3`, … rather than a silently-merged TOML document |
| Output | a string, `config` read-only | nothing under `src/numbers/` touches disk — pasting the result into `sluice.toml` stays a deliberate act, not an automatic one |

## Mutation testing, by hand, on committed code

Seven mutations against every branch the module has: the already-claimed
skip, the no-spending note, id collision disambiguation, the estimate's
year filter, the empty-state message, and accent stripping. Six caught on
the first pass; one didn't:

- Every fixture used plain ASCII category names, even though the plan
  requires accents stripped — the regex could be deleted and nothing
  failed. Added a case with real accented categories (`Énergie` /
  `Électricité`), confirming the id folds to ASCII while the display name
  keeps the accents.

## Code review

Self-review of the diff before merge:

- `generateEnvelopeBlock()` emitted new envelope blocks in ledger
  transaction encounter order (`Map`/`Set` insertion order), not a stated
  order — against this step's own convention. Sorted by `(category,
  subCategory)` with plain code-point comparison, matching `envelopes.ts`
  and `funding.ts`.
- That comparator is now needed identically in three files
  (`envelopes.ts`, `funding.ts`, `generate.ts`). Exported `funding.ts`'s
  private `compare()` rather than writing a third copy.

## Copilot review

One finding, fixed:

- The "declared envelope with no spending" note used `.some(...)` to test
  whether *any* transaction existed in the year, not whether there was
  net outflow. An envelope whose only transaction this year was a refund
  (no purchase behind it) would silently skip the note. Switched to
  `outflow(...) === 0`, the same net-of-refunds convention every other
  figure in this step already uses.

Also added, prompted by two incidents found while building this PR: a
repo-wide guard test (`src/source-hygiene.test.ts`) against a raw NUL byte
in any source file. A NUL byte inside a string or regex literal is
syntactically valid JavaScript — it silently becomes the wrong character
rather than throwing — which is exactly how a template literal meant to
hold a plain space ended up holding one instead, twice, undetected by
`runnable.test.ts`'s "loads under bare node" check.

## Verification

```bash
npm run check
```

283 tests (up from 271 on `main`), all passing — including one end-to-end
test that re-parses the generated block with the real `parseConfig()` to
confirm it's valid `sluice.toml`, not just plausible-looking text.

## Deliberately not here

- **Writing the result to `sluice.toml`.** Pasting it in is a deliberate,
  manual act.
- **Rendering, a button to trigger this from the page.** Step 4.


