### PR TITLE
MVP step 4c · section 03, the check

### DIFF
--- a/app/_components/CheckSection.tsx
+++ b/app/_components/CheckSection.tsx
@@ -19,7 +19,13 @@ function describeWarning(warning: PlanWarning): string {
     case 'transfer-matches-two-people':
       return `Transfer "${warning.transaction.label}" (${formatEur(warning.transaction.amount)}, ${warning.transaction.occurredOn}) matches ${warning.people.map((p) => p.name).join(' and ')} at once — not credited to anyone.`;
     case 'uncategorised-rows':
-      return `${warning.count} row${warning.count === 1 ? '' : 's'} still uncategorised, totalling ${formatEur(warning.total)}.`;
+      // `warning.total` sums both uncategorised-outgoing (negative) and
+      // uncategorised-incoming (positive) rows — a real net, not a
+      // magnitude. "Totalling X" would read as "X of unfiled spend," which
+      // overstates or understates the true unfiled volume whenever both
+      // kinds are present and partly offset. "Net" says plainly that the
+      // two can cancel.
+      return `${warning.count} row${warning.count === 1 ? '' : 's'} still uncategorised — net ${formatEur(warning.total)} (outgoing and incoming both count toward this figure).`;
   }
 }
 

--- a/app/_components/CheckSection.tsx
+++ b/app/_components/CheckSection.tsx
@@ -16,6 +16,30 @@ function formatDay(day: Day): string {
   return `${dayOfMonth(day)} ${formatMonthShort(monthOf(day))} ${yearOf(day)}`;
 }
 
