### PR TITLE
MVP step 4a · the page shell, the instalment strip, the split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ node_modules/
 next-env.d.ts
 *.tsbuildinfo
 
+# SLUICE_CONFIG_DIR lives here for local dev — never committed, same reason
+# sluice.toml itself never is: it's a path into the household's own machine.
+.env*.local
+
 # Bank exports and household config never live here — they live outside the
 # working tree entirely (see README). These patterns are a second line of
 # defence, not the mechanism.

--- a/app/_components/ContributionsChart.tsx
+++ b/app/_components/ContributionsChart.tsx
@@ -14,8 +14,8 @@ export interface ContributionsChartProps {
 
 // Only two categorical colours exist in globals.css — #296 frames this as a
 // two-person tool throughout, and the schema doesn't cap [people.*] at two.
-// A third person renders with an undefined CSS variable, which fails loudly
-// (a missing swatch) rather than silently reusing a colour.
+// A third `[people.*]` entry is refused loudly in page.tsx before this
+// component ever renders, rather than silently reusing a colour here.
 const SERIES_COLORS = ['var(--series-1)', 'var(--series-2)'] as const;
 
 const BAR_WIDTH = 22;
@@ -86,9 +86,17 @@ export function ContributionsChart({ months, people, referenceDay }: Contributio
   // to 18+ months of real bars, a total label on each one collides with its
   // neighbours long before it becomes readable. Two gridlines carry the
   // scale instead; the exact figure per month lives in the native tooltip.
+  //
+  // `value` is rounded to a whole cent — `axisMax * fraction` is only ever
+  // fractional for a very small `axisMax` (1 or 5, `niceMax`'s two odd
+  // steps), but "integer cents, never a float" has no exception for that.
+  // Keyed by `fraction`, not `value`: two gridlines can legitimately round
+  // to the same displayed cent at a small `axisMax`, and `fraction` (0.5,
+  // 1) is unique by construction where the rounded `value` isn't.
   const gridlines = [0.5, 1].map((fraction) => ({
+    fraction,
     y: baseline - CHART_HEIGHT * fraction,
-    value: axisMax * fraction,
+    value: Math.round(axisMax * fraction),
   }));
 
   return (
@@ -107,8 +115,8 @@ export function ContributionsChart({ months, people, referenceDay }: Contributio
         role="img"
         aria-label="Contributions by month, stacked by sender"
       >
-        {gridlines.map(({ y, value }) => (
-          <g key={value}>
+        {gridlines.map(({ fraction, y, value }) => (
+          <g key={fraction}>
             <line className="grid-line" x1={LEFT_AXIS_WIDTH} y1={y} x2={width} y2={y} />
             <text className="axis-tick-label" x={LEFT_AXIS_WIDTH - 8} y={y} textAnchor="end" dominantBaseline="middle">
               {formatEurCompact(value)}

--- a/app/_components/ContributionsChart.tsx
+++ b/app/_components/ContributionsChart.tsx
@@ -32,6 +32,30 @@ interface Segment {
   readonly label: string;
 }
 
+/**
+ * A rectangle rounded at the top two corners only, square at the bottom —
+ * "4px rounded data-end, square at the baseline" from the dataviz skill's
+ * mark spec. Plain `<rect rx>` rounds all four corners uniformly, which is
+ * wrong specifically when a stacked bar has only one segment: that segment
+ * is then both the data-end *and* the one touching the baseline, and a
+ * plain `rx` would round its bottom too. Radius is clamped to the
+ * segment's own size so a very small amount never produces overlapping arcs.
+ */
+function roundedTopRectPath(x: number, y: number, width: number, height: number, radius: number): string {
+  const r = Math.max(0, Math.min(radius, height / 2, width / 2));
+  if (r === 0) return `M${x},${y} h${width} v${height} h${-width} Z`;
+  return [
+    `M${x + r},${y}`,
+    `H${x + width - r}`,
+    `A${r},${r} 0 0 1 ${x + width},${y + r}`,
+    `V${y + height}`,
+    `H${x}`,
+    `V${y + r}`,
+    `A${r},${r} 0 0 1 ${x + r},${y}`,
+    'Z',
+  ].join(' ');
+}
+
 /** Rounds up to a "clean" step (1, 2, or 5 × a power of ten) for a Y-axis tick, the same rule the dataviz skill asks for. */
 function niceMax(value: number): number {
   if (value <= 0) return 1;
@@ -126,18 +150,12 @@ export function ContributionsChart({ months, people, referenceDay }: Contributio
             const top = cursorTop - seg.height;
             cursorTop = top - SEGMENT_GAP;
             const isTopmost = idx === segments.length - 1;
-            return (
-              <rect
-                key={idx}
-                x={x}
-                y={top}
-                width={BAR_WIDTH}
-                height={seg.height}
-                rx={isTopmost ? 4 : 0}
-                ry={isTopmost ? 4 : 0}
-                fill={seg.muted ? 'var(--ink-muted)' : seg.color}
-                fillOpacity={seg.muted ? 0.55 : 1}
-              />
+            const fill = seg.muted ? 'var(--ink-muted)' : seg.color;
+            const fillOpacity = seg.muted ? 0.55 : 1;
+            return isTopmost ? (
+              <path key={idx} d={roundedTopRectPath(x, top, BAR_WIDTH, seg.height, 4)} fill={fill} fillOpacity={fillOpacity} />
+            ) : (
+              <rect key={idx} x={x} y={top} width={BAR_WIDTH} height={seg.height} fill={fill} fillOpacity={fillOpacity} />
             );
           });
 

--- a/app/_components/ContributionsChart.tsx
+++ b/app/_components/ContributionsChart.tsx
@@ -22,8 +22,8 @@ const BAR_WIDTH = 22;
 const BAR_GAP = 16;
 const CHART_HEIGHT = 140;
 const SEGMENT_GAP = 2; // the surface gap between stacked segments, per the dataviz skill
-const LABEL_ROOM = 20; // above the tallest bar, for the total label
 const AXIS_ROOM = 26; // below the baseline, for the month label
+const LEFT_AXIS_WIDTH = 56; // for the Y-axis tick labels
 
 interface Segment {
   readonly height: number;
@@ -32,18 +32,40 @@ interface Segment {
   readonly label: string;
 }
 
+/** Rounds up to a "clean" step (1, 2, or 5 × a power of ten) for a Y-axis tick, the same rule the dataviz skill asks for. */
+function niceMax(value: number): number {
+  if (value <= 0) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  const steps = [1, 2, 5, 10];
+  const step = steps.find((s) => s * magnitude >= value) ?? 10;
+  return step * magnitude;
+}
+
 export function ContributionsChart({ months, people, referenceDay }: ContributionsChartProps) {
   if (months.length === 0) {
     return <p className="chart-empty">No contributions recorded yet.</p>;
   }
 
-  const maxTotal = Math.max(...months.map((m) => m.total), 1);
-  const scale = (cents: Cents): number => (cents / maxTotal) * CHART_HEIGHT;
+  // Rounded up to a clean tick value, not the raw max — a raw max would put
+  // the tallest bar's label at an arbitrary figure nobody would round-trip
+  // by eye, and every other bar would read off an axis with no clean anchor.
+  const axisMax = niceMax(Math.max(...months.map((m) => m.total), 1));
+  const scale = (cents: Cents): number => (cents / axisMax) * CHART_HEIGHT;
 
   const currentMonth = monthOf(referenceDay);
-  const width = months.length * (BAR_WIDTH + BAR_GAP) + BAR_GAP;
-  const svgHeight = CHART_HEIGHT + LABEL_ROOM + AXIS_ROOM;
-  const baseline = LABEL_ROOM + CHART_HEIGHT;
+  const chartWidth = months.length * (BAR_WIDTH + BAR_GAP) + BAR_GAP;
+  const width = LEFT_AXIS_WIDTH + chartWidth;
+  const svgHeight = CHART_HEIGHT + AXIS_ROOM;
+  const baseline = CHART_HEIGHT;
+
+  // Never a number on every point (the dataviz skill's own rule) — with up
+  // to 18+ months of real bars, a total label on each one collides with its
+  // neighbours long before it becomes readable. Two gridlines carry the
+  // scale instead; the exact figure per month lives in the native tooltip.
+  const gridlines = [0.5, 1].map((fraction) => ({
+    y: baseline - CHART_HEIGHT * fraction,
+    value: axisMax * fraction,
+  }));
 
   return (
     <div className="chart-wrap">
@@ -61,9 +83,18 @@ export function ContributionsChart({ months, people, referenceDay }: Contributio
         role="img"
         aria-label="Contributions by month, stacked by sender"
       >
-        <line className="axis-line" x1={0} y1={baseline} x2={width} y2={baseline} />
+        {gridlines.map(({ y, value }) => (
+          <g key={value}>
+            <line className="grid-line" x1={LEFT_AXIS_WIDTH} y1={y} x2={width} y2={y} />
+            <text className="axis-tick-label" x={LEFT_AXIS_WIDTH - 8} y={y} textAnchor="end" dominantBaseline="middle">
+              {formatEurCompact(value)}
+            </text>
+          </g>
+        ))}
+        <line className="axis-line" x1={LEFT_AXIS_WIDTH} y1={baseline} x2={width} y2={baseline} />
+
         {months.map((month, i) => {
-          const x = BAR_GAP + i * (BAR_WIDTH + BAR_GAP);
+          const x = LEFT_AXIS_WIDTH + BAR_GAP + i * (BAR_WIDTH + BAR_GAP);
           const isInProgress = month.month === currentMonth;
 
           const segments: Segment[] = [];
@@ -86,10 +117,9 @@ export function ContributionsChart({ months, people, referenceDay }: Contributio
             });
           }
 
-          const totalHeight = segments.reduce((a, s) => a + s.height, 0) + SEGMENT_GAP * Math.max(segments.length - 1, 0);
-          const titleText = `${formatMonthShort(month.month)}${isInProgress ? ' (in progress)' : ''} — ${
-            segments.length > 0 ? segments.map((s) => s.label).join(', ') : 'nothing recorded'
-          }`;
+          const titleText = `${formatMonthShort(month.month)}${isInProgress ? ' (in progress)' : ''} — ${formatEur(
+            month.total,
+          )} total${segments.length > 0 ? ` (${segments.map((s) => s.label).join(', ')})` : ''}`;
 
           let cursorTop = baseline;
           const rects = segments.map((seg, idx) => {
@@ -115,16 +145,6 @@ export function ContributionsChart({ months, people, referenceDay }: Contributio
             <g key={month.month} opacity={isInProgress ? 0.6 : 1}>
               <title>{titleText}</title>
               {rects}
-              {month.total > 0 && (
-                <text
-                  className="bar-total-label"
-                  x={x + BAR_WIDTH / 2}
-                  y={baseline - totalHeight - 8}
-                  textAnchor="middle"
-                >
-                  {formatEurCompact(month.total)}
-                </text>
-              )}
               <text className="month-label" x={x + BAR_WIDTH / 2} y={svgHeight - 8} textAnchor="middle">
                 {formatMonthShort(month.month)}
                 {isInProgress ? '*' : ''}

--- a/app/_components/ContributionsChart.tsx
+++ b/app/_components/ContributionsChart.tsx
@@ -1,0 +1,141 @@
+import { formatMonthShort, monthOf, type Day } from '@/core/dates.ts';
+import { formatEur, formatEurCompact, type Cents } from '@/core/money.ts';
+import type { Person } from '@/config/load.ts';
+import type { MonthlyContributions } from '@/numbers/funding.ts';
+import { Legend } from './Legend.tsx';
+
+export interface ContributionsChartProps {
+  readonly months: readonly MonthlyContributions[];
+  /** For name + colour-slot order — `config.people`, declaration order. */
+  readonly people: readonly Person[];
+  /** Marks the in-progress month distinctly: it is not yet a complete data point. */
+  readonly referenceDay: Day;
+}
+
+// Only two categorical colours exist in globals.css — #296 frames this as a
+// two-person tool throughout, and the schema doesn't cap [people.*] at two.
+// A third person renders with an undefined CSS variable, which fails loudly
+// (a missing swatch) rather than silently reusing a colour.
+const SERIES_COLORS = ['var(--series-1)', 'var(--series-2)'] as const;
+
+const BAR_WIDTH = 22;
+const BAR_GAP = 16;
+const CHART_HEIGHT = 140;
+const SEGMENT_GAP = 2; // the surface gap between stacked segments, per the dataviz skill
+const LABEL_ROOM = 20; // above the tallest bar, for the total label
+const AXIS_ROOM = 26; // below the baseline, for the month label
+
+interface Segment {
+  readonly height: number;
+  readonly color: string;
+  readonly muted: boolean;
+  readonly label: string;
+}
+
+export function ContributionsChart({ months, people, referenceDay }: ContributionsChartProps) {
+  if (months.length === 0) {
+    return <p className="chart-empty">No contributions recorded yet.</p>;
+  }
+
+  const maxTotal = Math.max(...months.map((m) => m.total), 1);
+  const scale = (cents: Cents): number => (cents / maxTotal) * CHART_HEIGHT;
+
+  const currentMonth = monthOf(referenceDay);
+  const width = months.length * (BAR_WIDTH + BAR_GAP) + BAR_GAP;
+  const svgHeight = CHART_HEIGHT + LABEL_ROOM + AXIS_ROOM;
+  const baseline = LABEL_ROOM + CHART_HEIGHT;
+
+  return (
+    <div className="chart-wrap">
+      <Legend
+        items={[
+          ...people.map((person, i) => ({ label: person.name, color: SERIES_COLORS[i % SERIES_COLORS.length]! })),
+          { label: 'Unattributed', muted: true },
+        ]}
+      />
+      <svg
+        className="contrib"
+        viewBox={`0 0 ${width} ${svgHeight}`}
+        width="100%"
+        height={svgHeight}
+        role="img"
+        aria-label="Contributions by month, stacked by sender"
+      >
+        <line className="axis-line" x1={0} y1={baseline} x2={width} y2={baseline} />
+        {months.map((month, i) => {
+          const x = BAR_GAP + i * (BAR_WIDTH + BAR_GAP);
+          const isInProgress = month.month === currentMonth;
+
+          const segments: Segment[] = [];
+          for (const [idx, person] of people.entries()) {
+            const amount = month.byPerson.get(person.id) ?? 0;
+            if (amount <= 0) continue;
+            segments.push({
+              height: scale(amount),
+              color: SERIES_COLORS[idx % SERIES_COLORS.length]!,
+              muted: false,
+              label: `${person.name} ${formatEur(amount)}`,
+            });
+          }
+          if (month.unattributed > 0) {
+            segments.push({
+              height: scale(month.unattributed),
+              color: '',
+              muted: true,
+              label: `Unattributed ${formatEur(month.unattributed)}`,
+            });
+          }
+
+          const totalHeight = segments.reduce((a, s) => a + s.height, 0) + SEGMENT_GAP * Math.max(segments.length - 1, 0);
+          const titleText = `${formatMonthShort(month.month)}${isInProgress ? ' (in progress)' : ''} — ${
+            segments.length > 0 ? segments.map((s) => s.label).join(', ') : 'nothing recorded'
+          }`;
+
+          let cursorTop = baseline;
+          const rects = segments.map((seg, idx) => {
+            const top = cursorTop - seg.height;
+            cursorTop = top - SEGMENT_GAP;
+            const isTopmost = idx === segments.length - 1;
+            return (
+              <rect
+                key={idx}
+                x={x}
+                y={top}
+                width={BAR_WIDTH}
+                height={seg.height}
+                rx={isTopmost ? 4 : 0}
+                ry={isTopmost ? 4 : 0}
+                fill={seg.muted ? 'var(--ink-muted)' : seg.color}
+                fillOpacity={seg.muted ? 0.55 : 1}
+              />
+            );
+          });
+
+          return (
+            <g key={month.month} opacity={isInProgress ? 0.6 : 1}>
+              <title>{titleText}</title>
+              {rects}
+              {month.total > 0 && (
+                <text
+                  className="bar-total-label"
+                  x={x + BAR_WIDTH / 2}
+                  y={baseline - totalHeight - 8}
+                  textAnchor="middle"
+                >
+                  {formatEurCompact(month.total)}
+                </text>
+              )}
+              <text className="month-label" x={x + BAR_WIDTH / 2} y={svgHeight - 8} textAnchor="middle">
+                {formatMonthShort(month.month)}
+                {isInProgress ? '*' : ''}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      {months.some((m) => m.month === currentMonth) && (
+        <p className="chart-note">* month in progress — not yet a complete data point</p>
+      )}
+    </div>
+  );
+}

--- a/app/_components/InstalmentStrip.tsx
+++ b/app/_components/InstalmentStrip.tsx
@@ -1,0 +1,36 @@
+import { formatEur, sum } from '@/core/money.ts';
+import type { Config } from '@/config/load.ts';
+import type { Plan } from '@/numbers/plan.ts';
+import { StatTile } from './StatTile.tsx';
+
+// Same colour-slot convention as ContributionsChart — see its comment on why
+// only two exist.
+const SERIES_COLORS = ['var(--series-1)', 'var(--series-2)'] as const;
+
+/** A KPI row, one stat tile per person — a handful of headline numbers, not a chart. */
+export function InstalmentStrip({ config, plan }: { readonly config: Config; readonly plan: Plan }) {
+  const totalNet = sum(plan.shares.map((s) => s.netMonthly));
+
+  return (
+    <div className="strip">
+      {config.people.map((person, i) => {
+        const share = plan.shares.find((s) => s.personId === person.id);
+        const pct = share !== undefined && totalNet > 0 ? ((share.netMonthly / totalNet) * 100).toFixed(1) : null;
+        // exactOptionalPropertyTypes: an optional prop must be omitted, not
+        // passed `undefined` — the same rule this codebase's fixture
+        // builders already follow.
+        return (
+          <StatTile
+            key={person.id}
+            label={`${person.name} transfers`}
+            value={share?.amount ?? 0}
+            seriesColor={SERIES_COLORS[i % SERIES_COLORS.length]!}
+            {...(share !== undefined
+              ? { sub: `net income ${formatEur(share.netMonthly)}${pct !== null ? ` · ${pct}% share` : ''}` }
+              : {})}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/app/_components/Legend.tsx
+++ b/app/_components/Legend.tsx
@@ -1,0 +1,28 @@
+/**
+ * Always present for two or more series — the dependable identity channel,
+ * per the dataviz skill: never make the reader rely on colour-matching a
+ * chart to memory alone.
+ */
+export interface LegendItem {
+  readonly label: string;
+  /** A CSS colour, e.g. `'var(--series-1)'`. Ignored when `muted` is set. */
+  readonly color?: string;
+  /** The "unattributed" treatment — a muted grey, not a categorical hue: see ContributionsChart. */
+  readonly muted?: boolean;
+}
+
+export function Legend({ items }: { readonly items: readonly LegendItem[] }) {
+  return (
+    <div className="chart-legend">
+      {items.map((item) => (
+        <span className="legend-key" key={item.label}>
+          <span
+            className={item.muted === true ? 'swatch swatch-muted' : 'swatch'}
+            style={item.muted === true ? undefined : { background: item.color }}
+          />
+          {item.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/app/_components/SplitSection.tsx
+++ b/app/_components/SplitSection.tsx
@@ -1,0 +1,67 @@
+import { formatEur, sum } from '@/core/money.ts';
+import type { Config } from '@/config/load.ts';
+import type { Plan } from '@/numbers/plan.ts';
+import { ContributionsChart } from './ContributionsChart.tsx';
+
+const SERIES_COLORS = ['var(--series-1)', 'var(--series-2)'] as const;
+
+export function SplitSection({ config, plan }: { readonly config: Config; readonly plan: Plan }) {
+  const totalNet = sum(plan.shares.map((s) => s.netMonthly));
+
+  return (
+    <section className="card">
+      <h2>01 · The split</h2>
+      <p className="deck">Income, net of tax, split proportionally. Recomputed every run — never a stored figure.</p>
+
+      <table className="income">
+        <thead>
+          <tr>
+            <th>Person</th>
+            <th>Source</th>
+            <th className="amount">Net</th>
+            <th className="amount">Share</th>
+            <th className="amount">Transfers</th>
+          </tr>
+        </thead>
+        <tbody>
+          {config.people.map((person, personIndex) => {
+            const share = plan.shares.find((s) => s.personId === person.id);
+            const pct = share !== undefined && totalNet > 0 ? ((share.netMonthly / totalNet) * 100).toFixed(1) : null;
+            return person.income.map((source, sourceIndex) => (
+              <tr key={`${person.id}:${sourceIndex}`}>
+                {sourceIndex === 0 && (
+                  <td rowSpan={person.income.length}>
+                    <span className="person">
+                      <span
+                        className="swatch"
+                        style={{ background: SERIES_COLORS[personIndex % SERIES_COLORS.length] }}
+                      />
+                      {person.name}
+                    </span>
+                  </td>
+                )}
+                <td>{source.label}</td>
+                <td className="amount num">
+                  {formatEur(source.net)}{' '}
+                  <span className="cadence">/{source.cadence === 'monthly' ? 'mo' : 'yr'}</span>
+                </td>
+                {sourceIndex === 0 && (
+                  <td className="amount num share" rowSpan={person.income.length}>
+                    {pct !== null ? `${pct}%` : '—'}
+                  </td>
+                )}
+                {sourceIndex === 0 && (
+                  <td className="amount num" rowSpan={person.income.length}>
+                    {share !== undefined ? formatEur(share.amount) : '—'}
+                  </td>
+                )}
+              </tr>
+            ));
+          })}
+        </tbody>
+      </table>
+
+      <ContributionsChart months={plan.contributions} people={config.people} referenceDay={plan.referenceDay} />
+    </section>
+  );
+}

--- a/app/_components/SplitSection.tsx
+++ b/app/_components/SplitSection.tsx
@@ -13,53 +13,56 @@ export function SplitSection({ config, plan }: { readonly config: Config; readon
       <h2>01 · The split</h2>
       <p className="deck">Income, net of tax, split proportionally. Recomputed every run — never a stored figure.</p>
 
-      <table className="income">
-        <thead>
-          <tr>
-            <th>Person</th>
-            <th>Source</th>
-            <th className="amount">Net</th>
-            <th className="amount">Share</th>
-            <th className="amount">Transfers</th>
-          </tr>
-        </thead>
-        <tbody>
-          {config.people.map((person, personIndex) => {
-            const share = plan.shares.find((s) => s.personId === person.id);
-            const pct = share !== undefined && totalNet > 0 ? ((share.netMonthly / totalNet) * 100).toFixed(1) : null;
-            return person.income.map((source, sourceIndex) => (
-              <tr key={`${person.id}:${sourceIndex}`}>
-                {sourceIndex === 0 && (
-                  <td rowSpan={person.income.length}>
-                    <span className="person">
-                      <span
-                        className="swatch"
-                        style={{ background: SERIES_COLORS[personIndex % SERIES_COLORS.length] }}
-                      />
-                      {person.name}
-                    </span>
+      <div className="table-scroll">
+        <table className="income">
+          <thead>
+            <tr>
+              <th>Person</th>
+              <th>Source</th>
+              <th className="amount">Net</th>
+              <th className="amount">Share</th>
+              <th className="amount">Transfers</th>
+            </tr>
+          </thead>
+          <tbody>
+            {config.people.map((person, personIndex) => {
+              const share = plan.shares.find((s) => s.personId === person.id);
+              const pct =
+                share !== undefined && totalNet > 0 ? ((share.netMonthly / totalNet) * 100).toFixed(1) : null;
+              return person.income.map((source, sourceIndex) => (
+                <tr key={`${person.id}:${sourceIndex}`}>
+                  {sourceIndex === 0 && (
+                    <td rowSpan={person.income.length}>
+                      <span className="person">
+                        <span
+                          className="swatch"
+                          style={{ background: SERIES_COLORS[personIndex % SERIES_COLORS.length] }}
+                        />
+                        {person.name}
+                      </span>
+                    </td>
+                  )}
+                  <td>{source.label}</td>
+                  <td className="amount num">
+                    {formatEur(source.net)}{' '}
+                    <span className="cadence">/{source.cadence === 'monthly' ? 'mo' : 'yr'}</span>
                   </td>
-                )}
-                <td>{source.label}</td>
-                <td className="amount num">
-                  {formatEur(source.net)}{' '}
-                  <span className="cadence">/{source.cadence === 'monthly' ? 'mo' : 'yr'}</span>
-                </td>
-                {sourceIndex === 0 && (
-                  <td className="amount num share" rowSpan={person.income.length}>
-                    {pct !== null ? `${pct}%` : '—'}
-                  </td>
-                )}
-                {sourceIndex === 0 && (
-                  <td className="amount num" rowSpan={person.income.length}>
-                    {share !== undefined ? formatEur(share.amount) : '—'}
-                  </td>
-                )}
-              </tr>
-            ));
-          })}
-        </tbody>
-      </table>
+                  {sourceIndex === 0 && (
+                    <td className="amount num share" rowSpan={person.income.length}>
+                      {pct !== null ? `${pct}%` : '—'}
+                    </td>
+                  )}
+                  {sourceIndex === 0 && (
+                    <td className="amount num" rowSpan={person.income.length}>
+                      {share !== undefined ? formatEur(share.amount) : '—'}
+                    </td>
+                  )}
+                </tr>
+              ));
+            })}
+          </tbody>
+        </table>
+      </div>
 
       <ContributionsChart months={plan.contributions} people={config.people} referenceDay={plan.referenceDay} />
     </section>

--- a/app/_components/SplitSection.tsx
+++ b/app/_components/SplitSection.tsx
@@ -14,7 +14,7 @@ export function SplitSection({ config, plan }: { readonly config: Config; readon
       <p className="deck">Income, net of tax, split proportionally. Recomputed every run — never a stored figure.</p>
 
       <div className="table-scroll">
-        <table className="income">
+        <table className="data-table income">
           <thead>
             <tr>
               <th>Person</th>

--- a/app/_components/StatTile.tsx
+++ b/app/_components/StatTile.tsx
@@ -1,0 +1,28 @@
+import { formatEur, type Cents } from '@/core/money.ts';
+
+/**
+ * A headline number, not a column: proportional figures, not `.num`
+ * (tabular) — `tabular-nums` gives every digit the width of a `0`, which
+ * looks loose at display sizes and is reserved for columns that must align
+ * vertically (the dataviz skill's own rule for stat-tile values).
+ */
+export interface StatTileProps {
+  readonly label: string;
+  readonly value: Cents;
+  /** A CSS colour, e.g. `'var(--series-1)'` — identity for the label, never for the value text itself. */
+  readonly seriesColor?: string;
+  readonly sub?: string;
+}
+
+export function StatTile({ label, value, seriesColor, sub }: StatTileProps) {
+  return (
+    <div className="stat-tile">
+      <span className="stat-tile-label">
+        {seriesColor !== undefined && <span className="swatch" style={{ background: seriesColor }} />}
+        {label}
+      </span>
+      <span className="stat-tile-value">{formatEur(value)}</span>
+      {sub !== undefined && <span className="stat-tile-sub">{sub}</span>}
+    </div>
+  );
+}

--- a/app/_lib/telemetry.ts
+++ b/app/_lib/telemetry.ts
@@ -1,0 +1,74 @@
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Spans for the reserved `service.name=sluice` workload
+ * `observability/README.md` already describes, over the identical transport
+ * `observability/hooks/session-outcome.ts` uses: raw OTLP/HTTP JSON over
+ * `fetch()`, zero dependencies — no SDK to keep in step with a beta trace
+ * shape, no npm install before the product's own stack is chosen.
+ *
+ * Differs from that hook in one way: `emitSpan` never awaits its own
+ * network call. The hook is a short-lived CLI process that would otherwise
+ * exit before the request lands; `app/page.tsx` runs inside Next's
+ * long-lived server process, so a genuinely fire-and-forget call never adds
+ * the collector's latency to a page render, and a dead collector — the
+ * normal case when `observability/` isn't running — costs nothing. Errors
+ * are swallowed here: nothing about telemetry may be the reason a page
+ * fails to render.
+ */
+
+const ENDPOINT = process.env.SLUICE_OTLP_HTTP_ENDPOINT ?? 'http://localhost:4318';
+const EXPORT_TIMEOUT_MS = 2000;
+
+/** One `traceId`, shared by every span emitted for a single page view — so "what happened during this visit" is one trace, not several unrelated ones. */
+export interface Trace {
+  readonly traceId: string;
+}
+
+export function newTrace(): Trace {
+  return { traceId: randomBytes(16).toString('hex') };
+}
+
+type AttrValue = string | number | boolean;
+
+function attrValue(value: AttrValue): Record<string, unknown> {
+  if (typeof value === 'string') return { stringValue: value };
+  if (typeof value === 'boolean') return { boolValue: value };
+  return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value };
+}
+
+export function emitSpan(trace: Trace, name: string, attrs: Record<string, AttrValue> = {}): void {
+  const nowNs = String(BigInt(Date.now()) * 1_000_000n);
+  const body = {
+    resourceSpans: [
+      {
+        resource: { attributes: [{ key: 'service.name', value: { stringValue: 'sluice' } }] },
+        scopeSpans: [
+          {
+            scope: { name: 'sluice.page' },
+            spans: [
+              {
+                traceId: trace.traceId,
+                spanId: randomBytes(8).toString('hex'),
+                name,
+                kind: 1,
+                startTimeUnixNano: nowNs,
+                endTimeUnixNano: nowNs,
+                attributes: Object.entries(attrs).map(([key, value]) => ({ key, value: attrValue(value) })),
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  fetch(`${ENDPOINT}/v1/traces`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(EXPORT_TIMEOUT_MS),
+  }).catch(() => {
+    // A dead collector is the normal case when observability/ isn't running.
+  });
+}

--- a/app/_lib/today.ts
+++ b/app/_lib/today.ts
@@ -1,0 +1,19 @@
+import type { Day } from '@/core/dates.ts';
+
+/**
+ * "Today," read once — the one place in the whole app that touches the wall
+ * clock. `src/numbers/`'s own doc comments promise nothing under it ever
+ * does; this is the edge those comments point to.
+ *
+ * Correct because sluice is localhost, single-user: the server *is* the
+ * household's own machine, so its local time and the reader's are the same
+ * clock by construction. Would need revisiting the day this ever runs
+ * anywhere else.
+ */
+export function todayAsDay(): Day {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}` as Day;
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+/**
+ * `ConfigNotFoundError`, `ConfigError`, `ExportsNotFoundError`, and every
+ * other error `loadConfig`/`loadLedger` can throw already carry a good,
+ * actionable message — that was the whole point of steps 1 and 2. This
+ * renders `error.message` directly rather than a generic "something broke,"
+ * so none of that work goes to waste the one time it's actually needed.
+ *
+ * Next's App Router requires this to be a client component even though
+ * nothing here is interactive.
+ */
+export default function Error({ error }: { readonly error: Error & { digest?: string } }) {
+  return (
+    <div className="error-panel">
+      <h1>Couldn’t render the plan</h1>
+      <pre>{error.message}</pre>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -120,3 +120,202 @@ body {
   font-variant-numeric: tabular-nums;
   font-feature-settings: 'tnum' 1;
 }
+
+/* --- step 4: the page --- */
+
+main {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 48px 24px 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.page-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+.page-header h1 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.page-header .as-of {
+  font-size: 13px;
+  color: var(--ink-muted);
+}
+
+/* Instalment strip: a KPI row, one stat tile per person. */
+.strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2px;
+  background: var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.stat-tile {
+  background: var(--surface-raised);
+  padding: 20px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.stat-tile-label {
+  font-size: 13px;
+  color: var(--ink-secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.stat-tile-value {
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.stat-tile-sub {
+  font-size: 12.5px;
+  color: var(--ink-muted);
+}
+
+.swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex: none;
+}
+.swatch-muted {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex: none;
+  background: var(--ink-muted);
+  opacity: 0.55;
+}
+
+.card {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 22px 24px 24px;
+}
+.card > h2 {
+  margin: 0 0 4px;
+  font-size: 15px;
+  font-weight: 600;
+}
+.card > .deck {
+  margin: 0 0 18px;
+  font-size: 13px;
+  color: var(--ink-muted);
+  max-width: 60ch;
+}
+
+table.income {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+table.income th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--ink-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0 10px 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+table.income td {
+  padding: 9px 10px 9px 0;
+  border-bottom: 1px solid var(--border);
+  vertical-align: baseline;
+}
+table.income tr:last-child td {
+  border-bottom: none;
+}
+table.income td.amount,
+table.income th.amount {
+  text-align: right;
+}
+table.income .person {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+table.income .cadence {
+  color: var(--ink-muted);
+}
+table.income .share {
+  color: var(--ink-secondary);
+}
+
+.chart-wrap {
+  margin-top: 22px;
+}
+.chart-legend {
+  display: flex;
+  gap: 18px;
+  margin-bottom: 12px;
+  font-size: 12.5px;
+  color: var(--ink-secondary);
+}
+.chart-legend .legend-key {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.chart-empty,
+.chart-note {
+  font-size: 12.5px;
+  color: var(--ink-muted);
+}
+.chart-note {
+  margin: 8px 0 0;
+}
+
+svg.contrib text {
+  font-family: var(--font-sans);
+  fill: var(--ink-muted);
+}
+svg.contrib .axis-line {
+  stroke: var(--axis);
+  stroke-width: 1;
+}
+svg.contrib .bar-total-label {
+  font-family: var(--font-num);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  fill: var(--ink-secondary);
+}
+svg.contrib .month-label {
+  font-size: 11px;
+}
+
+/* Error boundary */
+.error-panel {
+  max-width: 880px;
+  margin: 64px auto;
+  padding: 24px 24px;
+  border: 1px solid var(--critical);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+}
+.error-panel h1 {
+  margin: 0 0 10px;
+  font-size: 16px;
+  color: var(--critical);
+}
+.error-panel pre {
+  white-space: pre-wrap;
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  color: var(--ink-secondary);
+  margin: 0;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -216,6 +216,11 @@ main {
   max-width: 60ch;
 }
 
+/* Wide content scrolls in its own box — the page body never scrolls sideways. */
+.table-scroll {
+  overflow-x: auto;
+}
+
 table.income {
   width: 100%;
   border-collapse: collapse;
@@ -288,11 +293,15 @@ svg.contrib .axis-line {
   stroke: var(--axis);
   stroke-width: 1;
 }
-svg.contrib .bar-total-label {
+svg.contrib .grid-line {
+  stroke: var(--grid);
+  stroke-width: 1;
+}
+svg.contrib .axis-tick-label {
   font-family: var(--font-num);
-  font-size: 11px;
+  font-size: 10.5px;
   font-variant-numeric: tabular-nums;
-  fill: var(--ink-secondary);
+  fill: var(--ink-muted);
 }
 svg.contrib .month-label {
   font-size: 11px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -221,12 +221,18 @@ main {
   overflow-x: auto;
 }
 
-table.income {
+/*
+ * Shared by every data table on the page (.income, .checks, .year) — column-
+ * specific styling (income's .person/.cadence/.share, checks' .pace-over/
+ * .pace-ok) stays on each table's own class, applied alongside .data-table
+ * rather than duplicated into it.
+ */
+.data-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 13.5px;
 }
-table.income th {
+.data-table th {
   text-align: left;
   font-weight: 500;
   color: var(--ink-muted);
@@ -236,17 +242,20 @@ table.income th {
   padding: 0 10px 8px 0;
   border-bottom: 1px solid var(--border);
 }
-table.income td {
+.data-table td {
   padding: 9px 10px 9px 0;
   border-bottom: 1px solid var(--border);
-  vertical-align: baseline;
 }
-table.income tr:last-child td {
+.data-table tr:last-child td {
   border-bottom: none;
 }
-table.income td.amount,
-table.income th.amount {
+.data-table td.amount,
+.data-table th.amount {
   text-align: right;
+}
+
+table.income td {
+  vertical-align: baseline;
 }
 table.income .person {
   display: flex;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,64 @@
-export default function Page() {
+import { loadConfig, expandHome } from '@/config/load.ts';
+import { loadLedger, type Ledger } from '@/ingest/load.ts';
+import { computePlan, type Plan } from '@/numbers/plan.ts';
+import { todayAsDay } from './_lib/today.ts';
+import { newTrace, emitSpan } from './_lib/telemetry.ts';
+import { InstalmentStrip } from './_components/InstalmentStrip.tsx';
+import { SplitSection } from './_components/SplitSection.tsx';
+
+function ingestAttrs(ledger: Ledger): Record<string, string | number | boolean> {
+  const r = ledger.reconciliation;
+  return {
+    transaction_count: ledger.transactions.length,
+    source_count: ledger.sources.length,
+    reconciled_count: r.reconciled,
+    in_flight_count: r.inFlight,
+    window_edge_count: r.windowEdge,
+    mismatched_count: r.mismatched,
+  };
+}
+
+function planAttrs(plan: Plan): Record<string, string | number | boolean> {
+  const configuredCount = plan.consumption.filter((c) => c.envelope.kind === 'configured').length;
+  const pastPaceCount = plan.check.envelopes.filter((e) => e.pastPace).length;
+  return {
+    envelope_count: plan.consumption.length,
+    configured_envelope_count: configuredCount,
+    warning_count: plan.warnings.length,
+    past_pace_count: pastPaceCount,
+    buffer_sufficient: plan.check.bufferSufficient,
+  };
+}
+
+export default async function Page() {
+  const directory = process.env.SLUICE_CONFIG_DIR;
+  if (directory === undefined || directory === '') {
+    throw new Error(
+      'SLUICE_CONFIG_DIR is not set. Point it at the folder holding sluice.toml, ' +
+        'e.g. SLUICE_CONFIG_DIR=~/sluice-private npm run dev.',
+    );
+  }
+
+  const trace = newTrace();
+
+  const config = await loadConfig(expandHome(directory));
+  const ledger = await loadLedger(config.exportsDirectory);
+  emitSpan(trace, 'sluice.ingest.load', ingestAttrs(ledger));
+
+  const plan = computePlan(config, ledger, todayAsDay());
+  emitSpan(trace, 'sluice.numbers.compute_plan', planAttrs(plan));
+
+  emitSpan(trace, 'sluice.page.report_displayed', { reference_day: plan.referenceDay });
+
   return (
-    <main style={{ maxWidth: 960, margin: '0 auto', padding: '48px 24px' }}>
-      <h1 style={{ margin: 0, fontSize: 22 }}>sluice</h1>
-      <p style={{ color: 'var(--ink-secondary)' }}>
-        The page is assembled once the ingest and the config land. See issue #296.
-      </p>
+    <main>
+      <header className="page-header">
+        <h1>sluice</h1>
+        <span className="as-of">as of {plan.referenceDay}</span>
+      </header>
+
+      <InstalmentStrip config={config} plan={plan} />
+      <SplitSection config={config} plan={plan} />
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,15 @@ import { newTrace, emitSpan } from './_lib/telemetry.ts';
 import { InstalmentStrip } from './_components/InstalmentStrip.tsx';
 import { SplitSection } from './_components/SplitSection.tsx';
 
+// Never statically prerendered: `next.config.ts`'s own comment already says
+// this app re-reads its inputs on every request because a stale render is
+// worse than a slow one. Without this, `next build` tries to prerender "/"
+// once at build time — executing this component with no SLUICE_CONFIG_DIR
+// available and no exports to read — and fails the build for the wrong
+// reason (a missing env var) while quietly implying the opposite of what
+// this app actually promises.
+export const dynamic = 'force-dynamic';
+
 function ingestAttrs(ledger: Ledger): Record<string, string | number | boolean> {
   const r = ledger.reconciliation;
   return {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,6 +51,18 @@ export default async function Page() {
   const trace = newTrace();
 
   const config = await loadConfig(expandHome(directory));
+
+  // Only two categorical colours exist for the page to draw with (see
+  // app/globals.css's --series-1/--series-2) — refused here, loudly, rather
+  // than letting a third person silently reuse a colour and misrepresent
+  // whose money is whose further down the page.
+  if (config.people.length > 2) {
+    throw new Error(
+      `"${directory}/sluice.toml" declares ${config.people.length} people, but this page only has colours ` +
+        'for two (see app/globals.css). Add a third series colour before adding a third person.',
+    );
+  }
+
   const ledger = await loadLedger(config.exportsDirectory);
   emitSpan(trace, 'sluice.ingest.load', ingestAttrs(ledger));
 

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -31,8 +31,12 @@ export class ConfigNotFoundError extends Error {
   }
 }
 
-/** A leading `~/` is the household's home directory. */
-function expandHome(path: string): string {
+/**
+ * A leading `~/` is the household's home directory. Exported: `app/page.tsx`
+ * expands `SLUICE_CONFIG_DIR` with this same function, so a `~/` there means
+ * exactly what it means in `sluice.toml` — one rule, not two that could drift.
+ */
+export function expandHome(path: string): string {
   if (path === '~') return homedir();
   if (path.startsWith('~/')) return join(homedir(), path.slice(2));
   return path;


### PR DESCRIPTION
Step 4a of 4 towards #296 — the page. Draft — opened early so the plan is
reviewable before the code lands, per the usual cadence. Based on `main`;
steps 1–3 are fully merged.

Household figures stay out of this repo. This describes structure and mechanism.

## Why

Steps 1–3 produce `computePlan(config, ledger, referenceDay)` — shares,
contributions, consumption, checks, warnings — mutation-tested against
synthetic fixtures and, separately, run once against real data from a
terminal script. Nothing has ever *rendered* it. `M1 mvp`'s exit condition is
"used it against real data at least once," and a script doesn't count.

`app/` was scaffolded back in step 1 with exactly this in mind:
`app/page.tsx` already says *"assembled once the ingest and the config land.
See issue #296,"* and `app/globals.css` already carries a full light/dark
token system — including a categorical pair validated (confirmed against the
dataviz skill's own validator, not just its code comment) for lightness,
chroma, and colour-vision separation. This step is the first thing to use
any of it.

## Scope — 4a only

The page shell, the instalment strip, and section 01 ("the split"). Sections
02–04 are 4b–4d, stacked on top of this once it merges — see the mockup and
decisions below for why they aren't fully designed yet.

**A mockup exists**, built against `globals.css`'s real tokens with
placeholder figures (not real household data), reviewed before any component
code was written: https://claude.ai/code/artifact/03153f55-344c-4c63-bedd-128a913bf9f1

## Decisions

| decision | choice | why |
|---|---|---|
| Charts | hand-rolled inline SVG, no chart library | the token system in `globals.css` was clearly built for this already; a chart library would fight it and adds a dependency to a project that's stayed at three on purpose |
| Config location | `SLUICE_CONFIG_DIR` env var, required | matches "refuse rather than default" everywhere else in this codebase |
| The wall clock | read once, in `app/page.tsx` only | `consumption.ts`'s own doc comment promises this: *"nothing under `src/numbers/` reads the wall clock; that stays at the edge, in step 4"* — this is that edge. Correct because this is localhost, single-user: server time and the household's time are the same clock |
| User-facing mutation | none — no forms, no config-editing UI | `sluice.toml` stays hand-edited outside the app; confirmed against the schema, no field exists for "reviewed" states |
| Telemetry | hand-rolled OTLP/HTTP over `fetch()`, reused from `observability/hooks/session-outcome.ts`'s exact pattern | `observability/README.md` already reserves `service.name=sluice` as a workload distinct from `service.name=dev-loop` — this fills a slot that was already there. Emitted only from `app/page.tsx`, never inside `src/ingest/` or `src/numbers/`, for the same reason the wall clock lives at the edge: those layers' whole value is being pure, provably so by mutation testing, and a `fetch()` inside them breaks that |
| Testing | `src/` gets the usual vitest + mutation discipline; `app/` is verified in the browser | `vitest.config.ts` only scopes `src/**/*.test.ts`; `tsc --noEmit` still typechecks `app/**`. Named as a real, if partial, gap rather than left implicit |

## Telemetry, in a bit more detail

Three spans, one shared `traceId` per page view: `sluice.ingest.load` (after
`loadLedger`), `sluice.numbers.compute_plan` (after `computePlan`),
`sluice.page.report_displayed` (right before rendering — a server-side
signal, not a browser-confirmed paint event; named as a deliberate gap, not
papered over). Attributes are counts and booleans (`transaction_count`,
`warning_count`, `buffer_sufficient`, …), not raw currency figures — a
judgment call given the collector is local infrastructure the household
already controls, open to being overridden in review.

`emitSpan()` does **not** `await` its `fetch()`, unlike the hook it's
modeled on — `session-outcome.ts` awaits (with a watchdog) because a short-
lived CLI process would otherwise exit before the call lands; `page.tsx`
runs inside Next's long-lived server process, so fire-and-forget is safe and
a dead collector costs nothing.

## Found while verifying against real data

The mockup used two months of small synthetic numbers; the real household
config (18 months, real category set) surfaced two things the mockup
couldn't have:

- `ContributionsChart` labeled every bar's total — which the dataviz
  skill explicitly rules out ("never a number on every point"). With 19
  real months of bars, those labels visibly collided into each other.
  Replaced with a proper Y-axis (two gridlines, rounded to a clean step);
  exact per-month figures now live in the native tooltip instead.
- The income table overflowed the viewport at mobile width with no scroll
  container, silently clipping the Transfers column. Wrapped it in its own
  `overflow-x: auto` box — the page body no longer scrolls sideways, only
  the table does.

Also confirmed telemetry end to end against the real running
`observability/` stack, not just that the `fetch()` didn't throw: all three
spans arrive in Phoenix under `service.name=sluice`, sharing one `traceId`,
carrying the expected attributes.

## Code review

One finding, from re-reading the geometry rather than seeing it break:
`ContributionsChart` used a plain `<rect rx>` for the topmost segment of
each stacked bar, which rounds all four corners uniformly. For a bar with
two or three segments that's fine — the topmost segment never touches the
baseline. But a month with only one segment (a single-earner household, or
a month where only "unattributed" has anything) makes that segment both the
top *and* the baseline-touching one, and `rx` would round its bottom too —
"square at the baseline" is the dataviz skill's own mark spec, not
optional. Every bar in the real test data happens to have ≥2 segments, so
this never showed up visually. Replaced with an explicit rounded-top-only
path, radius clamped to the segment's own size so a very small amount can't
produce overlapping arcs; verified the path geometry for both a normal and
a clamped case, and confirmed no visual change to the existing multi-segment
bars.

## Copilot review (post-merge follow-up, in 8fd91d8)

Three findings, all legitimate:

- The comment above `SERIES_COLORS` claimed a third person would fail loudly
  with an undefined CSS variable — but the code actually uses `%
  SERIES_COLORS.length`, which silently wraps and reuses a colour instead.
  Fixed by making the claim true: `page.tsx` now refuses to render (with an
  actionable error) when a config declares more than two people, matching
  this codebase's "refuse rather than silently degrade" convention. The
  comment now points at that guard instead of describing a failure mode the
  code never actually produced.
- Gridline `value: axisMax * fraction` could be a fractional cent (`axisMax`
  of 1 or 5 — `niceMax`'s two odd steps), violating "integer cents, never a
  float." Rounded now.
- The same rounding could make two gridlines collide on `key={value}` at a
  small `axisMax` (verified: `axisMax=1` rounds both the 50%/100% ticks to
  the same cent). Keyed by `fraction` instead, unique by construction.

All three threads replied-to and resolved on the PR.

## Simplify: shared `.data-table` CSS (post-merge follow-up, in 3fd6b15)

Found while reviewing 4c/4d against this PR: `table.income` here,
`table.checks` (4c), and `table.year` (4d) each carried an identical
~20-line block (width, border-collapse, font-size, header styling, cell
padding/borders, amount-column alignment) copy-pasted three times. Pulled
the common rules into `.data-table`, applied alongside each table's own
class for its column-specific styling. `table.income` kept its one real
difference (`vertical-align: baseline`) as its own rule.

## Verification

```bash
npm run check
SLUICE_CONFIG_DIR=~/sluice-private npm run dev
```

Then the Browser tool against the real household data already in
`~/sluice-private/sluice.toml` (from the manual step-3 validation) — light
and dark. With `observability`'s stack up, confirming the three spans
actually land in Tempo/Phoenix under `service.name=sluice`, not just that
the request didn't throw; with it down, confirming the page still renders at
normal speed.

## Found by CI

`next build` tries to statically prerender `/` by default, executing the
page once at build time — where `SLUICE_CONFIG_DIR` and the exports folder
don't exist. That failed the build for the wrong reason (a missing env var)
while quietly implying the opposite of what `next.config.ts` already
promises: every run re-reads its inputs because a stale render is worse
than a slow one. A build-time snapshot would be exactly that. Fixed with
`export const dynamic = 'force-dynamic'`; verified locally that `next build`
now succeeds with the env var unset entirely, and the route table shows `/`
as `ƒ Dynamic` rather than `○ Static`.

## Deliberately not in this step

- Sections 02–04 — 4b, 4c, 4d, stacked after this merges.
- Triggering the envelope generator from the page — stays a manual script.
- Automated UI tests (component tests, E2E) — named as a gap, revisit if
  `M2 dog-fed` argues for it.
- A browser-confirmed "report displayed" event — the server-side signal
  ships now; the stronger one is a contained follow-up.
- Loading states / streaming — local file reads are fast enough not to need it yet.




