### PR TITLE
docs: step 4 merged, SLUICE_CONFIG_DIR now required to run it

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,21 @@ v0.2 is being built in steps, each its own pull request. The first version was d
 |---|---|---|
 | 1 | **ingest** — bank exports into one reconciled ledger | merged |
 | 2 | **config** — `sluice.toml`: income, envelopes, goals, buffer | merged |
-| 3 | the numbers — the split, envelope consumption, seasonal pacing, the checks, the envelope generator | in review |
-| 4 | the page — instalment strip and four sections | next |
-| 5 | `CLAUDE.md`, written once there is code to describe | |
+| 3 | the numbers — the split, envelope consumption, seasonal pacing, the checks, the envelope generator | merged |
+| 4 | the page — instalment strip and four sections | merged |
+| 5 | `CLAUDE.md`, written once there is code to describe | next |
 
 ## Running it
 
 ```bash
 npm install
-npm run check      # typecheck and tests
-npm run dev        # the app, on localhost
+npm run check                                     # typecheck and tests
+SLUICE_CONFIG_DIR=~/sluice-private npm run dev     # the app, on localhost
 ```
 
 sluice reads two things and holds nothing: a folder of bank exports, and one configuration file. There is no database and no import step — every run re-reads the files, because a stale render of a household's money is worse than a slow one.
+
+`SLUICE_CONFIG_DIR` points at the folder holding `sluice.toml`; the page refuses to render without it, with a message saying so, rather than guessing a path.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- README's status table: step 3 and 4 were both still showing stale states ("in review" / "next") — both merged (#305–#308). Step 5 (`CLAUDE.md`) is next.
- "Running it" didn't mention `SLUICE_CONFIG_DIR`, which the page has required since #305 — `npm run dev` alone now hits the page's own "not set" error rather than rendering anything.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)