### PR TITLE
MVP step 4b · section 02, the spend trend and per-envelope pace meters

### DIFF
--- a/app/_components/ConsumptionSection.tsx
+++ b/app/_components/ConsumptionSection.tsx
@@ -15,7 +15,7 @@ export function ConsumptionSection({ plan, timeline }: ConsumptionSectionProps) 
       <h2>02 · What we spent</h2>
       <p className="deck">Total spend by month, against its own average, and every configured envelope's pace.</p>
 
-      <SpendTrendChart months={timeline} />
+      <SpendTrendChart months={timeline} referenceDay={plan.referenceDay} />
       <EnvelopeMeters consumption={plan.consumption} />
     </section>
   );

--- a/app/_components/ConsumptionSection.tsx
+++ b/app/_components/ConsumptionSection.tsx
@@ -1,0 +1,22 @@
+import type { Plan } from '@/numbers/plan.ts';
+import type { MonthlySpend } from '@/numbers/timeline.ts';
+import { SpendTrendChart } from './SpendTrendChart.tsx';
+import { EnvelopeMeters } from './EnvelopeMeters.tsx';
+
+export interface ConsumptionSectionProps {
+  readonly plan: Plan;
+  /** `monthlySpendTimeline(ledger)` — computed separately from `Plan`: it has no `referenceDay` bound. */
+  readonly timeline: readonly MonthlySpend[];
+}
+
+export function ConsumptionSection({ plan, timeline }: ConsumptionSectionProps) {
+  return (
+    <section className="card">
+      <h2>02 · What we spent</h2>
+      <p className="deck">Total spend by month, against its own average, and every configured envelope's pace.</p>
+
+      <SpendTrendChart months={timeline} />
+      <EnvelopeMeters consumption={plan.consumption} />
+    </section>
+  );
+}

--- a/app/_components/ContributionsChart.tsx
+++ b/app/_components/ContributionsChart.tsx
@@ -2,6 +2,7 @@ import { formatMonthShort, monthOf, type Day } from '@/core/dates.ts';
 import { formatEur, formatEurCompact, type Cents } from '@/core/money.ts';
 import type { Person } from '@/config/load.ts';
 import type { MonthlyContributions } from '@/numbers/funding.ts';
