### PR TITLE
Real-data feedback: sustainable-share check, pace fix, meter redesign

### DIFF
--- a/app/_components/CheckSection.tsx
+++ b/app/_components/CheckSection.tsx
@@ -3,12 +3,28 @@ import { formatEur } from '@/core/money.ts';
 import type { Config, EnvelopeMatcher } from '@/config/load.ts';
 import type { Plan } from '@/numbers/plan.ts';
 import type { PlanWarning } from '@/numbers/audit.ts';
+import type { ShareStatus } from '@/numbers/checks.ts';
 import { StatTile } from './StatTile.tsx';
-import { StatusBadge } from './StatusBadge.tsx';
+import { StatusBadge, type StatusTone } from './StatusBadge.tsx';
 import { EnvelopeCheckTable } from './EnvelopeCheckTable.tsx';
 
 function describeMatcher(matcher: EnvelopeMatcher): string {
   return matcher.kind === 'category' ? `"${matcher.category}"` : `"${matcher.category} / ${matcher.subCategory}"`;
+}
+
+function personName(config: Config, personId: string): string {
+  return config.people.find((p) => p.id === personId)?.name ?? personId;
+}
+
+function shareBadge(status: ShareStatus): { readonly tone: StatusTone; readonly icon: string; readonly label: string } {
+  switch (status) {
+    case 'ok':
+      return { tone: 'good', icon: '✓', label: 'Sustainable' };
+    case 'high':
+      return { tone: 'warning', icon: '!', label: 'High — over 3/4 of income' };
+    case 'exceeds-income':
+      return { tone: 'critical', icon: '!', label: 'Exceeds income' };
+  }
 }
 
 /** "24 Jan 2026" — every other date-like figure on the page is formatted for humans; a findings sentence shouldn't be the one place a raw ISO string shows through. */
