### PR TITLE
MVP step 4d · section 04, envelopes for next year

### DIFF
--- a/app/_components/EnvelopeYearTable.tsx
+++ b/app/_components/EnvelopeYearTable.tsx
@@ -13,6 +13,12 @@ export interface EnvelopeYearTableProps {
  * only what it actually cost; a configured one with no `goal` set shows
  * `—` there too, same as `EnvelopeCheckTable`'s "no goal" case.
  *
+ * A configured envelope's own `[envelopes.<id>]` id is shown as a muted
+ * sub-line under its name — this table's whole point is rebuilding
+ * `sluice.toml` by hand, and the id (not the display name) is what a
+ * reader copies to cross-reference a generated block against. A derived
+ * envelope's name already *is* its id, so it isn't repeated.
+ *
  * A table, not a chart: `> ~7 classes` already argues for one, and a real
  * household clears that many times over (54 rows, one real test run so
  * far). Sorted the same way `plan.consumption` already is — this is a
@@ -34,7 +40,10 @@ export function EnvelopeYearTable({ consumption }: EnvelopeYearTableProps) {
         <tbody>
           {consumption.map((c) => (
             <tr key={envelopeId(c.envelope)}>
-              <td>{envelopeName(c.envelope)}</td>
+              <td>
+                {envelopeName(c.envelope)}
+                {c.envelope.kind === 'configured' && <div className="envelope-id">{c.envelope.config.id}</div>}
+              </td>
               <td className="amount num">{formatEur(c.priorYearActual)}</td>
               <td className="amount num">
                 {c.envelope.kind === 'configured' ? formatEur(c.envelope.config.estimate) : '—'}

--- a/app/_components/EnvelopeYearTable.tsx
+++ b/app/_components/EnvelopeYearTable.tsx
@@ -1,0 +1,60 @@
+import { formatEur } from '@/core/money.ts';
+import type { EnvelopeConsumption } from '@/numbers/consumption.ts';
+
+export interface EnvelopeYearTableProps {
+  readonly consumption: readonly EnvelopeConsumption[];
+}
+
+function idOf(envelope: EnvelopeConsumption['envelope']): string {
+  return envelope.kind === 'configured' ? envelope.config.id : envelope.id;
+}
+
+function nameOf(envelope: EnvelopeConsumption['envelope']): string {
+  return envelope.kind === 'configured' ? envelope.config.name : envelope.id;
+}
+
+/**
+ * Every envelope's shape from the completed prior year, alongside what's
+ * currently configured — the reference a household rebuilds next year's
+ * estimates from. A derived envelope has no estimate or goal to show,
+ * only what it actually cost; a configured one with no `goal` set shows
+ * `—` there too, same as `EnvelopeCheckTable`'s "no goal" case.
+ *
+ * A table, not a chart: `> ~7 classes` already argues for one, and a real
+ * household clears that many times over (54 rows, one real test run so
+ * far). Sorted the same way `plan.consumption` already is — this is a
+ * reference to read down, not a "which one first" ranking the way 02's
+ * meters or 03's check table are.
+ */
+export function EnvelopeYearTable({ consumption }: EnvelopeYearTableProps) {
+  return (
+    <div className="table-scroll">
+      <table className="year">
+        <thead>
+          <tr>
+            <th>Envelope</th>
+            <th className="amount">Prior year actual</th>
+            <th className="amount">Estimate</th>
+            <th className="amount">Goal</th>
+          </tr>
+        </thead>
+        <tbody>
+          {consumption.map((c) => (
+            <tr key={idOf(c.envelope)}>
+              <td>{nameOf(c.envelope)}</td>
+              <td className="amount num">{formatEur(c.priorYearActual)}</td>
+              <td className="amount num">
+                {c.envelope.kind === 'configured' ? formatEur(c.envelope.config.estimate) : '—'}
+              </td>
+              <td className="amount num">
+                {c.envelope.kind === 'configured' && c.envelope.config.goal !== null
+                  ? formatEur(c.envelope.config.goal)
+                  : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/_components/EnvelopeYearTable.tsx
+++ b/app/_components/EnvelopeYearTable.tsx
@@ -1,16 +1,9 @@
 import { formatEur } from '@/core/money.ts';
+import { envelopeId, envelopeName } from '@/numbers/envelopes.ts';
 import type { EnvelopeConsumption } from '@/numbers/consumption.ts';
 
 export interface EnvelopeYearTableProps {
   readonly consumption: readonly EnvelopeConsumption[];
-}
-
-function idOf(envelope: EnvelopeConsumption['envelope']): string {
-  return envelope.kind === 'configured' ? envelope.config.id : envelope.id;
-}
-
-function nameOf(envelope: EnvelopeConsumption['envelope']): string {
-  return envelope.kind === 'configured' ? envelope.config.name : envelope.id;
 }
 
 /**
@@ -29,7 +22,7 @@ function nameOf(envelope: EnvelopeConsumption['envelope']): string {
 export function EnvelopeYearTable({ consumption }: EnvelopeYearTableProps) {
   return (
     <div className="table-scroll">
-      <table className="year">
+      <table className="data-table year">
         <thead>
           <tr>
             <th>Envelope</th>
@@ -40,8 +33,8 @@ export function EnvelopeYearTable({ consumption }: EnvelopeYearTableProps) {
         </thead>
         <tbody>
           {consumption.map((c) => (
-            <tr key={idOf(c.envelope)}>
-              <td>{nameOf(c.envelope)}</td>
+            <tr key={envelopeId(c.envelope)}>
+              <td>{envelopeName(c.envelope)}</td>
               <td className="amount num">{formatEur(c.priorYearActual)}</td>
               <td className="amount num">
                 {c.envelope.kind === 'configured' ? formatEur(c.envelope.config.estimate) : '—'}

--- a/app/_components/NextYearSection.tsx
+++ b/app/_components/NextYearSection.tsx
@@ -1,0 +1,20 @@
+import type { Plan } from '@/numbers/plan.ts';
+import { EnvelopeYearTable } from './EnvelopeYearTable.tsx';
+
+/**
+ * The reference for rebuilding next year's plan. Deliberately read-only —
+ * `generateEnvelopeBlock` stays a script, run manually when rebuilding the
+ * year; a button here would be this stateless app's first mutation.
+ */
+export function NextYearSection({ plan }: { readonly plan: Plan }) {
+  return (
+    <section className="card">
+      <h2>04 · Envelopes for next year</h2>
+      <p className="deck">
+        Every envelope&apos;s prior-year actual against what&apos;s currently configured — the reference for
+        rebuilding the plan. Run the generator to turn the completed year into a ready-to-paste block.
+      </p>
+      <EnvelopeYearTable consumption={plan.consumption} />
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -464,6 +464,11 @@ table.checks .pace-ok {
 }
 
 /* 04 · envelopes for next year — .year has no rules of its own; .data-table covers all of it. */
+.envelope-id {
+  font-family: var(--font-num);
+  font-size: 11.5px;
+  color: var(--ink-muted);
+}
 
 /* Error boundary */
 .error-panel {

--- a/app/globals.css
+++ b/app/globals.css
@@ -463,33 +463,7 @@ table.checks .pace-ok {
   color: var(--ink-secondary);
 }
 
-/* 04 · envelopes for next year */
-table.year {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 13.5px;
-}
-table.year th {
-  text-align: left;
-  font-weight: 500;
-  color: var(--ink-muted);
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  padding: 0 10px 8px 0;
-  border-bottom: 1px solid var(--border);
-}
-table.year td {
-  padding: 9px 10px 9px 0;
-  border-bottom: 1px solid var(--border);
-}
-table.year tr:last-child td {
-  border-bottom: none;
-}
-table.year td.amount,
-table.year th.amount {
-  text-align: right;
-}
+/* 04 · envelopes for next year — .year has no rules of its own; .data-table covers all of it. */
 
 /* Error boundary */
 .error-panel {

--- a/app/globals.css
+++ b/app/globals.css
@@ -463,6 +463,34 @@ table.checks .pace-ok {
   color: var(--ink-secondary);
 }
 
+/* 04 · envelopes for next year */
+table.year {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+table.year th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--ink-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0 10px 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+table.year td {
+  padding: 9px 10px 9px 0;
+  border-bottom: 1px solid var(--border);
+}
+table.year tr:last-child td {
+  border-bottom: none;
+}
+table.year td.amount,
+table.year th.amount {
+  text-align: right;
+}
+
 /* Error boundary */
 .error-panel {
   max-width: 880px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { InstalmentStrip } from './_components/InstalmentStrip.tsx';
 import { SplitSection } from './_components/SplitSection.tsx';
 import { ConsumptionSection } from './_components/ConsumptionSection.tsx';
 import { CheckSection } from './_components/CheckSection.tsx';
+import { NextYearSection } from './_components/NextYearSection.tsx';
 
 // Never statically prerendered: `next.config.ts`'s own comment already says
 // this app re-reads its inputs on every request because a stale render is
@@ -111,6 +112,7 @@ export default async function Page() {
       <SplitSection config={config} plan={plan} />
       <ConsumptionSection plan={plan} timeline={timeline} />
       <CheckSection config={config} plan={plan} />
+      <NextYearSection plan={plan} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Stacked on #307 (4c). Adds section 04, "envelopes for next year" — the last section in the step-4 plan (#296). The page now covers all four sections plus the instalment strip.

- A read-only reference table — id, prior year's actual, this year's estimate, this year's goal — for rebuilding next year's plan by hand.
- Deliberately not wired to the generator: that stays a script, run manually; a button here would be this stateless app's first mutation.
- A table, not a chart, per the same cardinality rule 03's check table already uses.
- Sorted the same order `plan.consumption` already is: a reference to read down, not a ranking.

## Simplify + Copilot review (post-merge follow-up)

- `table.year` turned out to have zero rules of its own once compared
  side-by-side with the shared `.data-table` class (#305) — deleted the
  whole block rather than kept as an empty pass-through. Switched to the
  `envelopeId`/`envelopeName` exports added in #307, dropping this file's
  own `idOf`/`nameOf` copies — the third and last copy of that logic across
  4c/4d.
- Copilot: the PR description promised "id, prior year's actual, estimate,
  goal," but a configured envelope's row only showed its display name, not
  its `sluice.toml` id — the very thing a household needs to cross-reference
  this table against a generated `[envelopes.<id>]` block when rebuilding
  next year's plan. A derived envelope's name already *is* its id, so it
  isn't repeated. Added the id as a muted sub-line under the name. Thread
  replied-to and resolved on the PR.

## Test plan

- [x] `npm run check`
- [x] `npm run build`
- [x] Verified rendering logic against a synthetic fixture (real household config was mid-edit at review time, blocking a live check — both derived and configured envelope cases confirmed correct, same conditional pattern already proven live in section 03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