+import { niceMax } from '../_lib/chart.ts';
 import { Legend } from './Legend.tsx';
 
 export interface ContributionsChartProps {
@@ -23,6 +24,7 @@ const BAR_GAP = 16;
 const CHART_HEIGHT = 140;
 const SEGMENT_GAP = 2; // the surface gap between stacked segments, per the dataviz skill
 const AXIS_ROOM = 26; // below the baseline, for the month label
+const TOP_ROOM = 14; // above the 100% gridline, so its label isn't clipped by the viewBox
 const LEFT_AXIS_WIDTH = 56; // for the Y-axis tick labels
 
 interface Segment {
@@ -56,15 +58,6 @@ function roundedTopRectPath(x: number, y: number, width: number, height: number,
   ].join(' ');
 }
 
-/** Rounds up to a "clean" step (1, 2, or 5 × a power of ten) for a Y-axis tick, the same rule the dataviz skill asks for. */
-function niceMax(value: number): number {
-  if (value <= 0) return 1;
-  const magnitude = 10 ** Math.floor(Math.log10(value));
-  const steps = [1, 2, 5, 10];
-  const step = steps.find((s) => s * magnitude >= value) ?? 10;
-  return step * magnitude;
-}
-
 export function ContributionsChart({ months, people, referenceDay }: ContributionsChartProps) {
   if (months.length === 0) {
     return <p className="chart-empty">No contributions recorded yet.</p>;
@@ -79,8 +72,8 @@ export function ContributionsChart({ months, people, referenceDay }: Contributio
   const currentMonth = monthOf(referenceDay);
   const chartWidth = months.length * (BAR_WIDTH + BAR_GAP) + BAR_GAP;
   const width = LEFT_AXIS_WIDTH + chartWidth;
-  const svgHeight = CHART_HEIGHT + AXIS_ROOM;
-  const baseline = CHART_HEIGHT;
+  const svgHeight = TOP_ROOM + CHART_HEIGHT + AXIS_ROOM;
+  const baseline = TOP_ROOM + CHART_HEIGHT;
 
   // Never a number on every point (the dataviz skill's own rule) — with up
   // to 18+ months of real bars, a total label on each one collides with its

--- a/app/_components/EnvelopeMeters.tsx
+++ b/app/_components/EnvelopeMeters.tsx
@@ -1,0 +1,89 @@
+import { formatEur, type Cents } from '@/core/money.ts';
+import type { EnvelopeConsumption } from '@/numbers/consumption.ts';
+
+export interface EnvelopeMetersProps {
+  readonly consumption: readonly EnvelopeConsumption[];
+}
+
+interface MeterRow {
+  readonly id: string;
+  readonly name: string;
+  readonly spent: Cents;
+  readonly estimate: Cents;
+  readonly paceExpected: Cents;
+}
+
+/**
+ * How far over its own expected-by-now pace this envelope is, as a ratio —
+ * the sort key, not a rendered figure. An envelope whose season hasn't
+ * started yet has `paceExpected === 0`; any spending against it at all is
+ * as over-pace as an envelope can get, so it sorts ahead of every real
+ * ratio rather than dividing by zero.
+ */
+function paceRatio(row: MeterRow): number {
+  if (row.paceExpected > 0) return row.spent / row.paceExpected;
+  return row.spent > 0 ? Number.POSITIVE_INFINITY : 0;
+}
+
+/**
+ * Only configured envelopes have an estimate to meter against — a derived
+ * envelope has nowhere to put a track. Sorted worst-pace-first, so the
+ * highest-signal envelope is the first thing seen, not alphabetical.
+ */
+function toRows(consumption: readonly EnvelopeConsumption[]): readonly MeterRow[] {
+  const rows: MeterRow[] = [];
+  for (const c of consumption) {
+    if (c.envelope.kind !== 'configured') continue;
+    rows.push({
+      id: c.envelope.config.id,
+      name: c.envelope.config.name,
+      spent: c.yearToDateSpent,
+      estimate: c.envelope.config.estimate,
+      paceExpected: c.paceExpected,
+    });
+  }
+  return [...rows].sort((a, b) => paceRatio(b) - paceRatio(a));
+}
+
+/**
+ * A single ratio against a limit, per envelope — the dataviz skill's own
+ * "meter" row. Spend is the fill, the estimate is the track, and the
+ * seasonally-paced expectation is an overlaid tick: where spending *should*
+ * be by now, not a flat one-twelfth-per-month line. Native `title` carries
+ * the exact figures — this is a plain HTML meter, not an SVG chart, so the
+ * browser's own tooltip is the cheap baseline rather than a `<title>` mark.
+ */
+export function EnvelopeMeters({ consumption }: EnvelopeMetersProps) {
+  const rows = toRows(consumption);
+  if (rows.length === 0) {
+    return <p className="chart-empty">No configured envelopes yet.</p>;
+  }
+
+  return (
+    <div className="meters">
+      {rows.map((row) => {
+        const fillPct = row.estimate > 0 ? Math.min(100, (row.spent / row.estimate) * 100) : row.spent > 0 ? 100 : 0;
+        const pacePct = row.estimate > 0 ? Math.min(100, (row.paceExpected / row.estimate) * 100) : 0;
+        const overflow = row.spent > row.estimate;
+        const title = `${row.name}: ${formatEur(row.spent)} spent of ${formatEur(row.estimate)} estimated — expected ${formatEur(row.paceExpected)} by now`;
+        return (
+          <div className="meter-row" key={row.id} title={title}>
+            <div className="meter-label">
+              <span className="meter-name">{row.name}</span>
+              <span className="meter-figures num">
+                {formatEur(row.spent)} / {formatEur(row.estimate)}
+              </span>
+            </div>
+            <div className="meter-track">
+              <div
+                className={overflow ? 'meter-fill meter-fill-over' : 'meter-fill'}
+                style={{ width: `${fillPct}%` }}
+              />
+              <div className="meter-pace-tick" style={{ left: `${pacePct}%` }} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/_components/EnvelopeMeters.tsx
+++ b/app/_components/EnvelopeMeters.tsx
@@ -74,7 +74,15 @@ export function EnvelopeMeters({ consumption }: EnvelopeMetersProps) {
                 {formatEur(row.spent)} / {formatEur(row.estimate)}
               </span>
             </div>
-            <div className="meter-track">
+            <div
+              className="meter-track"
+              role="meter"
+              aria-label={row.name}
+              aria-valuenow={row.spent}
+              aria-valuemin={0}
+              aria-valuemax={Math.max(row.estimate, row.spent)}
+              aria-valuetext={`${formatEur(row.spent)} spent of ${formatEur(row.estimate)} estimated`}
+            >
               <div
                 className={overflow ? 'meter-fill meter-fill-over' : 'meter-fill'}
                 style={{ width: `${fillPct}%` }}

--- a/app/_components/SpendTrendChart.tsx
+++ b/app/_components/SpendTrendChart.tsx
@@ -57,9 +57,16 @@ export function SpendTrendChart({ months, referenceDay }: SpendTrendChartProps) 
   // Same "never a number on every point" rule as ContributionsChart: two
   // gridlines carry the scale, the exact figure per month lives in the
   // native tooltip.
+  //
+  // `value` rounded to a whole cent, keyed by `fraction` not `value` — same
+  // fix as ContributionsChart's own gridlines: `axisMax * fraction` is only
+  // fractional at a very small `axisMax` (1 or 5), but at that size the
+  // rounded 50%/100% values can collide, and `fraction` (0.5, 1) stays
+  // unique where the rounded value doesn't.
   const gridlines = [0.5, 1].map((fraction) => ({
+    fraction,
     y: baseline - CHART_HEIGHT * fraction,
-    value: axisMax * fraction,
+    value: Math.round(axisMax * fraction),
   }));
 
   const points = months.map((month, i) => ({ x: xFor(i), y: yFor(month.total), month }));
@@ -76,8 +83,8 @@ export function SpendTrendChart({ months, referenceDay }: SpendTrendChartProps) 
         role="img"
         aria-label="Total spend by month, against its own average"
       >
-        {gridlines.map(({ y, value }) => (
-          <g key={value}>
+        {gridlines.map(({ fraction, y, value }) => (
+          <g key={fraction}>
             <line className="grid-line" x1={LEFT_AXIS_WIDTH} y1={y} x2={width} y2={y} />
             <text className="axis-tick-label" x={LEFT_AXIS_WIDTH - 8} y={y} textAnchor="end" dominantBaseline="middle">
               {formatEurCompact(value)}

--- a/app/_components/SpendTrendChart.tsx
+++ b/app/_components/SpendTrendChart.tsx
@@ -1,0 +1,106 @@
+import { formatMonthShort, formatMonthLong } from '@/core/dates.ts';
+import { formatEur, formatEurCompact, sum, type Cents } from '@/core/money.ts';
+import type { MonthlySpend } from '@/numbers/timeline.ts';
+import { niceMax } from '../_lib/chart.ts';
+
+export interface SpendTrendChartProps {
+  /** `monthlySpendTimeline(ledger)` — every month the ledger has, ascending. */
+  readonly months: readonly MonthlySpend[];
+}
+
+const CHART_HEIGHT = 140;
+const AXIS_ROOM = 26;
+const TOP_ROOM = 14; // above the 100% gridline, so its label isn't clipped by the viewBox
+const LEFT_AXIS_WIDTH = 56;
+const POINT_GAP = 34;
+const MARKER_R = 4;
+
+/**
+ * Total household spend, one line across the whole ledger, against its own
+ * mean — trend over time against a single reference value, the line-chart
+ * row of the dataviz skill's form table. A single series needs no legend
+ * box; the chart's own `aria-label` and the caption below it carry identity
+ * instead. The average figure is a plain HTML caption rather than inline
+ * SVG text next to the dashed line: an in-chart label anchored to the
+ * line's own y-position collides with whichever data point happens to sit
+ * near the mean, at any number of months — a fixed caption never does.
+ */
+export function SpendTrendChart({ months }: SpendTrendChartProps) {
+  if (months.length === 0) {
+    return <p className="chart-empty">No spending recorded yet.</p>;
+  }
+
+  const mean = Math.round(sum(months.map((m) => m.total)) / months.length);
+  const axisMax = niceMax(Math.max(...months.map((m) => m.total), mean, 1));
+  const scale = (cents: Cents): number => (cents / axisMax) * CHART_HEIGHT;
+
+  const chartWidth = months.length * POINT_GAP;
+  const width = LEFT_AXIS_WIDTH + chartWidth;
+  const svgHeight = TOP_ROOM + CHART_HEIGHT + AXIS_ROOM;
+  const baseline = TOP_ROOM + CHART_HEIGHT;
+
+  const xFor = (i: number): number => LEFT_AXIS_WIDTH + POINT_GAP / 2 + i * POINT_GAP;
+  const yFor = (cents: Cents): number => baseline - scale(cents);
+
+  // Same "never a number on every point" rule as ContributionsChart: two
+  // gridlines carry the scale, the exact figure per month lives in the
+  // native tooltip.
+  const gridlines = [0.5, 1].map((fraction) => ({
+    y: baseline - CHART_HEIGHT * fraction,
+    value: axisMax * fraction,
+  }));
+
+  const points = months.map((month, i) => ({ x: xFor(i), y: yFor(month.total), month }));
+  const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
+  const meanY = yFor(mean);
+  const lastIndex = months.length - 1;
+
+  return (
+    <div className="chart-wrap">
+      <svg
+        className="trend"
+        viewBox={`0 0 ${width} ${svgHeight}`}
+        width="100%"
+        height={svgHeight}
+        role="img"
+        aria-label="Total spend by month, against its own average"
+      >
+        {gridlines.map(({ y, value }) => (
+          <g key={value}>
+            <line className="grid-line" x1={LEFT_AXIS_WIDTH} y1={y} x2={width} y2={y} />
+            <text className="axis-tick-label" x={LEFT_AXIS_WIDTH - 8} y={y} textAnchor="end" dominantBaseline="middle">
+              {formatEurCompact(value)}
+            </text>
+          </g>
+        ))}
+        <line className="axis-line" x1={LEFT_AXIS_WIDTH} y1={baseline} x2={width} y2={baseline} />
+
+        <line className="mean-line" x1={LEFT_AXIS_WIDTH} y1={meanY} x2={width} y2={meanY}>
+          <title>{`Average ${formatEur(mean)} / month`}</title>
+        </line>
+
+        <path className="trend-line" d={linePath} fill="none" />
+
+        {points.map((p, i) => {
+          const isPartial = i === lastIndex;
+          const titleText = `${formatMonthLong(p.month.month)}${isPartial ? ' (in progress)' : ''} — ${formatEur(
+            p.month.total,
+          )}`;
+          return (
+            <g key={p.month.month} opacity={isPartial ? 0.6 : 1}>
+              <title>{titleText}</title>
+              <circle className="trend-point" cx={p.x} cy={p.y} r={MARKER_R} />
+              <text className="month-label" x={p.x} y={svgHeight - 8} textAnchor="middle">
+                {formatMonthShort(p.month.month)}
+                {isPartial ? '*' : ''}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <p className="chart-note">
+        dashed line — average {formatEurCompact(mean)} / month · * month in progress, not yet a complete data point
+      </p>
+    </div>
+  );
+}

--- a/app/_components/SpendTrendChart.tsx
+++ b/app/_components/SpendTrendChart.tsx
@@ -1,4 +1,4 @@
-import { formatMonthShort, formatMonthLong } from '@/core/dates.ts';
+import { formatMonthShort, formatMonthLong, monthOf, type Day } from '@/core/dates.ts';
 import { formatEur, formatEurCompact, sum, type Cents } from '@/core/money.ts';
 import type { MonthlySpend } from '@/numbers/timeline.ts';
 import { niceMax } from '../_lib/chart.ts';
@@ -6,6 +6,8 @@ import { niceMax } from '../_lib/chart.ts';
 export interface SpendTrendChartProps {
   /** `monthlySpendTimeline(ledger)` — every month the ledger has, ascending. */
   readonly months: readonly MonthlySpend[];
+  /** Marks the in-progress month distinctly, by actual calendar month rather than array position — same role as ContributionsChart's prop. */
+  readonly referenceDay: Day;
 }
 
 const CHART_HEIGHT = 140;
@@ -25,12 +27,22 @@ const MARKER_R = 4;
  * line's own y-position collides with whichever data point happens to sit
  * near the mean, at any number of months — a fixed caption never does.
  */
-export function SpendTrendChart({ months }: SpendTrendChartProps) {
+export function SpendTrendChart({ months, referenceDay }: SpendTrendChartProps) {
   if (months.length === 0) {
     return <p className="chart-empty">No spending recorded yet.</p>;
   }
 
-  const mean = Math.round(sum(months.map((m) => m.total)) / months.length);
+  const currentMonth = monthOf(referenceDay);
+
+  // The in-progress month reads lower than a finished one by construction —
+  // averaging it in at full weight would silently pull "average X / month"
+  // down every time this renders mid-month. Excluded from the mean, not
+  // just dimmed in the line: `completeMonths` falls back to `months` only
+  // for the degenerate case of a ledger that has nothing but its first,
+  // in-progress month.
+  const completeMonths = months.filter((m) => m.month !== currentMonth);
+  const meanSource = completeMonths.length > 0 ? completeMonths : months;
+  const mean = Math.round(sum(meanSource.map((m) => m.total)) / meanSource.length);
   const axisMax = niceMax(Math.max(...months.map((m) => m.total), mean, 1));
   const scale = (cents: Cents): number => (cents / axisMax) * CHART_HEIGHT;
 
@@ -53,7 +65,6 @@ export function SpendTrendChart({ months }: SpendTrendChartProps) {
   const points = months.map((month, i) => ({ x: xFor(i), y: yFor(month.total), month }));
   const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
   const meanY = yFor(mean);
-  const lastIndex = months.length - 1;
 
   return (
     <div className="chart-wrap">
@@ -81,8 +92,8 @@ export function SpendTrendChart({ months }: SpendTrendChartProps) {
 
         <path className="trend-line" d={linePath} fill="none" />
 
-        {points.map((p, i) => {
-          const isPartial = i === lastIndex;
+        {points.map((p) => {
+          const isPartial = p.month.month === currentMonth;
           const titleText = `${formatMonthLong(p.month.month)}${isPartial ? ' (in progress)' : ''} — ${formatEur(
             p.month.total,
           )}`;
@@ -98,9 +109,10 @@ export function SpendTrendChart({ months }: SpendTrendChartProps) {
           );
         })}
       </svg>
-      <p className="chart-note">
-        dashed line — average {formatEurCompact(mean)} / month · * month in progress, not yet a complete data point
-      </p>
+      <p className="chart-note">dashed line — average {formatEurCompact(mean)} / month</p>
+      {months.some((m) => m.month === currentMonth) && (
+        <p className="chart-note">* month in progress — not yet a complete data point</p>
+      )}
     </div>
   );
 }

--- a/app/_lib/chart.ts
+++ b/app/_lib/chart.ts
@@ -1,0 +1,12 @@
+/**
+ * Rounds up to a "clean" step (1, 2, or 5 × a power of ten) for a Y-axis
+ * tick — the dataviz skill's own rule, shared by every SVG chart under
+ * `_components/` rather than reimplemented per chart.
+ */
+export function niceMax(value: number): number {
+  if (value <= 0) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  const steps = [1, 2, 5, 10];
+  const step = steps.find((s) => s * magnitude >= value) ?? 10;
+  return step * magnitude;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -316,6 +316,95 @@ svg.contrib .month-label {
   font-size: 11px;
 }
 
+svg.trend text {
+  font-family: var(--font-sans);
+  fill: var(--ink-muted);
+}
+svg.trend .axis-line {
+  stroke: var(--axis);
+  stroke-width: 1;
+}
+svg.trend .grid-line {
+  stroke: var(--grid);
+  stroke-width: 1;
+}
+svg.trend .axis-tick-label {
+  font-family: var(--font-num);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  fill: var(--ink-muted);
+}
+svg.trend .month-label {
+  font-size: 11px;
+}
+svg.trend .trend-line {
+  stroke: var(--series-1);
+  stroke-width: 2;
+  stroke-linejoin: round;
+}
+svg.trend .trend-point {
+  fill: var(--surface-raised);
+  stroke: var(--series-1);
+  stroke-width: 2;
+}
+svg.trend .mean-line {
+  stroke: var(--ink-muted);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+}
+
+/* Envelope meters: a plain HTML ratio-against-a-limit row, not an SVG chart. */
+.meters {
+  margin-top: 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.meter-row {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.meter-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 13px;
+}
+.meter-name {
+  color: var(--ink-secondary);
+}
+.meter-figures {
+  color: var(--ink-muted);
+  font-size: 12.5px;
+}
+.meter-track {
+  position: relative;
+  height: 8px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-sunken);
+  border: 1px solid var(--border);
+  overflow: visible;
+}
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  right: auto;
+  border-radius: var(--radius-sm);
+  background: var(--series-1);
+}
+.meter-fill-over {
+  background: var(--serious);
+}
+.meter-pace-tick {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 2px;
+  background: var(--ink);
+  transform: translateX(-1px);
+}
+
 /* Error boundary */
 .error-panel {
   max-width: 880px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,8 @@
+import { monthOf, type Day } from '@/core/dates.ts';
 import { loadConfig, expandHome } from '@/config/load.ts';
 import { loadLedger, type Ledger } from '@/ingest/load.ts';
 import { computePlan, type Plan } from '@/numbers/plan.ts';
-import { monthlySpendTimeline } from '@/numbers/timeline.ts';
+import { monthlySpendTimeline, type MonthlySpend } from '@/numbers/timeline.ts';
 import { todayAsDay } from './_lib/today.ts';
 import { newTrace, emitSpan } from './_lib/telemetry.ts';
 import { InstalmentStrip } from './_components/InstalmentStrip.tsx';
@@ -27,6 +28,23 @@ function ingestAttrs(ledger: Ledger): Record<string, string | number | boolean> 
     window_edge_count: r.windowEdge,
     mismatched_count: r.mismatched,
   };
+}
+
+/**
+ * `monthlySpendTimeline` stops at the last month with a real `movement` in
+ * it, which is not necessarily the current one — bank exports lag behind
+ * today more often than not. Left alone, a household that hasn't spent yet
+ * this month would see the chart silently end last month with no sign the
+ * current one even exists. `monthlySpendTimeline` itself stays wall-clock
+ * -free (`src/numbers/` never reads it); this is the edge extending its
+ * result by exactly one point when needed, the same place `todayAsDay()`
+ * itself lives.
+ */
+function withCurrentMonth(timeline: readonly MonthlySpend[], referenceDay: Day): readonly MonthlySpend[] {
+  const currentMonth = monthOf(referenceDay);
+  const last = timeline[timeline.length - 1];
+  if (last !== undefined && last.month >= currentMonth) return timeline;
+  return [...timeline, { month: currentMonth, total: 0 }];
 }
 
 function planAttrs(plan: Plan): Record<string, string | number | boolean> {
@@ -71,7 +89,7 @@ export default async function Page() {
   const plan = computePlan(config, ledger, todayAsDay());
   emitSpan(trace, 'sluice.numbers.compute_plan', planAttrs(plan));
 
-  const timeline = monthlySpendTimeline(ledger);
+  const timeline = withCurrentMonth(monthlySpendTimeline(ledger), plan.referenceDay);
 
   emitSpan(trace, 'sluice.page.report_displayed', { reference_day: plan.referenceDay });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,12 @@
 import { loadConfig, expandHome } from '@/config/load.ts';
 import { loadLedger, type Ledger } from '@/ingest/load.ts';
 import { computePlan, type Plan } from '@/numbers/plan.ts';
+import { monthlySpendTimeline } from '@/numbers/timeline.ts';
 import { todayAsDay } from './_lib/today.ts';
 import { newTrace, emitSpan } from './_lib/telemetry.ts';
 import { InstalmentStrip } from './_components/InstalmentStrip.tsx';
 import { SplitSection } from './_components/SplitSection.tsx';
+import { ConsumptionSection } from './_components/ConsumptionSection.tsx';
 
 // Never statically prerendered: `next.config.ts`'s own comment already says
 // this app re-reads its inputs on every request because a stale render is
@@ -69,6 +71,8 @@ export default async function Page() {
   const plan = computePlan(config, ledger, todayAsDay());
   emitSpan(trace, 'sluice.numbers.compute_plan', planAttrs(plan));
 
+  const timeline = monthlySpendTimeline(ledger);
+
   emitSpan(trace, 'sluice.page.report_displayed', { reference_day: plan.referenceDay });
 
   return (
@@ -80,6 +84,7 @@ export default async function Page() {
 
       <InstalmentStrip config={config} plan={plan} />
       <SplitSection config={config} plan={plan} />
+      <ConsumptionSection plan={plan} timeline={timeline} />
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,11 +39,17 @@ function ingestAttrs(ledger: Ledger): Record<string, string | number | boolean> 
  * -free (`src/numbers/` never reads it); this is the edge extending its
  * result by exactly one point when needed, the same place `todayAsDay()`
  * itself lives.
+ *
+ * A genuinely empty timeline (no `movement` transactions at all — a fresh
+ * household) is left empty rather than extended: `SpendTrendChart`'s own
+ * "No spending recorded yet" empty state is the honest answer there, not a
+ * synthetic one-point, zero-value chart that looks like real data.
  */
 function withCurrentMonth(timeline: readonly MonthlySpend[], referenceDay: Day): readonly MonthlySpend[] {
+  if (timeline.length === 0) return timeline;
   const currentMonth = monthOf(referenceDay);
-  const last = timeline[timeline.length - 1];
-  if (last !== undefined && last.month >= currentMonth) return timeline;
+  const last = timeline[timeline.length - 1]!;
+  if (last.month >= currentMonth) return timeline;
   return [...timeline, { month: currentMonth, total: 0 }];
 }
 

--- a/src/numbers/timeline.test.ts
+++ b/src/numbers/timeline.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { monthlySpendTimeline } from './timeline.ts';
+import { ledgerOf, tx } from './__fixtures__/build.ts';
+
+describe('monthlySpendTimeline', () => {
+  it('returns nothing for a ledger with no movement transactions', () => {
+    const ledger = ledgerOf([tx({ kind: 'transfer-in', occurredOn: '2026-01-05', amount: 300000 })]);
+    expect(monthlySpendTimeline(ledger)).toEqual([]);
+  });
+
+  it('nets refunds against spending, floored at zero, per month', () => {
+    const ledger = ledgerOf([
+      tx({ id: 'a', occurredOn: '2026-01-05', amount: -10000 }),
+      tx({ id: 'b', occurredOn: '2026-01-20', amount: -5000 }),
+      // A month where a refund outweighs the spend: must read as 0, not negative.
+      tx({ id: 'c', occurredOn: '2026-02-05', amount: -2000 }),
+      tx({ id: 'd', occurredOn: '2026-02-06', amount: 3000 }),
+    ]);
+    expect(monthlySpendTimeline(ledger)).toEqual([
+      { month: '2026-01', total: 15000 },
+      { month: '2026-02', total: 0 },
+    ]);
+  });
+
+  it('fills a month with no movements at all as a zero, not a gap', () => {
+    const ledger = ledgerOf([
+      tx({ id: 'a', occurredOn: '2026-01-05', amount: -10000 }),
+      // February: nothing.
+      tx({ id: 'c', occurredOn: '2026-03-05', amount: -5000 }),
+    ]);
+    expect(monthlySpendTimeline(ledger)).toEqual([
+      { month: '2026-01', total: 10000 },
+      { month: '2026-02', total: 0 },
+      { month: '2026-03', total: 5000 },
+    ]);
+  });
+
+  it('ignores non-movement transactions entirely', () => {
+    const ledger = ledgerOf([
+      tx({ id: 'm', occurredOn: '2026-01-05', amount: -10000 }),
+      tx({ kind: 'transfer-in', id: 't', occurredOn: '2026-01-06', amount: 500000 }),
+      tx({ kind: 'settlement', id: 's', occurredOn: '2026-01-07', amount: -3000 }),
+    ]);
+    expect(monthlySpendTimeline(ledger)).toEqual([{ month: '2026-01', total: 10000 }]);
+  });
+
+  it('sorts ascending regardless of input order', () => {
+    const ledger = ledgerOf([
+      tx({ id: 'b', occurredOn: '2026-03-05', amount: -1000 }),
+      tx({ id: 'a', occurredOn: '2026-01-05', amount: -1000 }),
+    ]);
+    expect(monthlySpendTimeline(ledger).map((m) => m.month)).toEqual(['2026-01', '2026-02', '2026-03']);
+  });
+});

--- a/src/numbers/timeline.ts
+++ b/src/numbers/timeline.ts
@@ -1,0 +1,50 @@
+import type { Cents } from '../core/money.ts';
+import { monthOf, monthRange, type Month } from '../core/dates.ts';
+import type { Ledger } from '../ingest/load.ts';
+import type { Transaction } from '../ingest/ledger.ts';
+import { outflow } from './envelopes.ts';
+
+export interface MonthlySpend {
+  readonly month: Month;
+  /** Net outflow (`outflow()`) across every `movement` transaction, every envelope, that month. */
+  readonly total: Cents;
+}
+
+/**
+ * Total household spend, one figure per calendar month, across the whole
+ * ledger — unlike `computeConsumption`, this has no `referenceDay` bound:
+ * every month the ledger has a `movement` in is a historical fact, not
+ * something to cut off "so far."
+ *
+ * `monthRange` fills any month with no `movement` transactions at all in
+ * with a zero, between the first and last month seen — a real gap (the
+ * household simply spent nothing that month, or an export is missing) reads
+ * as a genuine dip on 4b's line chart rather than vanishing as a silent
+ * skip in the x-axis.
+ *
+ * The last month in the returned range is very likely partial — however far
+ * through it `referenceDay` is — and this function has no way to know that;
+ * a caller charting this must show that last point distinctly, as the
+ * step-4 plan calls out.
+ */
+export function monthlySpendTimeline(ledger: Ledger): readonly MonthlySpend[] {
+  const movements = ledger.transactions.filter((t) => t.kind === 'movement');
+  if (movements.length === 0) return [];
+
+  const byMonth = new Map<Month, Transaction[]>();
+  for (const t of movements) {
+    const month = monthOf(t.occurredOn);
+    const bucket = byMonth.get(month);
+    if (bucket === undefined) byMonth.set(month, [t]);
+    else bucket.push(t);
+  }
+
+  const months = [...byMonth.keys()].sort();
+  const first = months[0]!;
+  const last = months[months.length - 1]!;
+
+  return monthRange(first, last).map((month) => ({
+    month,
+    total: outflow(byMonth.get(month) ?? []),
+  }));
+}


### PR DESCRIPTION
## Summary

Stacked on #305 (4a). Adds section 02, "what we spent":

- `src/numbers/timeline.ts` — `monthlySpendTimeline(ledger)`: total household spend, one figure per calendar month, across the whole ledger. Hand-mutation tested (3/3 mutants killed on committed code).
- `SpendTrendChart` — a line chart of monthly spend against its own mean.
- `EnvelopeMeters` — one meter per configured envelope: spend as fill, estimate as track, seasonally-paced expectation as an overlaid tick, sorted worst-pace-first.
- `niceMax()` pulled out to a shared `app/_lib/chart.ts`, used by this chart and 4a's `ContributionsChart` (was duplicated).

## Fixed in this PR (post self-review)

A follow-up commit fixes a real bug found reviewing this branch: `SpendTrendChart` was marking whichever array entry happened to be *last* as "in progress," instead of comparing it to the actual reference day the way `ContributionsChart` already does. If bank exports ever lag behind today, that mislabels a real, complete month as partial while the true current month silently disappears from the chart. Fixed by threading `referenceDay` through, matching `ContributionsChart`'s pattern, and excluding the in-progress month from the displayed average. See the fix commit for the full writeup and a standalone reproduction of the exact failure scenario.

## Proactive fix + accessibility (same review pass)

- `SpendTrendChart`'s gridlines had the identical fractional-cent /
  duplicate-key issue Copilot later caught in `ContributionsChart` on #305
  — same pattern, copied when this chart was built. Fixed the same way:
  round to a whole cent, key by `fraction` instead of the (roundable,
  collidable) value.
- `EnvelopeMeters`' pace meters were plain divs with only a native `title`
  tooltip — a screen-reader user got the envelope name and figures but no
  indication a row was a proportional meter. Added `role="meter"` with
  `aria-valuenow`/`min`/`max` and a formatted `aria-valuetext`;
  `aria-valuemax` uses `max(estimate, spent)` so an over-budget envelope
  never reports a value outside its own range.

## Copilot review (post-merge follow-up)

One finding: `withCurrentMonth()` appended a zero-spend current month even
when the whole timeline was empty (a fresh household with no `movement`
transactions at all), producing a meaningless 1-point chart instead of
letting `SpendTrendChart`'s own "No spending recorded yet" empty state do
its job. Fixed to return the timeline unchanged when it's already empty —
verified against all three cases: empty, lagging export, up-to-date export.
Thread replied-to and resolved on the PR.

## Test plan

- [x] `npm run check` (typecheck + all `src/` tests, including new `timeline.test.ts`)
- [x] `npm run build` (force-dynamic route still correct)
- [x] Verified in browser, light + dark, against real household data (54 real envelopes)
- [x] Hand mutation-tested `timeline.ts` on committed code
- [x] Standalone repro confirming the in-progress-month fix handles a lagging-export scenario correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