@@ -62,7 +78,9 @@ function describeWarning(warning: PlanWarning): string {
 /**
  * Plan vs. reality: drift as a signed figure (no invented good/bad
  * threshold — the domain layer has none), envelopes past pace and their
- * goal status as a table, buffer sufficiency as a status badge, and
+ * goal status as a table, buffer sufficiency as a status badge, each
+ * person's transfer against their own income (also a status badge — this
+ * one *does* have a domain-computed threshold, `ShareStatus`), and
  * whatever the audit found as a plain findings list.
  */
 export function CheckSection({ config, plan }: { readonly config: Config; readonly plan: Plan }) {
@@ -94,6 +112,20 @@ export function CheckSection({ config, plan }: { readonly config: Config; readon
             {formatEur(config.bufferTarget)} target · worst month observed {formatEur(check.worstObservedMonth)}
           </span>
         </div>
+        {check.people.map((p) => {
+          const badge = shareBadge(p.status);
+          return (
+            <div className="buffer-status" key={p.personId}>
+              <span className="stat-tile-label">{personName(config, p.personId)} transfer</span>
+              <StatusBadge tone={badge.tone} icon={badge.icon} label={badge.label} />
+              <span className="stat-tile-sub">
+                {p.status === 'exceeds-income'
+                  ? `${formatEur(p.amount)} transferred — ${formatEur(p.amount - p.netMonthly)} more than their ${formatEur(p.netMonthly)} net income`
+                  : `${formatEur(p.amount)} of ${formatEur(p.netMonthly)} net income`}
+              </span>
+            </div>
+          );
+        })}
       </div>
 
       <EnvelopeCheckTable envelopes={check.envelopes} />

--- a/app/_components/ContributionsChart.tsx
+++ b/app/_components/ContributionsChart.tsx
@@ -1,8 +1,9 @@
-import { formatMonthShort, monthOf, type Day } from '@/core/dates.ts';
+import { Fragment } from 'react';
+import { formatMonthLong, formatMonthShort, monthOf, type Day } from '@/core/dates.ts';
 import { formatEur, formatEurCompact, type Cents } from '@/core/money.ts';
 import type { Person } from '@/config/load.ts';
 import type { MonthlyContributions } from '@/numbers/funding.ts';
-import { niceMax } from '../_lib/chart.ts';
+import { niceMax, TOOLTIP_GAP, TOOLTIP_WIDTH, tooltipHeight } from '../_lib/chart.ts';
 import { Legend } from './Legend.tsx';
 
 export interface ContributionsChartProps {
@@ -28,11 +29,13 @@ const TOP_ROOM = 14; // above the 100% gridline, so its label isn't clipped by t
 const LEFT_AXIS_WIDTH = 56; // for the Y-axis tick labels
 
 interface Segment {
+  readonly name: string;
+  readonly amount: Cents;
   readonly height: number;
   readonly color: string;
   readonly muted: boolean;
-  readonly label: string;
 }
+
 
 /**
  * A rectangle rounded at the top two corners only, square at the bottom —
@@ -127,24 +130,26 @@ export function ContributionsChart({ months, people, referenceDay }: Contributio
             const amount = month.byPerson.get(person.id) ?? 0;
             if (amount <= 0) continue;
             segments.push({
+              name: person.name,
+              amount,
               height: scale(amount),
               color: SERIES_COLORS[idx % SERIES_COLORS.length]!,
               muted: false,
-              label: `${person.name} ${formatEur(amount)}`,
             });
           }
           if (month.unattributed > 0) {
             segments.push({
+              name: 'Unattributed',
+              amount: month.unattributed,
               height: scale(month.unattributed),
               color: '',
               muted: true,
-              label: `Unattributed ${formatEur(month.unattributed)}`,
             });
           }
 
           const titleText = `${formatMonthShort(month.month)}${isInProgress ? ' (in progress)' : ''} — ${formatEur(
             month.total,
-          )} total${segments.length > 0 ? ` (${segments.map((s) => s.label).join(', ')})` : ''}`;
+          )} total${segments.length > 0 ? ` (${segments.map((s) => `${s.name} ${formatEur(s.amount)}`).join(', ')})` : ''}`;
 
           let cursorTop = baseline;
           const rects = segments.map((seg, idx) => {
@@ -159,15 +164,56 @@ export function ContributionsChart({ months, people, referenceDay }: Contributio
               <rect key={idx} x={x} y={top} width={BAR_WIDTH} height={seg.height} fill={fill} fillOpacity={fillOpacity} />
             );
           });
+          // `cursorTop` has stepped one SEGMENT_GAP past the topmost
+          // segment's own top edge — add it back to anchor the tooltip
+          // there rather than in the gap above the bar.
+          const barTop = segments.length > 0 ? cursorTop + SEGMENT_GAP : baseline;
+
+          // One figure row per segment, plus the total note line.
+          const boxHeight = tooltipHeight(segments.length + 1);
+          const tooltipX = Math.min(
+            Math.max(x + BAR_WIDTH / 2 - TOOLTIP_WIDTH / 2, 2),
+            width - TOOLTIP_WIDTH - 2,
+          );
+          const tooltipY = barTop - TOOLTIP_GAP - boxHeight;
 
           return (
-            <g key={month.month} opacity={isInProgress ? 0.6 : 1}>
+            <g key={month.month} className="bar-group" opacity={isInProgress ? 0.6 : 1}>
               <title>{titleText}</title>
               {rects}
               <text className="month-label" x={x + BAR_WIDTH / 2} y={svgHeight - 8} textAnchor="middle">
                 {formatMonthShort(month.month)}
                 {isInProgress ? '*' : ''}
               </text>
+              <foreignObject
+                className="bar-tooltip-anchor"
+                x={tooltipX}
+                y={tooltipY}
+                width={TOOLTIP_WIDTH}
+                height={boxHeight}
+              >
+                <div className="tooltip-box">
+                  <div className="tooltip-title">
+                    {formatMonthLong(month.month)}
+                    {isInProgress ? ' (in progress)' : ''}
+                  </div>
+                  <dl className="tooltip-figures">
+                    {segments.map((seg) => (
+                      <Fragment key={seg.name}>
+                        <dt>
+                          <span
+                            className={seg.muted ? 'swatch swatch-muted' : 'swatch'}
+                            style={seg.muted ? undefined : { background: seg.color }}
+                          />
+                          {seg.name}
+                        </dt>
+                        <dd className="num">{formatEur(seg.amount)}</dd>
+                      </Fragment>
+                    ))}
+                  </dl>
+                  <p className="tooltip-note">Total {formatEur(month.total)}</p>
+                </div>
+              </foreignObject>
             </g>
           );
         })}

--- a/app/_components/EnvelopeCheckTable.tsx
+++ b/app/_components/EnvelopeCheckTable.tsx
@@ -20,10 +20,22 @@ function goalBadge(status: GoalStatus): { readonly tone: StatusTone; readonly ic
   }
 }
 
+/**
+ * A derived envelope has no estimate, so `paceExpected` is always 0 and
+ * `pastPace` reads `true` the moment it has any spending at all — a fact
+ * about the domain field (documented on `EnvelopeCheck.pastPace` in
+ * checks.ts), not a real "ahead of where it should be" signal, since there
+ * is no plan for it to be ahead of. Pace only means something for a
+ * configured envelope, which has a real estimate to pace against.
+ */
+function hasPace(c: EnvelopeCheck): boolean {
+  return c.envelope.kind === 'configured';
+}
+
 /** At-risk first, then merely over pace, then everyone else — the same "highest-signal row first" rule 02's meters already use. */
 function rank(c: EnvelopeCheck): number {
   if (c.goalStatus === 'at-risk') return 0;
-  if (c.pastPace) return 1;
+  if (hasPace(c) && c.pastPace) return 1;
   return 2;
 }
 
@@ -49,10 +61,11 @@ export function EnvelopeCheckTable({ envelopes }: EnvelopeCheckTableProps) {
         <tbody>
           {rows.map((c) => {
             const badge = goalBadge(c.goalStatus);
+            const over = hasPace(c) && c.pastPace;
             return (
               <tr key={`${c.envelope.kind}:${envelopeId(c.envelope)}`}>
                 <td>{envelopeName(c.envelope)}</td>
-                <td className={c.pastPace ? 'pace-over' : 'pace-ok'}>{c.pastPace ? 'Over' : '—'}</td>
+                <td className={over ? 'pace-over' : 'pace-ok'}>{over ? 'Over' : '—'}</td>
                 <td>
                   <StatusBadge tone={badge.tone} icon={badge.icon} label={badge.label} />
                 </td>

--- a/app/_components/EnvelopeMeters.tsx
+++ b/app/_components/EnvelopeMeters.tsx
@@ -77,9 +77,9 @@ function MeterRowView({ row }: { readonly row: MeterRow }) {
         <div className="meter-mark meter-mark-pace" style={{ left: `${pacePct}%` }} />
         {goalPct !== null && <div className="meter-mark meter-mark-goal" style={{ left: `${goalPct}%` }} />}
       </div>
-      <div className="meter-tooltip" role="tooltip">
-        <div className="meter-tooltip-title">{row.name}</div>
-        <dl className="meter-tooltip-figures">
+      <div className="tooltip-box" role="tooltip">
+        <div className="tooltip-title">{row.name}</div>
+        <dl className="tooltip-figures">
           <dt>Spent</dt>
           <dd className="num">{formatEur(row.spent)}</dd>
           <dt>Estimate</dt>
@@ -93,7 +93,7 @@ function MeterRowView({ row }: { readonly row: MeterRow }) {
             </>
           )}
         </dl>
-        <p className="meter-tooltip-note">
+        <p className="tooltip-note">
           {overEstimate
             ? `${formatEur(row.spent - row.estimate)} over the estimate (striped).`
             : `${formatEur(row.estimate - row.spent)} left in the estimate.`}

--- a/app/_components/EnvelopeMeters.tsx
+++ b/app/_components/EnvelopeMeters.tsx
@@ -11,24 +11,12 @@ interface MeterRow {
   readonly spent: Cents;
   readonly estimate: Cents;
   readonly paceExpected: Cents;
-}
-
-/**
- * How far over its own expected-by-now pace this envelope is, as a ratio —
- * the sort key, not a rendered figure. An envelope whose season hasn't
- * started yet has `paceExpected === 0`; any spending against it at all is
- * as over-pace as an envelope can get, so it sorts ahead of every real
- * ratio rather than dividing by zero.
- */
-function paceRatio(row: MeterRow): number {
-  if (row.paceExpected > 0) return row.spent / row.paceExpected;
-  return row.spent > 0 ? Number.POSITIVE_INFINITY : 0;
+  readonly goal: Cents | null;
 }
 
 /**
  * Only configured envelopes have an estimate to meter against — a derived
- * envelope has nowhere to put a track. Sorted worst-pace-first, so the
- * highest-signal envelope is the first thing seen, not alphabetical.
+ * envelope has nowhere to put a track.
  */
 function toRows(consumption: readonly EnvelopeConsumption[]): readonly MeterRow[] {
   const rows: MeterRow[] = [];
@@ -40,18 +28,98 @@ function toRows(consumption: readonly EnvelopeConsumption[]): readonly MeterRow[
       spent: c.yearToDateSpent,
       estimate: c.envelope.config.estimate,
       paceExpected: c.paceExpected,
+      goal: c.envelope.config.goal,
     });
   }
-  return [...rows].sort((a, b) => paceRatio(b) - paceRatio(a));
+  return rows;
+}
+
+function MeterRowView({ row }: { readonly row: MeterRow }) {
+  // The track's own 100% is whichever of spent/estimate/goal is largest —
+  // not a fixed "estimate = full width" the way a plain progress bar would
+  // read, because that leaves nowhere to draw the part of the bar that's
+  // actually over the estimate. Floored at 1 so an envelope with nothing
+  // set anywhere (estimate 0, nothing spent) never divides by zero.
+  const scaleMax = Math.max(row.spent, row.estimate, row.goal ?? 0, 1);
+  const spentPct = (row.spent / scaleMax) * 100;
+  const estimatePct = (row.estimate / scaleMax) * 100;
+  const pacePct = (row.paceExpected / scaleMax) * 100;
+  const goalPct = row.goal !== null ? (row.goal / scaleMax) * 100 : null;
+
+  const overEstimate = row.spent > row.estimate;
+  // Solid up to the estimate (or up to spent, if spend hasn't reached it
+  // yet); the striped segment is only ever the part beyond the estimate.
+  const basePct = Math.min(spentPct, estimatePct);
+  const overFillPct = overEstimate ? spentPct - estimatePct : 0;
+
+  return (
+    <div className={overEstimate ? 'meter-row meter-row-over' : 'meter-row meter-row-under'} tabIndex={0}>
+      <div className="meter-label">
+        <span className="meter-name">{row.name}</span>
+        <span className="meter-figures num">
+          {formatEur(row.spent)} / {formatEur(row.estimate)}
+        </span>
+      </div>
+      <div
+        className="meter-track"
+        role="meter"
+        aria-label={row.name}
+        aria-valuenow={row.spent}
+        aria-valuemin={0}
+        aria-valuemax={Math.max(row.estimate, row.spent)}
+        aria-valuetext={`${formatEur(row.spent)} spent of ${formatEur(row.estimate)} estimated`}
+      >
+        <div className="meter-fill" style={{ width: `${basePct}%` }} />
+        {overFillPct > 0 && (
+          <div className="meter-fill-over" style={{ left: `${estimatePct}%`, width: `${overFillPct}%` }} />
+        )}
+        <div className="meter-mark meter-mark-estimate" style={{ left: `${estimatePct}%` }} />
+        <div className="meter-mark meter-mark-pace" style={{ left: `${pacePct}%` }} />
+        {goalPct !== null && <div className="meter-mark meter-mark-goal" style={{ left: `${goalPct}%` }} />}
+      </div>
+      <div className="meter-tooltip" role="tooltip">
+        <div className="meter-tooltip-title">{row.name}</div>
+        <dl className="meter-tooltip-figures">
+          <dt>Spent</dt>
+          <dd className="num">{formatEur(row.spent)}</dd>
+          <dt>Estimate</dt>
+          <dd className="num">{formatEur(row.estimate)}</dd>
+          <dt>Expected by now</dt>
+          <dd className="num">{formatEur(row.paceExpected)}</dd>
+          {row.goal !== null && (
+            <>
+              <dt>Goal</dt>
+              <dd className="num">{formatEur(row.goal)}</dd>
+            </>
+          )}
+        </dl>
+        <p className="meter-tooltip-note">
+          {overEstimate
+            ? `${formatEur(row.spent - row.estimate)} over the estimate (striped).`
+            : `${formatEur(row.estimate - row.spent)} left in the estimate.`}
+        </p>
+      </div>
+    </div>
+  );
 }
 
 /**
  * A single ratio against a limit, per envelope — the dataviz skill's own
- * "meter" row. Spend is the fill, the estimate is the track, and the
- * seasonally-paced expectation is an overlaid tick: where spending *should*
- * be by now, not a flat one-twelfth-per-month line. Native `title` carries
- * the exact figures — this is a plain HTML meter, not an SVG chart, so the
- * browser's own tooltip is the cheap baseline rather than a `<title>` mark.
+ * "meter" row. The bar fills solid up to the estimate; anything spent
+ * beyond it renders as a diagonal-stripe segment rather than more solid
+ * fill, so "over" is a different texture, not just a longer bar. Three
+ * marks sit on the track: the estimate boundary itself, the seasonally
+ * -paced expectation (where spending *should* be by now, not a flat
+ * one-twelfth-per-month line), and the goal when one is set. The row's own
+ * background tints toward over/under so the state reads before the numbers
+ * do. A hover tooltip spells out every figure at once, replacing the plain
+ * `title` attribute this used to carry.
+ *
+ * Sorted by spend, biggest first — the highest-euro envelope is the first
+ * thing seen, not the worst-paced one (spend size, not pace, is what a
+ * household scanning this list cares about first). Envelopes with nothing
+ * spent yet are real but not urgent, so they collapse behind a toggle
+ * rather than pushing the list halfway down the page.
  */
 export function EnvelopeMeters({ consumption }: EnvelopeMetersProps) {
   const rows = toRows(consumption);
@@ -59,39 +127,29 @@ export function EnvelopeMeters({ consumption }: EnvelopeMetersProps) {
     return <p className="chart-empty">No configured envelopes yet.</p>;
   }
 
+  const sorted = [...rows].sort((a, b) => b.spent - a.spent);
+  const spent = sorted.filter((r) => r.spent > 0);
+  const empty = sorted.filter((r) => r.spent === 0);
+
   return (
-    <div className="meters">
-      {rows.map((row) => {
-        const fillPct = row.estimate > 0 ? Math.min(100, (row.spent / row.estimate) * 100) : row.spent > 0 ? 100 : 0;
-        const pacePct = row.estimate > 0 ? Math.min(100, (row.paceExpected / row.estimate) * 100) : 0;
-        const overflow = row.spent > row.estimate;
-        const title = `${row.name}: ${formatEur(row.spent)} spent of ${formatEur(row.estimate)} estimated — expected ${formatEur(row.paceExpected)} by now`;
-        return (
-          <div className="meter-row" key={row.id} title={title}>
-            <div className="meter-label">
-              <span className="meter-name">{row.name}</span>
-              <span className="meter-figures num">
-                {formatEur(row.spent)} / {formatEur(row.estimate)}
-              </span>
-            </div>
-            <div
-              className="meter-track"
-              role="meter"
-              aria-label={row.name}
-              aria-valuenow={row.spent}
-              aria-valuemin={0}
-              aria-valuemax={Math.max(row.estimate, row.spent)}
-              aria-valuetext={`${formatEur(row.spent)} spent of ${formatEur(row.estimate)} estimated`}
-            >
-              <div
-                className={overflow ? 'meter-fill meter-fill-over' : 'meter-fill'}
-                style={{ width: `${fillPct}%` }}
-              />
-              <div className="meter-pace-tick" style={{ left: `${pacePct}%` }} />
-            </div>
+    <div className="envelope-meters">
+      <div className="meters">
+        {spent.map((row) => (
+          <MeterRowView row={row} key={row.id} />
+        ))}
+      </div>
+      {empty.length > 0 && (
+        <details className="meters-empty">
+          <summary>
+            {empty.length} envelope{empty.length === 1 ? '' : 's'} with nothing spent yet
+          </summary>
+          <div className="meters">
+            {empty.map((row) => (
+              <MeterRowView row={row} key={row.id} />
+            ))}
           </div>
-        );
-      })}
+        </details>
+      )}
     </div>
   );
 }

--- a/app/_components/EnvelopeYearTable.tsx
+++ b/app/_components/EnvelopeYearTable.tsx
@@ -21,11 +21,13 @@ export interface EnvelopeYearTableProps {
  *
  * A table, not a chart: `> ~7 classes` already argues for one, and a real
  * household clears that many times over (54 rows, one real test run so
- * far). Sorted the same way `plan.consumption` already is — this is a
- * reference to read down, not a "which one first" ranking the way 02's
- * meters or 03's check table are.
+ * far). Sorted by prior-year actual, biggest first — the envelopes worth
+ * the most money are the ones worth checking the estimate on first when
+ * rebuilding next year's plan.
  */
 export function EnvelopeYearTable({ consumption }: EnvelopeYearTableProps) {
+  const rows = [...consumption].sort((a, b) => b.priorYearActual - a.priorYearActual);
+
   return (
     <div className="table-scroll">
       <table className="data-table year">
@@ -38,7 +40,7 @@ export function EnvelopeYearTable({ consumption }: EnvelopeYearTableProps) {
           </tr>
         </thead>
         <tbody>
-          {consumption.map((c) => (
+          {rows.map((c) => (
             <tr key={`${c.envelope.kind}:${envelopeId(c.envelope)}`}>
               <td>
                 {envelopeName(c.envelope)}

--- a/app/_components/RequirementBreakdown.tsx
+++ b/app/_components/RequirementBreakdown.tsx
@@ -1,0 +1,127 @@
+import { formatMonthLong, monthNumber, monthOf, type Day } from '@/core/dates.ts';
+import { formatEur, formatEurExplicitSign, sum, type Cents } from '@/core/money.ts';
+import type { EnvelopeConsumption } from '@/numbers/consumption.ts';
+import type { SeasonalProvenance } from '@/numbers/seasonal.ts';
+import { envelopeId, envelopeName } from '@/numbers/envelopes.ts';
+
+export interface RequirementBreakdownProps {
+  readonly consumption: readonly EnvelopeConsumption[];
+  readonly referenceDay: Day;
+  /** `plan.monthlyRequirement` — passed in rather than re-summed, so this table can never disagree with what `computeShares` actually split. */
+  readonly monthlyRequirement: Cents;
+}
+
+interface Row {
+  readonly id: string;
+  readonly name: string;
+  readonly thisMonth: Cents;
+  readonly flat: Cents;
+  readonly provenance: SeasonalProvenance;
+}
+
+function provenanceLabel(provenance: SeasonalProvenance): string {
+  switch (provenance) {
+    case 'configured':
+      return 'Configured shape';
+    case 'derived-from-history':
+      return "From last year's pattern";
+    case 'flat-no-history':
+      return 'Flat — no history yet';
+  }
+}
+
+/**
+ * Every configured envelope's contribution to *this specific month's*
+ * requirement, next to what the same estimate would ask for if it were
+ * spread flat across the year — the seasonal shape made visible, not just
+ * felt as "why is this month's total so high." A derived envelope has no
+ * estimate and so nothing to contribute here; its spending shows up in
+ * `check.drift` instead, never silently folded into this total.
+ *
+ * Sorted biggest-this-month first, same "highest-signal row first" rule
+ * 02's meters and 03's check table already use. Envelopes asking for
+ * nothing this month collapse behind a toggle — a real, correct fact for a
+ * strongly seasonal envelope (a mortgage that hasn't started yet, a
+ * holiday pot outside its season), not something to pad the table with.
+ */
+export function RequirementBreakdown({ consumption, referenceDay, monthlyRequirement }: RequirementBreakdownProps) {
+  const monthIndex = monthNumber(monthOf(referenceDay)) - 1;
+
+  const rows: Row[] = [];
+  for (const c of consumption) {
+    if (c.envelope.kind !== 'configured' || c.monthlyPlan === null || c.flatMonthlyPlan === null) continue;
+    rows.push({
+      id: envelopeId(c.envelope),
+      name: envelopeName(c.envelope),
+      thisMonth: c.monthlyPlan[monthIndex] ?? 0,
+      flat: c.flatMonthlyPlan[monthIndex] ?? 0,
+      provenance: c.seasonal.provenance,
+    });
+  }
+
+  if (rows.length === 0) {
+    return <p className="chart-empty">No configured envelopes yet.</p>;
+  }
+
+  const sorted = [...rows].sort((a, b) => b.thisMonth - a.thisMonth);
+  const active = sorted.filter((r) => r.thisMonth > 0);
+  const inactive = sorted.filter((r) => r.thisMonth === 0);
+  const flatTotal = sum(rows.map((r) => r.flat));
+  const monthLabel = formatMonthLong(monthOf(referenceDay));
+
+  const renderRows = (list: readonly Row[]) =>
+    list.map((r) => {
+      const delta = r.thisMonth - r.flat;
+      return (
+        <tr key={r.id}>
+          <td>{r.name}</td>
+          <td className="amount num">{formatEur(r.thisMonth)}</td>
+          <td className="amount num">{formatEur(r.flat)}</td>
+          <td className="amount num">{delta === 0 ? '—' : formatEurExplicitSign(delta)}</td>
+          <td className="requirement-provenance">{provenanceLabel(r.provenance)}</td>
+        </tr>
+      );
+    });
+
+  return (
+    <div className="requirement-breakdown">
+      <div className="table-scroll">
+        <table className="data-table requirement">
+          <thead>
+            <tr>
+              <th>Envelope</th>
+              <th className="amount">{monthLabel}</th>
+              <th className="amount">Flat (1/12)</th>
+              <th className="amount">Seasonal effect</th>
+              <th>Shape</th>
+            </tr>
+          </thead>
+          <tbody>
+            {renderRows(active)}
+            <tr className="requirement-total">
+              <td>Total</td>
+              <td className="amount num">{formatEur(monthlyRequirement)}</td>
+              <td className="amount num">{formatEur(flatTotal)}</td>
+              <td className="amount num">
+                {monthlyRequirement === flatTotal ? '—' : formatEurExplicitSign(monthlyRequirement - flatTotal)}
+              </td>
+              <td />
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {inactive.length > 0 && (
+        <details className="requirement-inactive">
+          <summary>
+            {inactive.length} envelope{inactive.length === 1 ? '' : 's'} asking for nothing this month
+          </summary>
+          <div className="table-scroll">
+            <table className="data-table requirement">
+              <tbody>{renderRows(inactive)}</tbody>
+            </table>
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/app/_components/SpendTrendChart.tsx
+++ b/app/_components/SpendTrendChart.tsx
@@ -1,7 +1,7 @@
 import { formatMonthShort, formatMonthLong, monthOf, type Day } from '@/core/dates.ts';
 import { formatEur, formatEurCompact, sum, type Cents } from '@/core/money.ts';
 import type { MonthlySpend } from '@/numbers/timeline.ts';
-import { niceMax } from '../_lib/chart.ts';
+import { niceMax, TOOLTIP_GAP, TOOLTIP_WIDTH, tooltipHeight } from '../_lib/chart.ts';
 
 export interface SpendTrendChartProps {
   /** `monthlySpendTimeline(ledger)` — every month the ledger has, ascending. */
@@ -104,14 +104,43 @@ export function SpendTrendChart({ months, referenceDay }: SpendTrendChartProps) 
           const titleText = `${formatMonthLong(p.month.month)}${isPartial ? ' (in progress)' : ''} — ${formatEur(
             p.month.total,
           )}`;
+
+          const delta = p.month.total - mean;
+          const deltaText =
+            delta === 0
+              ? 'Exactly average.'
+              : `${formatEur(Math.abs(delta))} ${delta > 0 ? 'above' : 'below'} average.`;
+          const boxHeight = tooltipHeight(2); // one figure row (spent) + the delta note
+          const tooltipX = Math.min(Math.max(p.x - TOOLTIP_WIDTH / 2, 2), width - TOOLTIP_WIDTH - 2);
+          const tooltipY = p.y - TOOLTIP_GAP - boxHeight;
+
           return (
-            <g key={p.month.month} opacity={isPartial ? 0.6 : 1}>
+            <g key={p.month.month} className="bar-group" opacity={isPartial ? 0.6 : 1}>
               <title>{titleText}</title>
               <circle className="trend-point" cx={p.x} cy={p.y} r={MARKER_R} />
               <text className="month-label" x={p.x} y={svgHeight - 8} textAnchor="middle">
                 {formatMonthShort(p.month.month)}
                 {isPartial ? '*' : ''}
               </text>
+              <foreignObject
+                className="bar-tooltip-anchor"
+                x={tooltipX}
+                y={tooltipY}
+                width={TOOLTIP_WIDTH}
+                height={boxHeight}
+              >
+                <div className="tooltip-box">
+                  <div className="tooltip-title">
+                    {formatMonthLong(p.month.month)}
+                    {isPartial ? ' (in progress)' : ''}
+                  </div>
+                  <dl className="tooltip-figures">
+                    <dt>Spent</dt>
+                    <dd className="num">{formatEur(p.month.total)}</dd>
+                  </dl>
+                  <p className="tooltip-note">{deltaText}</p>
+                </div>
+              </foreignObject>
             </g>
           );
         })}

--- a/app/_components/SplitSection.tsx
+++ b/app/_components/SplitSection.tsx
@@ -2,6 +2,7 @@ import { formatEur, sum } from '@/core/money.ts';
 import type { Config } from '@/config/load.ts';
 import type { Plan } from '@/numbers/plan.ts';
 import { ContributionsChart } from './ContributionsChart.tsx';
+import { RequirementBreakdown } from './RequirementBreakdown.tsx';
 
 const SERIES_COLORS = ['var(--series-1)', 'var(--series-2)'] as const;
 
@@ -63,6 +64,17 @@ export function SplitSection({ config, plan }: { readonly config: Config; readon
           </tbody>
         </table>
       </div>
+
+      <h3>Expected this month</h3>
+      <p className="deck">
+        Every configured envelope&apos;s share of this month&apos;s requirement, against what the same estimate
+        would ask for spread flat across the year — the seasonal shape that number is made of, not just the total.
+      </p>
+      <RequirementBreakdown
+        consumption={plan.consumption}
+        referenceDay={plan.referenceDay}
+        monthlyRequirement={plan.monthlyRequirement}
+      />
 
       <ContributionsChart months={plan.contributions} people={config.people} referenceDay={plan.referenceDay} />
     </section>

--- a/app/_components/StatTile.tsx
+++ b/app/_components/StatTile.tsx
@@ -1,4 +1,4 @@
-import { formatEur, formatEurSigned, type Cents } from '@/core/money.ts';
+import { formatEur, formatEurExplicitSign, type Cents } from '@/core/money.ts';
 
 /**
  * A headline number, not a column: proportional figures, not `.num`
@@ -23,20 +23,8 @@ export interface StatTileProps {
   readonly signed?: boolean;
 }
 
-/**
- * Prefixes `+` unless `formatEurSigned` already put a `-` in front, or the
- * value is exactly zero (zero has no direction to mark). Checking the
- * formatted string rather than `value > 0` — a numeric comparison would
- * also need its own zero special-case, and gets it wrong for a `-0`, which
- * compares equal to `0` but Intl can still render as negative.
- */
-function formatSigned(value: Cents): string {
-  const formatted = formatEurSigned(value);
-  return value === 0 || formatted.startsWith('-') ? formatted : `+${formatted}`;
-}
-
 export function StatTile({ label, value, seriesColor, sub, signed }: StatTileProps) {
-  const text = signed === true ? formatSigned(value) : formatEur(value);
+  const text = signed === true ? formatEurExplicitSign(value) : formatEur(value);
   return (
     <div className="stat-tile">
       <span className="stat-tile-label">

--- a/app/_lib/chart.ts
+++ b/app/_lib/chart.ts
@@ -10,3 +10,18 @@ export function niceMax(value: number): number {
   const step = steps.find((s) => s * magnitude >= value) ?? 10;
   return step * magnitude;
 }
+
+/**
+ * Layout constants for the hover tooltip every SVG chart under
+ * `_components/` draws as a `<foreignObject>` — same box, same "how much
+ * room does N lines of figures need," shared rather than re-picked per
+ * chart.
+ */
+export const TOOLTIP_WIDTH = 200;
+export const TOOLTIP_LINE_HEIGHT = 20;
+export const TOOLTIP_GAP = 10; // between the mark (bar/point) and the tooltip box
+
+/** `title` line + one row per figure + the padding `.tooltip-box` itself carries. */
+export function tooltipHeight(figureRows: number): number {
+  return 34 + figureRows * TOOLTIP_LINE_HEIGHT;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -209,6 +209,12 @@ main {
   font-size: 15px;
   font-weight: 600;
 }
+.card > h3 {
+  margin: 28px 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink-secondary);
+}
 .card > .deck {
   margin: 0 0 18px;
   font-size: 13px;
@@ -268,6 +274,33 @@ table.income .cadence {
 }
 table.income .share {
   color: var(--ink-secondary);
+}
+
+/* "Expected this month" — the seasonal requirement breakdown. */
+.requirement-provenance {
+  color: var(--ink-muted);
+  font-size: 12.5px;
+  white-space: nowrap;
+}
+.requirement-total td {
+  font-weight: 600;
+  border-top: 1px solid var(--border-strong);
+  border-bottom: none;
+}
+.requirement-inactive {
+  margin-top: 10px;
+}
+.requirement-inactive summary {
+  cursor: pointer;
+  font-size: 12.5px;
+  color: var(--ink-muted);
+  padding: 4px 0;
+}
+.requirement-inactive summary:hover {
+  color: var(--ink-secondary);
+}
+.requirement-inactive .table-scroll {
+  margin-top: 10px;
 }
 
 .chart-wrap {

--- a/app/globals.css
+++ b/app/globals.css
@@ -294,6 +294,10 @@ table.income .share {
   margin: 8px 0 0;
 }
 
+/* visible, not the SVG default hidden: bar tooltips (foreignObject) render outside the nominal viewBox */
+svg.contrib {
+  overflow: visible;
+}
 svg.contrib text {
   font-family: var(--font-sans);
   fill: var(--ink-muted);
@@ -316,6 +320,9 @@ svg.contrib .month-label {
   font-size: 11px;
 }
 
+svg.trend {
+  overflow: visible;
+}
 svg.trend text {
   font-family: var(--font-sans);
   fill: var(--ink-muted);
@@ -439,50 +446,82 @@ svg.trend .mean-line {
   top: -5px;
   bottom: -5px;
 }
-.meter-tooltip {
-  position: absolute;
-  left: 10px;
-  bottom: calc(100% + 6px);
-  min-width: 220px;
+/*
+ * Shared by every hover tooltip on the page (envelope meters, the two SVG
+ * bar/line charts) — only the positioning + show/hide trigger differs by
+ * context, set up separately below for each.
+ */
+.tooltip-box {
   background: var(--ink);
   color: var(--surface);
   padding: 10px 12px;
   border-radius: var(--radius-sm);
   font-size: 12px;
   line-height: 1.5;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
   transition: opacity 0.1s ease;
-  z-index: 20;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
 }
-.meter-row:hover .meter-tooltip,
-.meter-row:focus-within .meter-tooltip {
-  opacity: 1;
-  visibility: visible;
-}
-.meter-tooltip-title {
+.tooltip-title {
   font-weight: 600;
   margin-bottom: 6px;
 }
-.meter-tooltip-figures {
+.tooltip-figures {
   display: grid;
   grid-template-columns: auto auto;
   column-gap: 10px;
   row-gap: 2px;
   margin: 0;
 }
-.meter-tooltip-figures dt {
+.tooltip-figures dt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   color: color-mix(in srgb, var(--surface) 65%, transparent);
 }
-.meter-tooltip-figures dd {
+.tooltip-figures dd {
   margin: 0;
   text-align: right;
 }
-.meter-tooltip-note {
+.tooltip-note {
   margin: 8px 0 0;
   color: color-mix(in srgb, var(--surface) 80%, transparent);
+}
+
+/* Positioning + trigger: envelope meters (plain HTML rows). */
+.meter-row .tooltip-box {
+  position: absolute;
+  left: 10px;
+  bottom: calc(100% + 6px);
+  min-width: 220px;
+  z-index: 20;
+}
+.meter-row:hover .tooltip-box,
+.meter-row:focus-within .tooltip-box {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Positioning + trigger: SVG bar/line charts — the tooltip lives inside a
+   foreignObject already positioned in the chart's own coordinate space, so
+   it just fills the box rather than positioning itself. `overflow: visible`
+   on the anchor lets the box render outside its nominally-reserved area
+   without being clipped by the SVG's own viewBox. */
+.bar-tooltip-anchor {
+  overflow: visible;
+  pointer-events: none;
+}
+.bar-tooltip-anchor .tooltip-box {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}
+.bar-group:hover .tooltip-box,
+.bar-group:focus-within .tooltip-box {
+  opacity: 1;
+  visibility: visible;
 }
 
 .meters-empty {

--- a/app/globals.css
+++ b/app/globals.css
@@ -354,16 +354,27 @@ svg.trend .mean-line {
 }
 
 /* Envelope meters: a plain HTML ratio-against-a-limit row, not an SVG chart. */
-.meters {
+.envelope-meters {
   margin-top: 26px;
+}
+.meters {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 4px;
 }
 .meter-row {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+}
+.meter-row-over {
+  background: color-mix(in srgb, var(--serious) 7%, transparent);
+}
+.meter-row-under {
+  background: color-mix(in srgb, var(--good) 5%, transparent);
 }
 .meter-label {
   display: flex;
@@ -393,16 +404,101 @@ svg.trend .mean-line {
   border-radius: var(--radius-sm);
   background: var(--series-1);
 }
+/* The part of the bar beyond the estimate — a different texture, not just a longer solid fill. */
 .meter-fill-over {
-  background: var(--serious);
-}
-.meter-pace-tick {
   position: absolute;
-  top: -2px;
-  bottom: -2px;
+  top: 0;
+  bottom: 0;
+  background-color: color-mix(in srgb, var(--serious) 35%, transparent);
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--serious) 0,
+    var(--serious) 2px,
+    transparent 2px,
+    transparent 6px
+  );
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+.meter-mark {
+  position: absolute;
+  top: -3px;
+  bottom: -3px;
   width: 2px;
-  background: var(--ink);
   transform: translateX(-1px);
+}
+.meter-mark-estimate {
+  background: var(--ink);
+}
+.meter-mark-pace {
+  background: var(--ink-muted);
+  top: -1px;
+  bottom: -1px;
+}
+.meter-mark-goal {
+  background: var(--good);
+  top: -5px;
+  bottom: -5px;
+}
+.meter-tooltip {
+  position: absolute;
+  left: 10px;
+  bottom: calc(100% + 6px);
+  min-width: 220px;
+  background: var(--ink);
+  color: var(--surface);
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  line-height: 1.5;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.1s ease;
+  z-index: 20;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+.meter-row:hover .meter-tooltip,
+.meter-row:focus-within .meter-tooltip {
+  opacity: 1;
+  visibility: visible;
+}
+.meter-tooltip-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.meter-tooltip-figures {
+  display: grid;
+  grid-template-columns: auto auto;
+  column-gap: 10px;
+  row-gap: 2px;
+  margin: 0;
+}
+.meter-tooltip-figures dt {
+  color: color-mix(in srgb, var(--surface) 65%, transparent);
+}
+.meter-tooltip-figures dd {
+  margin: 0;
+  text-align: right;
+}
+.meter-tooltip-note {
+  margin: 8px 0 0;
+  color: color-mix(in srgb, var(--surface) 80%, transparent);
+}
+
+.meters-empty {
+  margin-top: 10px;
+}
+.meters-empty summary {
+  cursor: pointer;
+  font-size: 12.5px;
+  color: var(--ink-muted);
+  padding: 4px 0;
+}
+.meters-empty summary:hover {
+  color: var(--ink-secondary);
+}
+.meters-empty .meters {
+  margin-top: 10px;
 }
 
 /* 03 · the check */

--- a/src/core/money.test.ts
+++ b/src/core/money.test.ts
@@ -4,6 +4,7 @@ import {
   allocate,
   formatEur,
   formatEurCompact,
+  formatEurExplicitSign,
   formatEurSigned,
   parseAmount,
   sum,
@@ -236,5 +237,20 @@ describe('formatEurSigned', () => {
   it('differs from formatEur precisely in how it shows a negative', () => {
     expect(plain(formatEur(-802500))).toBe('(8 025,00 €)');
     expect(plain(formatEurSigned(-802500))).toBe('-8 025,00 €');
+  });
+});
+
+describe('formatEurExplicitSign', () => {
+  it('prefixes a positive value with +', () => {
+    expect(plain(formatEurExplicitSign(150000))).toBe('+1 500,00 €');
+  });
+
+  it('leaves a negative value with its own minus, not a double sign', () => {
+    expect(plain(formatEurExplicitSign(-150000))).toBe('-1 500,00 €');
+  });
+
+  it('renders zero unsigned — no direction to mark', () => {
+    expect(formatEurExplicitSign(0)).not.toContain('+');
+    expect(formatEurExplicitSign(0)).not.toContain('-');
   });
 });

--- a/src/core/money.ts
+++ b/src/core/money.ts
@@ -188,6 +188,22 @@ export function formatEurSigned(cents: Cents): string {
 }
 
 /**
+ * `formatEurSigned`, with an explicit "+" prefixed for a positive value —
+ * for a figure like drift or a seasonal delta, where positive and negative
+ * are two different directions to read, not a shortfall to parenthesise.
+ * Zero has no direction, so it renders unsigned, not "+0,00 €".
+ *
+ * Checks the *formatted string's* own sign rather than `cents > 0`: a
+ * numeric comparison would need the same zero special-case, and doesn't
+ * protect against a `-0` `Cents` value, which compares equal to `0` but
+ * `Intl` can still render with a minus sign.
+ */
+export function formatEurExplicitSign(cents: Cents): string {
+  const formatted = formatEurSigned(cents);
+  return cents === 0 || formatted.startsWith('-') ? formatted : `+${formatted}`;
+}
+
+/**
  * Whole euros, for chart axes where the cents are visual clutter.
  *
  * Rounded on the magnitude and the sign reapplied, rather than on the signed

--- a/src/numbers/checks.test.ts
+++ b/src/numbers/checks.test.ts
@@ -3,6 +3,7 @@ import type { Day } from '../core/dates.ts';
 import { checkPlan } from './checks.ts';
 import { resolveEnvelopes } from './envelopes.ts';
 import { computeConsumption } from './consumption.ts';
+import type { PersonShare } from './income.ts';
 import { ledgerOf, numbersConfig, tx } from './__fixtures__/build.ts';
 
 function check(configOverrides: Parameters<typeof numbersConfig>[0], transactions: Parameters<typeof tx>[0][], referenceDay: string) {
@@ -10,7 +11,7 @@ function check(configOverrides: Parameters<typeof numbersConfig>[0], transaction
   const ledger = ledgerOf(transactions.map(tx));
   const resolved = resolveEnvelopes(config, ledger);
   const consumption = computeConsumption(ledger, resolved, referenceDay as Day);
-  return checkPlan(config, ledger, consumption, referenceDay as Day);
+  return checkPlan(config, ledger, consumption, [], referenceDay as Day);
 }
 
 describe('checkPlan — goal status', () => {
@@ -136,7 +137,7 @@ describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
     ]);
     const resolved = resolveEnvelopes(config, ledger);
     const consumption = computeConsumption(ledger, resolved, '2026-02-15' as Day);
-    const result = checkPlan(config, ledger, consumption, '2026-02-15' as Day);
+    const result = checkPlan(config, ledger, consumption, [], '2026-02-15' as Day);
     // Without the floor, this would be 20000 — the smallest gain — not 0.
     expect(result.worstObservedMonth).toBe(0);
     expect(result.bufferSufficient).toBe(true);
@@ -168,7 +169,7 @@ describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
     ]);
     const resolved = resolveEnvelopes(config, ledger);
     const consumption = computeConsumption(ledger, resolved, '2026-02-15' as Day);
-    const result = checkPlan(config, ledger, consumption, '2026-02-15' as Day);
+    const result = checkPlan(config, ledger, consumption, [], '2026-02-15' as Day);
     expect(result.worstObservedMonth).toBe(-80000);
   });
 
@@ -187,7 +188,7 @@ describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
     ]);
     const resolved = resolveEnvelopes(config, ledger);
     const consumption = computeConsumption(ledger, resolved, '2026-02-15' as Day);
-    const result = checkPlan(config, ledger, consumption, '2026-02-15' as Day);
+    const result = checkPlan(config, ledger, consumption, [], '2026-02-15' as Day);
     expect(result.worstObservedMonth).toBe(-20000);
   });
 
@@ -198,7 +199,7 @@ describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
     ]);
     const resolved = resolveEnvelopes(config, ledger);
     const consumption = computeConsumption(ledger, resolved, '2026-01-25' as Day);
-    const result = checkPlan(config, ledger, consumption, '2026-01-25' as Day);
+    const result = checkPlan(config, ledger, consumption, [], '2026-01-25' as Day);
     expect(result.worstObservedMonth).toBe(-15000);
   });
 
@@ -211,6 +212,7 @@ describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
       config,
       atBoundary,
       computeConsumption(atBoundary, resolvedA, '2026-01-10' as Day),
+      [],
       '2026-01-10' as Day,
     );
     expect(resultA.worstObservedMonth).toBe(-250000);
@@ -222,8 +224,60 @@ describe('checkPlan — worstObservedMonth and bufferSufficient', () => {
       config,
       overBoundary,
       computeConsumption(overBoundary, resolvedB, '2026-01-10' as Day),
+      [],
       '2026-01-10' as Day,
     );
     expect(resultB.bufferSufficient).toBe(false);
+  });
+});
+
+describe('checkPlan — share vs income', () => {
+  function shareCheck(shares: readonly PersonShare[]) {
+    const config = numbersConfig();
+    const ledger = ledgerOf([]);
+    const resolved = resolveEnvelopes(config, ledger);
+    const consumption = computeConsumption(ledger, resolved, '2026-06-01' as Day);
+    return checkPlan(config, ledger, consumption, shares, '2026-06-01' as Day).people;
+  }
+
+  it('is ok well under three-quarters of income', () => {
+    const [p] = shareCheck([{ personId: 'alice', netMonthly: 400000, amount: 200000 }]);
+    expect(p?.status).toBe('ok');
+  });
+
+  it('is ok exactly at three-quarters — the boundary is not yet high', () => {
+    // 400000 * 3/4 = 300000 exactly.
+    const [p] = shareCheck([{ personId: 'alice', netMonthly: 400000, amount: 300000 }]);
+    expect(p?.status).toBe('ok');
+  });
+
+  it('is high one cent past three-quarters of income', () => {
+    const [p] = shareCheck([{ personId: 'alice', netMonthly: 400000, amount: 300001 }]);
+    expect(p?.status).toBe('high');
+  });
+
+  it('is still high exactly at income — not yet exceeds-income', () => {
+    const [p] = shareCheck([{ personId: 'alice', netMonthly: 400000, amount: 400000 }]);
+    expect(p?.status).toBe('high');
+  });
+
+  it('exceeds-income one cent past their own net income', () => {
+    const [p] = shareCheck([{ personId: 'alice', netMonthly: 400000, amount: 400001 }]);
+    expect(p?.status).toBe('exceeds-income');
+  });
+
+  it('carries personId, netMonthly and amount through unchanged', () => {
+    const [p] = shareCheck([{ personId: 'bruno', netMonthly: 245000, amount: 100000 }]);
+    expect(p).toEqual({ personId: 'bruno', netMonthly: 245000, amount: 100000, status: 'ok' });
+  });
+
+  it('checks every person independently, in the order shares were given', () => {
+    const people = shareCheck([
+      { personId: 'alice', netMonthly: 400000, amount: 500000 },
+      { personId: 'bruno', netMonthly: 245000, amount: 50000 },
+    ]);
+    expect(people.map((p) => p.personId)).toEqual(['alice', 'bruno']);
+    expect(people[0]?.status).toBe('exceeds-income');
+    expect(people[1]?.status).toBe('ok');
   });
 });

--- a/src/numbers/checks.ts
+++ b/src/numbers/checks.ts
@@ -4,6 +4,7 @@ import type { Config } from '../config/load.ts';
 import type { Ledger } from '../ingest/load.ts';
 import { outflow } from './envelopes.ts';
 import type { EnvelopeConsumption } from './consumption.ts';
+import type { PersonShare } from './income.ts';
 import { attributeContributions, contributionsByMonth } from './funding.ts';
 
 /**
@@ -25,6 +26,25 @@ export interface EnvelopeCheck {
   readonly projectedFullYear: Cents | null;
 }
 
+/**
+ * `ok`: a sustainable share of this person's own income.
+ * `high`: over three-quarters of it — worth a look before it gets to `exceeds-income`.
+ * `exceeds-income`: this person would transfer more than they themselves net — either
+ * wrong data (a `transfer_labels` pattern catching the wrong transfer, an income
+ * source missing from `sluice.toml`) or the plan has genuinely outgrown the
+ * household's income.
+ */
+export type ShareStatus = 'ok' | 'high' | 'exceeds-income';
+
+export interface PersonCheck {
+  readonly personId: string;
+  /** This person's own monthly-equivalent net income — `PersonShare.netMonthly`. */
+  readonly netMonthly: Cents;
+  /** What they actually transfer this month — `PersonShare.amount`. */
+  readonly amount: Cents;
+  readonly status: ShareStatus;
+}
+
 export interface PlanCheck {
   /** Sum of every configured envelope's estimate. */
   readonly plannedTotal: Cents;
@@ -40,6 +60,19 @@ export interface PlanCheck {
   readonly worstObservedMonth: Cents;
   readonly bufferSufficient: boolean;
   readonly envelopes: readonly EnvelopeCheck[];
+  readonly people: readonly PersonCheck[];
+}
+
+/**
+ * `amount * 4 > netMonthly * 3` rather than `amount > netMonthly * 0.75`:
+ * the same reason `allocate()` runs its remainder math in whole units
+ * rather than a float — a quarter-point threshold on real income figures
+ * has no business going anywhere near IEEE-754 division.
+ */
+function checkShare(share: PersonShare): PersonCheck {
+  const status: ShareStatus =
+    share.amount > share.netMonthly ? 'exceeds-income' : share.amount * 4 > share.netMonthly * 3 ? 'high' : 'ok';
+  return { personId: share.personId, netMonthly: share.netMonthly, amount: share.amount, status };
 }
 
 function checkEnvelope(c: EnvelopeConsumption): EnvelopeCheck {
@@ -91,14 +124,15 @@ function netFlowByMonth(config: Config, ledger: Ledger): ReadonlyMap<Month, Cent
 /**
  * How the plan compares to reality, as of `referenceDay`.
  *
- * `consumption` is supplied rather than recomputed, so this never disagrees
- * with what section 02 is showing at the same moment — both come from the
- * same call, in `numbers/plan.ts`.
+ * `consumption` and `shares` are supplied rather than recomputed, so this
+ * never disagrees with what sections 01 and 02 are showing at the same
+ * moment — all three come from the same call, in `numbers/plan.ts`.
  */
 export function checkPlan(
   config: Config,
   ledger: Ledger,
   consumption: readonly EnvelopeConsumption[],
+  shares: readonly PersonShare[],
   referenceDay: Day,
 ): PlanCheck {
   const plannedTotal = consumption.reduce(
@@ -127,5 +161,6 @@ export function checkPlan(
     worstObservedMonth,
     bufferSufficient: config.bufferTarget + worstObservedMonth >= 0,
     envelopes: consumption.map(checkEnvelope),
+    people: shares.map(checkShare),
   };
 }

--- a/src/numbers/consumption.test.ts
+++ b/src/numbers/consumption.test.ts
@@ -33,6 +33,8 @@ describe('computeConsumption', () => {
     // 120000 split proportionally to [10000,10000,10000,0,...]: each of the
     // first three months gets 120000*10000/30000 = 40000 exactly.
     expect(c?.monthlyPlan).toEqual([40000, 40000, 40000, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    // The same 120000 spread flat instead: 120000/12 = 10000 exactly, every month.
+    expect(c?.flatMonthlyPlan).toEqual(Array(12).fill(10000));
     // Cumulative through March (index 2): 40000 * 3 = 120000.
     expect(c?.paceExpected).toBe(120000);
     // Jan + Feb + the one March row before the 15th: 50000+50000+30000.
@@ -74,11 +76,75 @@ seasonal = { months = [7] }
 
     expect(c?.envelope.kind).toBe('derived');
     expect(c?.monthlyPlan).toBeNull();
+    expect(c?.flatMonthlyPlan).toBeNull();
     expect(c?.paceExpected).toBe(0);
     // No plan means nothing is "expected" — so any spending at all is, by
     // construction, entirely over pace.
     expect(c?.yearToDateSpent).toBe(1500);
     expect(c?.overPace).toBe(1500);
+  });
+
+  it('flatMonthlyPlan exposes a seasonal skew a mid-year-start envelope would otherwise hide', () => {
+    // A mortgage that started in June of the prior year: zero spend
+    // Jan-May, roughly equal June-December. Derived-from-history spreads
+    // this year's whole estimate across only those 7 months instead of 12
+    // — real behaviour this test pins down, the same pattern that showed
+    // up in a real household's own data.
+    const config = numbersConfig({
+      envelopes: `
+[envelopes.mortgage]
+name = "Mortgage"
+matches = [{ category = "Logement", sub_category = "Credit" }]
+estimate = "12000.00"
+`,
+    });
+    const ledger = ledgerOf(
+      ['06', '07', '08', '09', '10', '11', '12'].map((month) =>
+        tx({
+          id: `25-${month}`,
+          occurredOn: `2025-${month}-05`,
+          amount: -100000,
+          category: 'Logement',
+          subCategory: 'Credit',
+        }),
+      ),
+    );
+    const resolved = resolveEnvelopes(config, ledger);
+    const [c] = computeConsumption(ledger, resolved, '2026-08-01' as Day);
+
+    expect(c?.seasonal.provenance).toBe('derived-from-history');
+    // August is month index 7: seasonal weights are flat across Jun-Dec
+    // (all equal, 100000 each), so the estimate splits evenly across
+    // those 7 months: 1200000 / 7 = 171428.57... — allocate()'s remainder
+    // step lands the extra cents somewhere, but every one of the 7 months
+    // gets roughly this, not the flat-across-12 figure.
+    const august = c?.monthlyPlan?.[7] ?? 0;
+    const augustFlat = c?.flatMonthlyPlan?.[7] ?? 0;
+    expect(august).toBeGreaterThan(augustFlat);
+    // Flat spreads the same estimate evenly across all 12 months: exactly
+    // 1200000 / 12 = 100000.
+    expect(augustFlat).toBe(100000);
+    // The seasonal figure is close to a 7-way split of the full estimate —
+    // meaningfully larger than the 12-way flat split, not just a rounding
+    // difference.
+    expect(august).toBeGreaterThan(augustFlat * 1.5);
+  });
+
+  it('flatMonthlyPlan always sums to exactly the estimate, same guarantee monthlyPlan has', () => {
+    // 1000.00 (100000c) does not divide evenly by 12 — allocate()'s
+    // largest-remainder step must still land on the estimate exactly.
+    const config = numbersConfig({
+      envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [{ category = "Alimentation", sub_category = "Supermarche" }]
+estimate = "1000.00"
+`,
+    });
+    const resolved = resolveEnvelopes(config, ledgerOf([]));
+    const [c] = computeConsumption(ledgerOf([]), resolved, '2026-06-01' as Day);
+
+    expect(c?.flatMonthlyPlan?.reduce((a, b) => a + b, 0)).toBe(100000);
   });
 
   it('follows the same order resolveEnvelopes returns', () => {

--- a/src/numbers/consumption.ts
+++ b/src/numbers/consumption.ts
@@ -2,7 +2,7 @@ import { allocate, type Cents } from '../core/money.ts';
 import { monthNumber, monthOf, yearOf, type Day } from '../core/dates.ts';
 import type { Ledger } from '../ingest/load.ts';
 import { outflow, transactionsFor, type ResolvedEnvelope } from './envelopes.ts';
-import { resolveSeasonal, type SeasonalShape } from './seasonal.ts';
+import { resolveSeasonal, FLAT_WEIGHTS, type SeasonalShape } from './seasonal.ts';
 
 export interface EnvelopeConsumption {
   readonly envelope: ResolvedEnvelope;
@@ -16,6 +16,16 @@ export interface EnvelopeConsumption {
    * against, only a total to show.
    */
   readonly monthlyPlan: readonly Cents[] | null;
+  /**
+   * `allocate(estimate, FLAT_WEIGHTS)` — the same estimate, spread evenly
+   * across the year instead of by `seasonal.weights`. Exists purely as a
+   * baseline `monthlyPlan` is measured against: a household looking at one
+   * month's requirement has no way to tell "genuinely a heavier month" from
+   * "the seasonal shape derived from a partial year of history" without
+   * something to compare it to. `null` for a derived envelope, same as
+   * `monthlyPlan`.
+   */
+  readonly flatMonthlyPlan: readonly Cents[] | null;
   /** Cumulative `monthlyPlan` through `referenceDay`'s month, inclusive. */
   readonly paceExpected: Cents;
   /**
@@ -64,6 +74,8 @@ export function computeConsumption(
     const seasonal = resolveSeasonal(envelope, transactions, priorYear);
     const monthlyPlan =
       envelope.kind === 'configured' ? allocate(envelope.config.estimate, seasonal.weights) : null;
+    const flatMonthlyPlan =
+      envelope.kind === 'configured' ? allocate(envelope.config.estimate, FLAT_WEIGHTS) : null;
 
     const paceExpected =
       monthlyPlan === null
@@ -71,6 +83,15 @@ export function computeConsumption(
         : monthlyPlan.slice(0, referenceMonthIndex + 1).reduce((a, b) => a + b, 0);
     const overPace = Math.max(0, yearToDateSpent - paceExpected);
 
-    return { envelope, yearToDateSpent, priorYearActual, monthlyPlan, paceExpected, overPace, seasonal };
+    return {
+      envelope,
+      yearToDateSpent,
+      priorYearActual,
+      monthlyPlan,
+      flatMonthlyPlan,
+      paceExpected,
+      overPace,
+      seasonal,
+    };
   });
 }

--- a/src/numbers/plan.test.ts
+++ b/src/numbers/plan.test.ts
@@ -23,6 +23,7 @@ describe('computePlan', () => {
     const plan = computePlan(config, ledger, referenceDay);
 
     expect(plan.referenceDay).toBe(referenceDay);
+    expect(plan.monthlyRequirement).toBe(40000);
 
     // alice 3200.00, bruno 2450.00 net monthly (weight sum 565000):
     // 40000*320000/565000 = 22654.86..., 40000*245000/565000 = 17345.13...
@@ -58,9 +59,11 @@ seasonal = { months = [6] }
     const ledger = ledgerOf([]);
 
     const inJanuary = computePlan(config, ledger, '2026-01-15' as Day);
+    expect(inJanuary.monthlyRequirement).toBe(0);
     expect(sum(inJanuary.shares.map((s) => s.amount))).toBe(0);
 
     const inJune = computePlan(config, ledger, '2026-06-15' as Day);
+    expect(inJune.monthlyRequirement).toBe(120000);
     expect(sum(inJune.shares.map((s) => s.amount))).toBe(120000);
   });
 

--- a/src/numbers/plan.ts
+++ b/src/numbers/plan.ts
@@ -44,7 +44,7 @@ export function computePlan(config: Config, ledger: Ledger, referenceDay: Day): 
 
   const shares = computeShares(config.people, monthlyRequirement);
   const contributions = contributionsByMonth(attributeContributions(config, ledger));
-  const check = checkPlan(config, ledger, consumption, referenceDay);
+  const check = checkPlan(config, ledger, consumption, shares, referenceDay);
   const warnings = auditPlan(config, ledger);
 
   return { referenceDay, shares, contributions, consumption, check, warnings };

--- a/src/numbers/plan.ts
+++ b/src/numbers/plan.ts
@@ -1,4 +1,4 @@
-import { sum } from '../core/money.ts';
+import { sum, type Cents } from '../core/money.ts';
 import { monthNumber, monthOf, type Day } from '../core/dates.ts';
 import type { Config } from '../config/load.ts';
 import type { Ledger } from '../ingest/load.ts';
@@ -12,6 +12,15 @@ import { auditPlan, type PlanWarning } from './audit.ts';
 /** Everything section 01 through 03 of the page renders, computed together so none of it can disagree. */
 export interface Plan {
   readonly referenceDay: Day;
+  /**
+   * What `computeShares` splits across people — exposed directly rather
+   * than left for a caller to reconstruct by summing `shares`, even though
+   * `allocate()` guarantees that sum equals this exactly. This is the
+   * causally prior figure (a requirement, split into shares), not the
+   * other way around, and the page's own "why is this month's total what
+   * it is" breakdown reads better against the figure it was computed from.
+   */
+  readonly monthlyRequirement: Cents;
   readonly shares: readonly PersonShare[];
   readonly contributions: readonly MonthlyContributions[];
   readonly consumption: readonly EnvelopeConsumption[];
@@ -47,5 +56,5 @@ export function computePlan(config: Config, ledger: Ledger, referenceDay: Day): 
   const check = checkPlan(config, ledger, consumption, shares, referenceDay);
   const warnings = auditPlan(config, ledger);
 
-  return { referenceDay, shares, contributions, consumption, check, warnings };
+  return { referenceDay, monthlyRequirement, shares, contributions, consumption, check, warnings };
 }

--- a/src/numbers/seasonal.ts
+++ b/src/numbers/seasonal.ts
@@ -18,7 +18,14 @@ export interface SeasonalShape {
   readonly provenance: SeasonalProvenance;
 }
 
-const FLAT: SeasonalWeights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+/**
+ * Exported so `consumption.ts` can pace a *second* plan against the same
+ * estimate — what a month would need if the year were spread flat — as the
+ * baseline `monthlyPlan` (paced against whatever `resolveSeasonal` actually
+ * returns) is compared to, to make a seasonal skew visible rather than
+ * just felt.
+ */
+export const FLAT_WEIGHTS: SeasonalWeights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
 
 /**
  * The seasonal shape to pace `envelope` against.
@@ -54,5 +61,5 @@ export function resolveSeasonal(
   if (weights.some((w) => w > 0)) {
     return { weights: weights as unknown as SeasonalWeights, provenance: 'derived-from-history' };
   }
-  return { weights: FLAT, provenance: 'flat-no-history' };
+  return { weights: FLAT_WEIGHTS, provenance: 'flat-no-history' };
 }


### PR DESCRIPTION
## Summary

Feedback from actually using the page against real household data (post step-4 merge). Draft — happy to keep it that way until you've had a look.

Household figures stay out of this repo; PR description below is structure/mechanism only.

## 1. A person's transfer can now be flagged against their own income

`computeShares` splits proportionally to income and has no opinion on whether the *result* is sustainable for either person — real usage found both people transferring more than their own net income, which the app had no way to surface.

- `src/numbers/checks.ts`: new `PersonCheck`/`ShareStatus` (`ok` / `high` — over 3/4 of net income / `exceeds-income`), computed alongside the existing envelope checks in `checkPlan()`. Threshold math stays in whole cents (`amount * 4 > netMonthly * 3`), never a float.
- `CheckSection.tsx`: one status badge per person in the check summary, with the exact overage spelled out in the exceeds-income case ("X transferred — Y more than their Z net income").
- Mutation-tested (3/3 mutants killed on committed code): the `>`/`>=` boundary at both thresholds, and the multiplier constants themselves.

## 2. Fixed a misleading "Over" pace on derived envelopes

`EnvelopeCheck.pastPace` is `yearToDateSpent > paceExpected`, and a derived envelope's `paceExpected` is always 0 (documented behavior, from step 3) — so *any* spending at all reads as "Over" pace, which isn't a meaningful signal when there's no estimate to be over. Real data made this obvious: the check table was mostly "Over" rows for categories nobody has configured an envelope for.

Pace now only renders for configured envelopes (which have a real estimate to pace against); derived envelopes show "—", and the table's own worst-first ranking no longer elevates a row on a signal it can't meaningfully carry.

## 3. Envelope meters: resorted, collapsed, and redesigned

- Sorted by amount spent, biggest first (was worst-pace-first) — asked for directly; spend size is what a household scanning the list cares about first.
- Envelopes with nothing spent yet collapse behind a native `<details>` toggle instead of padding out a ~40-row list with rows that have nothing to say yet.
- The bar's own segment beyond the estimate now renders as a diagonal-stripe texture, not just more solid fill — "over" is a different texture, not a longer bar.
- Explicit marks for the estimate boundary and the goal (when set), alongside the existing seasonal-pace tick.
- The row's own background tints toward over/under (`color-mix()` off the existing `--good`/`--serious` tokens — no new tokens).
- A real hover tooltip spells out spent/estimate/expected-by-now/goal and the exact over/under amount, replacing the plain `title` attribute. CSS `:hover` + `tabIndex` for keyboard focus — no client component, no JS state.

## 4. Envelopes-for-next-year table: sorted by size

`EnvelopeYearTable` (section 04) was unsorted (id order); now sorted by prior-year actual, biggest first — the envelopes worth the most money are the ones worth checking the estimate on first.

## 5. Custom hover tooltips on both bar/line charts (sections 01 and 02)

The native `title` tooltip (OS box, ~1s hover delay, unstyled, a single concatenated string) wasn't reading as a real tooltip. Both charts now get the same custom hover tooltip built for the envelope meters above, rendered as a `foreignObject` positioned in the chart's own SVG coordinate space, shown via CSS `:hover` on the bar/point group — no client component, no JS state.

- `ContributionsChart`: one line per person plus unattributed, each with its own colour swatch matching the legend, a total line below — the actual ask was seeing the breakdown clearly separated per person, not concatenated into one string.
- `SpendTrendChart`: spent this month, plus how far above/below the average it is — the comparison the dashed mean line implies but didn't previously spell out anywhere.

Pulled the tooltip box's layout constants (`TOOLTIP_WIDTH`/`LINE_HEIGHT`/`GAP`, `tooltipHeight()`) into the shared `app/_lib/chart.ts` alongside `niceMax()` rather than a third copy of the same three numbers, and generalized the meter tooltip's CSS classes (`.meter-tooltip*` → `.tooltip-box`/`.tooltip-title`/`.tooltip-figures`/`.tooltip-note`) so all three tooltips draw from one shared visual definition. Tooltip x is clamped to the chart's own width so it doesn't overflow off either edge; `svg.contrib`/`svg.trend` get `overflow: visible` so the box (which can extend above the nominal viewBox) isn't clipped by it.

## 6. "Expected this month" breakdown (section 01)

Follow-up to #1: once the household could see they were transferring more than their own income, the next question was *why* — a specific month's requirement (~10.7k at the time) was well above their own average spend (~7.8k). Traced by hand to one envelope (a mortgage) whose seasonal shape was derived from a partial year of history (no payments before the loan started), concentrating a full year's estimate into 7 months instead of 12 — exactly the case #296 already names a config override for, just nothing on the page made it visible.

- `src/numbers/consumption.ts`: new `flatMonthlyPlan` on `EnvelopeConsumption` — the same estimate allocated with flat weights instead of the envelope's actual seasonal shape, so "what this month asks for" has a baseline to compare against. `Plan` now exposes `monthlyRequirement` directly (was computed in `computePlan()` but discarded after feeding `computeShares()`).
- New table between the income table and the contributions chart: every configured envelope's contribution to this month, next to its flat baseline, the signed difference, and where its shape came from (`configured` / `derived from history` / `flat, no history`). Sorted biggest-this-month-first; envelopes asking for nothing this month collapse behind a toggle. A total row uses `monthlyRequirement` itself, never a re-sum.
- Promoted `StatTile`'s local signed-formatting helper to `core/money.ts` as `formatEurExplicitSign` (this is now the second place needing it — the same "third copy" threshold this codebase already acts on).
- Mutation-tested `flatMonthlyPlan`'s computation and `formatEurExplicitSign` (all killed on committed code).

Verified live against the household's own data mid-edit — watched an envelope's seasonal effect appear and disappear on reload as its config gained and lost an explicit flat override, with the total row reconciling exactly across both states.

## Test plan

- [x] `npm run check`, `npm run build`
- [x] Mutation-tested `checkShare()`, `flatMonthlyPlan`, `formatEurExplicitSign` (all killed on committed code)
- [x] Verified in browser, light + dark, against real household data: both people's real `exceeds-income`/`high` status surfaces correctly; meters stripe/tint/tooltip correctly across ~40 real envelopes in both directions; check-table derived rows all show "—" while genuinely-over-pace configured envelopes still show "Over"; section 04 leads with the largest prior-year envelope; both chart tooltips verified including edge months (clamped, not clipped); the requirement breakdown's total reconciles exactly against the sum of transfers shown above it, checked across two different live edits to the household's own config

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Rebased onto `main` for CLAUDE.md + automated mutation testing

This branch had fallen 12 commits behind `main` — `CLAUDE.md` (#325), `npm run mutate` via Stryker (#323, #326), and a run of mutation-triage fixes had all landed since. Rebased rather than merged, matching `CLAUDE.md`'s own now-stated convention.

Two real conflicts, both the "both sides independently added something at the same insertion point" shape, not competing intent:
- `EnvelopeYearTable.tsx` — `main` fixed a React key collision (`envelopeId()` alone isn't unique across a derived and configured envelope sharing an id); this branch added the biggest-first sort. Combined: sort stays, key fix stays.
- `money.test.ts` — `main`'s mutation-triage pass added a `describe('formatEurSigned', ...)` block (a `-0` display fix, found via `npm run mutate`); this branch independently added `describe('formatEurExplicitSign', ...)` for the new function in item 6 above. Both kept, back to back.

**Then actually used `npm run mutate`** (unavailable when this branch's own commits were written by hand, per the "Mutation-tested... on committed code" notes above) against every `src/` file this PR touches:

```
npx stryker run --mutate "src/core/money.ts,src/numbers/checks.ts,src/numbers/consumption.ts,src/numbers/plan.ts,src/numbers/seasonal.ts"
```

`checks.ts`, `consumption.ts`, `plan.ts`, `seasonal.ts`: **100.00%**, zero survivors. `money.ts`: 91.79%, 10 survivors — all pre-existing and unrelated to this PR (the `allocate()` tie-break equivalence and the `Intl` formatter init, both already documented in `main`'s own comments; an unrelated regex in `parseAmount`; a boundary in `formatEurCompact`). The new `formatEurExplicitSign` specifically has zero survivors of its own. Confirms the hand-mutation spot-checks noted item-by-item above were accurate, at the file level rather than the function level.

## Post-rebase verification

- [x] `npm run check` — 372 tests, typecheck clean
- [x] `npm run build` — production build succeeds
- [x] CI green on the rebased branch
- [x] `npx stryker run --mutate <touched files>` — 100% on every numbers/ file this PR changes; `money.ts`'s survivors traced to pre-existing, already-documented gaps outside this PR's scope
- [x] No unresolved review threads at time of rebase
- [x] Re-verified live in browser post-rebase (`SLUICE_CONFIG_DIR=~/sluice-private npm run dev`, real household data, 54 envelopes): section 04 (`EnvelopeYearTable`) sorts by prior-year actual descending correctly; section 03 (`EnvelopeCheckTable`) ranks at-risk/over-pace/rest correctly — both are the files the rebase conflict touched. No console errors, no React key warnings from the id-collision case the conflict resolution preserved.