+/**
+ * A stable React key derived from each warning's own identifying fields —
+ * `PlanWarning` carries no single id field, and the array index isn't
+ * stable across renders where the underlying data (and so the list) can
+ * change. `matcher-matches-nothing` needs both the envelope id and the
+ * matcher itself: one envelope can have several matchers, each producing
+ * its own warning if it never fires.
+ */
+function warningKey(warning: PlanWarning): string {
+  switch (warning.kind) {
+    case 'matcher-matches-nothing': {
+      const m = warning.matcher;
+      const matcherKey = m.kind === 'category' ? m.category : `${m.category}/${m.subCategory}`;
+      return `matcher-matches-nothing:${warning.envelopeId}:${matcherKey}`;
+    }
+    case 'label-matches-nothing':
+      return `label-matches-nothing:${warning.personId}:${warning.label}`;
+    case 'transfer-matches-two-people':
+      return `transfer-matches-two-people:${warning.transaction.id}`;
+    case 'uncategorised-rows':
+      return 'uncategorised-rows';
+  }
+}
+
 function describeWarning(warning: PlanWarning): string {
   switch (warning.kind) {
     case 'matcher-matches-nothing':
@@ -78,8 +102,8 @@ export function CheckSection({ config, plan }: { readonly config: Config; readon
         <div className="findings">
           <h3>Findings</h3>
           <ul>
-            {warnings.map((w, i) => (
-              <li key={i}>{describeWarning(w)}</li>
+            {warnings.map((w) => (
+              <li key={warningKey(w)}>{describeWarning(w)}</li>
             ))}
           </ul>
         </div>

--- a/app/_components/CheckSection.tsx
+++ b/app/_components/CheckSection.tsx
@@ -1,3 +1,4 @@
+import { dayOfMonth, formatMonthShort, monthOf, yearOf, type Day } from '@/core/dates.ts';
 import { formatEur } from '@/core/money.ts';
 import type { Config, EnvelopeMatcher } from '@/config/load.ts';
 import type { Plan } from '@/numbers/plan.ts';
@@ -10,6 +11,11 @@ function describeMatcher(matcher: EnvelopeMatcher): string {
   return matcher.kind === 'category' ? `"${matcher.category}"` : `"${matcher.category} / ${matcher.subCategory}"`;
 }
 
+/** "24 Jan 2026" — every other date-like figure on the page is formatted for humans; a findings sentence shouldn't be the one place a raw ISO string shows through. */
+function formatDay(day: Day): string {
+  return `${dayOfMonth(day)} ${formatMonthShort(monthOf(day))} ${yearOf(day)}`;
+}
+
 function describeWarning(warning: PlanWarning): string {
   switch (warning.kind) {
     case 'matcher-matches-nothing':
@@ -17,7 +23,7 @@ function describeWarning(warning: PlanWarning): string {
     case 'label-matches-nothing':
       return `${warning.personId}: transfer label "${warning.label}" never matches a real inbound transfer.`;
     case 'transfer-matches-two-people':
-      return `Transfer "${warning.transaction.label}" (${formatEur(warning.transaction.amount)}, ${warning.transaction.occurredOn}) matches ${warning.people.map((p) => p.name).join(' and ')} at once — not credited to anyone.`;
+      return `Transfer "${warning.transaction.label}" (${formatEur(warning.transaction.amount)}, ${formatDay(warning.transaction.occurredOn)}) matches ${warning.people.map((p) => p.name).join(' and ')} at once — not credited to anyone.`;
     case 'uncategorised-rows':
       // `warning.total` sums both uncategorised-outgoing (negative) and
       // uncategorised-incoming (positive) rows — a real net, not a

--- a/app/_components/CheckSection.tsx
+++ b/app/_components/CheckSection.tsx
@@ -1,0 +1,77 @@
+import { formatEur } from '@/core/money.ts';
+import type { Config, EnvelopeMatcher } from '@/config/load.ts';
+import type { Plan } from '@/numbers/plan.ts';
+import type { PlanWarning } from '@/numbers/audit.ts';
+import { StatTile } from './StatTile.tsx';
+import { StatusBadge } from './StatusBadge.tsx';
+import { EnvelopeCheckTable } from './EnvelopeCheckTable.tsx';
+
+function describeMatcher(matcher: EnvelopeMatcher): string {
+  return matcher.kind === 'category' ? `"${matcher.category}"` : `"${matcher.category} / ${matcher.subCategory}"`;
+}
+
+function describeWarning(warning: PlanWarning): string {
+  switch (warning.kind) {
+    case 'matcher-matches-nothing':
+      return `Envelope "${warning.envelopeId}": the matcher for ${describeMatcher(warning.matcher)} never fires against a real transaction.`;
+    case 'label-matches-nothing':
+      return `${warning.personId}: transfer label "${warning.label}" never matches a real inbound transfer.`;
+    case 'transfer-matches-two-people':
+      return `Transfer "${warning.transaction.label}" (${formatEur(warning.transaction.amount)}, ${warning.transaction.occurredOn}) matches ${warning.people.map((p) => p.name).join(' and ')} at once — not credited to anyone.`;
+    case 'uncategorised-rows':
+      return `${warning.count} row${warning.count === 1 ? '' : 's'} still uncategorised, totalling ${formatEur(warning.total)}.`;
+  }
+}
+
+/**
+ * Plan vs. reality: drift as a signed figure (no invented good/bad
+ * threshold — the domain layer has none), envelopes past pace and their
+ * goal status as a table, buffer sufficiency as a status badge, and
+ * whatever the audit found as a plain findings list.
+ */
+export function CheckSection({ config, plan }: { readonly config: Config; readonly plan: Plan }) {
+  const { check, warnings } = plan;
+
+  return (
+    <section className="card">
+      <h2>03 · The check</h2>
+      <p className="deck">
+        The trailing year&apos;s actual spend against what&apos;s planned, and the buffer that has to absorb the
+        gap.
+      </p>
+
+      <div className="check-summary">
+        <StatTile
+          label="Drift — trailing year vs. planned"
+          value={check.drift}
+          signed
+          sub={`${formatEur(check.trailingYearActual)} actual · ${formatEur(check.plannedTotal)} planned`}
+        />
+        <div className="buffer-status">
+          <span className="stat-tile-label">Buffer</span>
+          {check.bufferSufficient ? (
+            <StatusBadge tone="good" icon="✓" label="Sufficient" />
+          ) : (
+            <StatusBadge tone="critical" icon="!" label="Insufficient" />
+          )}
+          <span className="stat-tile-sub">
+            {formatEur(config.bufferTarget)} target · worst month observed {formatEur(check.worstObservedMonth)}
+          </span>
+        </div>
+      </div>
+
+      <EnvelopeCheckTable envelopes={check.envelopes} />
+
+      {warnings.length > 0 && (
+        <div className="findings">
+          <h3>Findings</h3>
+          <ul>
+            {warnings.map((w, i) => (
+              <li key={i}>{describeWarning(w)}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/_components/EnvelopeCheckTable.tsx
+++ b/app/_components/EnvelopeCheckTable.tsx
@@ -1,17 +1,10 @@
 import { formatEur } from '@/core/money.ts';
+import { envelopeId, envelopeName } from '@/numbers/envelopes.ts';
 import type { EnvelopeCheck, GoalStatus } from '@/numbers/checks.ts';
 import { StatusBadge, type StatusTone } from './StatusBadge.tsx';
 
 export interface EnvelopeCheckTableProps {
   readonly envelopes: readonly EnvelopeCheck[];
-}
-
-function idOf(envelope: EnvelopeCheck['envelope']): string {
-  return envelope.kind === 'configured' ? envelope.config.id : envelope.id;
-}
-
-function nameOf(envelope: EnvelopeCheck['envelope']): string {
-  return envelope.kind === 'configured' ? envelope.config.name : envelope.id;
 }
 
 function goalBadge(status: GoalStatus): { readonly tone: StatusTone; readonly icon: string; readonly label: string } {
@@ -44,7 +37,7 @@ export function EnvelopeCheckTable({ envelopes }: EnvelopeCheckTableProps) {
 
   return (
     <div className="table-scroll">
-      <table className="checks">
+      <table className="data-table checks">
         <thead>
           <tr>
             <th>Envelope</th>
@@ -57,8 +50,8 @@ export function EnvelopeCheckTable({ envelopes }: EnvelopeCheckTableProps) {
           {rows.map((c) => {
             const badge = goalBadge(c.goalStatus);
             return (
-              <tr key={idOf(c.envelope)}>
-                <td>{nameOf(c.envelope)}</td>
+              <tr key={envelopeId(c.envelope)}>
+                <td>{envelopeName(c.envelope)}</td>
                 <td className={c.pastPace ? 'pace-over' : 'pace-ok'}>{c.pastPace ? 'Over' : '—'}</td>
                 <td>
                   <StatusBadge tone={badge.tone} icon={badge.icon} label={badge.label} />

--- a/app/_components/EnvelopeCheckTable.tsx
+++ b/app/_components/EnvelopeCheckTable.tsx
@@ -1,0 +1,74 @@
+import { formatEur } from '@/core/money.ts';
+import type { EnvelopeCheck, GoalStatus } from '@/numbers/checks.ts';
+import { StatusBadge, type StatusTone } from './StatusBadge.tsx';
+
+export interface EnvelopeCheckTableProps {
+  readonly envelopes: readonly EnvelopeCheck[];
+}
+
+function idOf(envelope: EnvelopeCheck['envelope']): string {
+  return envelope.kind === 'configured' ? envelope.config.id : envelope.id;
+}
+
+function nameOf(envelope: EnvelopeCheck['envelope']): string {
+  return envelope.kind === 'configured' ? envelope.config.name : envelope.id;
+}
+
+function goalBadge(status: GoalStatus): { readonly tone: StatusTone; readonly icon: string; readonly label: string } {
+  switch (status) {
+    case 'on-track':
+      return { tone: 'good', icon: '✓', label: 'On track' };
+    case 'at-risk':
+      return { tone: 'serious', icon: '!', label: 'At risk' };
+    case 'too-early':
+      return { tone: 'neutral', icon: '…', label: 'Too early' };
+    case 'no-goal':
+      return { tone: 'neutral', icon: '–', label: 'No goal' };
+  }
+}
+
+/** At-risk first, then merely over pace, then everyone else — the same "highest-signal row first" rule 02's meters already use. */
+function rank(c: EnvelopeCheck): number {
+  if (c.goalStatus === 'at-risk') return 0;
+  if (c.pastPace) return 1;
+  return 2;
+}
+
+/**
+ * `> ~7 classes` → table, per the dataviz skill's own form heuristic — a
+ * real household clears that with room to spare (54 envelopes, one real
+ * test run so far).
+ */
+export function EnvelopeCheckTable({ envelopes }: EnvelopeCheckTableProps) {
+  const rows = [...envelopes].sort((a, b) => rank(a) - rank(b));
+
+  return (
+    <div className="table-scroll">
+      <table className="checks">
+        <thead>
+          <tr>
+            <th>Envelope</th>
+            <th>Pace</th>
+            <th>Goal</th>
+            <th className="amount">Projected</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((c) => {
+            const badge = goalBadge(c.goalStatus);
+            return (
+              <tr key={idOf(c.envelope)}>
+                <td>{nameOf(c.envelope)}</td>
+                <td className={c.pastPace ? 'pace-over' : 'pace-ok'}>{c.pastPace ? 'Over' : '—'}</td>
+                <td>
+                  <StatusBadge tone={badge.tone} icon={badge.icon} label={badge.label} />
+                </td>
+                <td className="amount num">{c.projectedFullYear !== null ? formatEur(c.projectedFullYear) : '—'}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/_components/StatTile.tsx
+++ b/app/_components/StatTile.tsx
@@ -23,8 +23,20 @@ export interface StatTileProps {
   readonly signed?: boolean;
 }
 
+/**
+ * Prefixes `+` unless `formatEurSigned` already put a `-` in front, or the
+ * value is exactly zero (zero has no direction to mark). Checking the
+ * formatted string rather than `value > 0` — a numeric comparison would
+ * also need its own zero special-case, and gets it wrong for a `-0`, which
+ * compares equal to `0` but Intl can still render as negative.
+ */
+function formatSigned(value: Cents): string {
+  const formatted = formatEurSigned(value);
+  return value === 0 || formatted.startsWith('-') ? formatted : `+${formatted}`;
+}
+
 export function StatTile({ label, value, seriesColor, sub, signed }: StatTileProps) {
-  const text = signed === true ? (value > 0 ? `+${formatEurSigned(value)}` : formatEurSigned(value)) : formatEur(value);
+  const text = signed === true ? formatSigned(value) : formatEur(value);
   return (
     <div className="stat-tile">
       <span className="stat-tile-label">

--- a/app/_components/StatTile.tsx
+++ b/app/_components/StatTile.tsx
@@ -1,4 +1,4 @@
-import { formatEur, type Cents } from '@/core/money.ts';
+import { formatEur, formatEurSigned, type Cents } from '@/core/money.ts';
 
 /**
  * A headline number, not a column: proportional figures, not `.num`
@@ -12,16 +12,26 @@ export interface StatTileProps {
   /** A CSS colour, e.g. `'var(--series-1)'` — identity for the label, never for the value text itself. */
   readonly seriesColor?: string;
   readonly sub?: string;
+  /**
+   * Renders with an explicit sign (`+512,00 €`/`-512,00 €`) instead of
+   * accounting notation — for a figure like drift, where positive and
+   * negative are two different directions to read, not a shortfall to
+   * parenthesise. No colour is implied by the sign either way: the domain
+   * layer names no good/bad threshold for a value like this, so the tile
+   * doesn't invent one.
+   */
+  readonly signed?: boolean;
 }
 
-export function StatTile({ label, value, seriesColor, sub }: StatTileProps) {
+export function StatTile({ label, value, seriesColor, sub, signed }: StatTileProps) {
+  const text = signed === true ? (value > 0 ? `+${formatEurSigned(value)}` : formatEurSigned(value)) : formatEur(value);
   return (
     <div className="stat-tile">
       <span className="stat-tile-label">
         {seriesColor !== undefined && <span className="swatch" style={{ background: seriesColor }} />}
         {label}
       </span>
-      <span className="stat-tile-value">{formatEur(value)}</span>
+      <span className="stat-tile-value">{text}</span>
       {sub !== undefined && <span className="stat-tile-sub">{sub}</span>}
     </div>
   );

--- a/app/_components/StatusBadge.tsx
+++ b/app/_components/StatusBadge.tsx
@@ -1,0 +1,31 @@
+export type StatusTone = 'good' | 'warning' | 'serious' | 'critical' | 'neutral';
+
+export interface StatusBadgeProps {
+  readonly tone: StatusTone;
+  readonly icon: string;
+  readonly label: string;
+}
+
+const TONE_COLOR: Record<StatusTone, string> = {
+  good: 'var(--good)',
+  warning: 'var(--warning)',
+  serious: 'var(--serious)',
+  critical: 'var(--critical)',
+  neutral: 'var(--ink-muted)',
+};
+
+/**
+ * Icon + label, colour as a third channel never the only one — the
+ * dataviz skill's own rule for status. `tone` picks a reserved status
+ * token, never a categorical hue: these never mean "series 4."
+ */
+export function StatusBadge({ tone, icon, label }: StatusBadgeProps) {
+  return (
+    <span className="status-badge" style={{ color: TONE_COLOR[tone] }}>
+      <span className="status-icon" aria-hidden="true">
+        {icon}
+      </span>
+      {label}
+    </span>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -405,6 +405,88 @@ svg.trend .mean-line {
   transform: translateX(-1px);
 }
 
+/* 03 · the check */
+.check-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px;
+  margin-bottom: 24px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--border);
+}
+.buffer-status {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.status-icon {
+  font-size: 12px;
+}
+
+table.checks {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+table.checks th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--ink-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0 10px 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+table.checks td {
+  padding: 9px 10px 9px 0;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+table.checks tr:last-child td {
+  border-bottom: none;
+}
+table.checks td.amount,
+table.checks th.amount {
+  text-align: right;
+}
+table.checks .pace-over {
+  color: var(--serious);
+  font-weight: 500;
+}
+table.checks .pace-ok {
+  color: var(--ink-muted);
+}
+
+.findings {
+  margin-top: 22px;
+}
+.findings h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink-secondary);
+}
+.findings ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.findings li {
+  font-size: 13px;
+  color: var(--ink-secondary);
+}
+
 /* Error boundary */
 .error-panel {
   max-width: 880px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -431,32 +431,8 @@ svg.trend .mean-line {
   font-size: 12px;
 }
 
-table.checks {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 13.5px;
-}
-table.checks th {
-  text-align: left;
-  font-weight: 500;
-  color: var(--ink-muted);
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  padding: 0 10px 8px 0;
-  border-bottom: 1px solid var(--border);
-}
 table.checks td {
-  padding: 9px 10px 9px 0;
-  border-bottom: 1px solid var(--border);
   vertical-align: middle;
-}
-table.checks tr:last-child td {
-  border-bottom: none;
-}
-table.checks td.amount,
-table.checks th.amount {
-  text-align: right;
 }
 table.checks .pace-over {
   color: var(--serious);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { newTrace, emitSpan } from './_lib/telemetry.ts';
 import { InstalmentStrip } from './_components/InstalmentStrip.tsx';
 import { SplitSection } from './_components/SplitSection.tsx';
 import { ConsumptionSection } from './_components/ConsumptionSection.tsx';
+import { CheckSection } from './_components/CheckSection.tsx';
 
 // Never statically prerendered: `next.config.ts`'s own comment already says
 // this app re-reads its inputs on every request because a stale render is
@@ -109,6 +110,7 @@ export default async function Page() {
       <InstalmentStrip config={config} plan={plan} />
       <SplitSection config={config} plan={plan} />
       <ConsumptionSection plan={plan} timeline={timeline} />
+      <CheckSection config={config} plan={plan} />
     </main>
   );
 }

--- a/src/numbers/envelopes.test.ts
+++ b/src/numbers/envelopes.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import { envelopeFor, outflow, resolveEnvelopes, transactionsFor } from './envelopes.ts';
+import { envelopeFor, envelopeId, envelopeName, outflow, resolveEnvelopes, transactionsFor } from './envelopes.ts';
 import { ledgerOf, numbersConfig, tx } from './__fixtures__/build.ts';
+
+describe('envelopeId', () => {
+  it("is the configured envelope's own id", () => {
+    expect(envelopeId({ kind: 'configured', config: { id: 'groceries', name: 'Groceries', matches: [], estimate: 0, goal: null, seasonal: null } })).toBe('groceries');
+  });
+
+  it("is the derived envelope's category/subCategory id", () => {
+    expect(envelopeId({ kind: 'derived', id: 'Loisirs / Cinema', category: 'Loisirs', subCategory: 'Cinema' })).toBe(
+      'Loisirs / Cinema',
+    );
+  });
+});
+
+describe('envelopeName', () => {
+  it("is the configured envelope's own name, distinct from its id", () => {
+    expect(envelopeName({ kind: 'configured', config: { id: 'groceries', name: 'Groceries', matches: [], estimate: 0, goal: null, seasonal: null } })).toBe('Groceries');
+  });
+
+  it("falls back to the derived envelope's id, since it has no other name", () => {
+    expect(envelopeName({ kind: 'derived', id: 'Loisirs / Cinema', category: 'Loisirs', subCategory: 'Cinema' })).toBe(
+      'Loisirs / Cinema',
+    );
+  });
+});
 
 describe('resolveEnvelopes', () => {
   it('resolves a pair the config claims to its configured envelope, and an uncovered one to a derived envelope', () => {

--- a/src/numbers/envelopes.ts
+++ b/src/numbers/envelopes.ts
@@ -22,8 +22,26 @@ export type ResolvedEnvelope =
   | { readonly kind: 'configured'; readonly config: EnvelopeConfig }
   | { readonly kind: 'derived'; readonly id: string; readonly category: string; readonly subCategory: string };
 
-function idOf(envelope: ResolvedEnvelope): string {
+/**
+ * The id every consumer identifies this envelope by — a configured
+ * envelope's own `id`, or a derived one's `category / subCategory` pair.
+ * Exported so `app/_components/` reads an envelope's id in exactly one
+ * place, rather than reimplementing the same two-branch check per
+ * component (the same "no third copy" reasoning `funding.ts`'s `compare()`
+ * is exported for).
+ */
+export function envelopeId(envelope: ResolvedEnvelope): string {
   return envelope.kind === 'configured' ? envelope.config.id : envelope.id;
+}
+
+/**
+ * The name a reader sees — a configured envelope's own `name`, or a
+ * derived one's id, which is the only name it has (its `category /
+ * subCategory` pair, already human-readable). Exported for the same
+ * reason `envelopeId` is.
+ */
+export function envelopeName(envelope: ResolvedEnvelope): string {
+  return envelope.kind === 'configured' ? envelope.config.name : envelope.id;
 }
 
 /**
@@ -73,8 +91,8 @@ export function resolveEnvelopes(config: Config, ledger: Ledger): readonly Resol
   // agree between two machines (or two Node builds) — precisely the
   // opposite of the deterministic order this function promises.
   return [...configured, ...derived].sort((a, b) => {
-    const idA = idOf(a);
-    const idB = idOf(b);
+    const idA = envelopeId(a);
+    const idB = envelopeId(b);
     return idA < idB ? -1 : idA > idB ? 1 : 0;
   });
 }


### PR DESCRIPTION
## Summary

Stacked on #306 (4b). Adds section 03, "the check":

- Drift as a signed stat tile (no invented good/bad threshold — the domain layer has none for this figure).
- Buffer sufficiency as a status badge, icon + label, never colour alone.
- Envelopes past pace and goal status as a table, sorted worst-signal-first (at-risk, then over pace, then everyone else) — 54 real rows clears the "table, not a chart" cardinality line with room to spare.
- Findings rendered as a plain list.
- `StatTile` gets an optional `signed` prop for the drift figure — plain signed notation instead of accounting parens, since drift reads as two directions rather than a shortfall to parenthesise.
- New `StatusBadge` and `EnvelopeCheckTable` components; `CheckSection` composes them into the page.

## Fixed in this PR (post self-review)

A follow-up commit fixes the wording of the "uncategorised rows" finding: it summed both uncategorised-outgoing (negative) and uncategorised-incoming (positive) amounts and phrased the result as "totalling X€," which reads as a magnitude of unfiled spend when it's actually a net figure that can partly cancel. No data changed (`src/numbers/audit.ts`'s total is correct for what it is, and is out of scope here — already merged in step 3); only the wording that first surfaced it to a reader now says "net."

## Simplify + polish (same review pass)

- `EnvelopeCheckTable.tsx` and `EnvelopeYearTable.tsx` (4d) each carried an
  identical 4-line `idOf`/`nameOf` pair — the same "third copy" this
  codebase already names as worth avoiding (see `funding.ts`'s `compare()`).
  `envelopes.ts` already had a private `idOf` for its own sort; exported it
  as `envelopeId` and added `envelopeName` alongside it, both tested and
  mutation-tested. `EnvelopeCheckTable` switches over in this branch;
  `EnvelopeYearTable` switches over in its own PR (#308).
- `table.checks` now uses the shared `.data-table` class from #305, keeping
  only its own `vertical-align` and `.pace-over`/`.pace-ok` rules.
- The "transfer matches two people" finding showed a raw ISO date (e.g.
  "2026-01-24") — every other date-like figure on the page is formatted for
  humans. Added a small `formatDay()` built from already-exported
  `dayOfMonth`/`formatMonthShort`/`yearOf`, no new `core/dates.ts` export
  needed.

## Copilot review (post-merge follow-up)

Two findings:

- `StatTile`'s signed formatting used `value > 0` to decide whether to
  prefix a `+`, which needed its own zero special-case and didn't protect
  against a formatted "-0" (a negative-zero `Cents` value would compare
  equal to `0` numerically but `Intl` could still render it with a minus
  sign). Rewrote as `formatSigned()`: format once, then check the string's
  own sign rather than the input number's.
- `CheckSection`'s warnings list used the array index as its React key.
  `PlanWarning` carries no single id field, so added `warningKey()`,
  deriving a stable key from each variant's own identifying fields —
  `matcher-matches-nothing` needs both the envelope id and the matcher,
  since one envelope can have several matchers each producing its own
  warning.

Both threads replied-to and resolved on the PR.

## Test plan

- [x] `npm run check`
- [x] `npm run build`
- [x] Verified in browser, light + dark, against real household data (drift, buffer badge, 54-row check table, real findings all render correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
