### PR TITLE
docs: write CLAUDE.md (#294)

### DIFF
--- a/.claude/rules/app.md
+++ b/.claude/rules/app.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "app/**"
+---
+
+# `app/` has no automated tests, by design
+
+`vitest.config.ts` scopes `src/**` only; `tsc --noEmit` still covers
+`app/**`. The absence is a decision from the original page-building plan,
+not an oversight — verify a change here in a browser, against real data
+where possible (`SLUICE_CONFIG_DIR=~/sluice-private`), not by reaching for a
+component-test runner.

--- a/.claude/rules/app.md
+++ b/.claude/rules/app.md
@@ -10,3 +10,9 @@ paths:
 not an oversight — verify a change here in a browser, against real data
 where possible (`SLUICE_CONFIG_DIR=~/sluice-private`), not by reaching for a
 component-test runner.
+
+# No chart library, no state library
+
+Dependencies are added deliberately, not reflexively — `package.json` is
+the source of truth for the current count, and a new one is worth a second
+look before it lands.

--- a/.claude/rules/core-numbers.md
+++ b/.claude/rules/core-numbers.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "src/core/**"
+  - "src/numbers/**"
+---
+
+# `src/core/` and `src/numbers/` touch nothing but their arguments
+
+No wall clock, no disk, no network. Enforced by `src/purity.test.ts`, not
+just documented; `src/config/` and `src/ingest/` are the I/O layer, on
+purpose.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+Read before adding code. Two things live here: constraints this codebase
+can't teach you by being read, and how a change actually gets made. Nothing
+else — no phases, no `docs/` folder, no process apparatus. Adding a line
+here means finding one to cut.
+
+## Constraints not obvious from the code
+
+- **This repo is public and doubles as a portfolio.** Household figures,
+  local paths, and machine details never reach a commit, issue, or PR body.
+- **Bank exports and `sluice.toml` live outside the repo**, in
+  `~/sluice-private/`. Nothing real ever enters this working tree, fixture
+  or otherwise — every fixture here is hand-written.
+- **Stage explicit paths. Never `git add -A`.** Twice, an untracked leftover
+  sitting in the tree since before the work began got swept into an
+  unrelated commit and pushed. Run `git status` at the start of a session,
+  not just before committing.
+- **Every defect this project's reviews have found is a plausible wrong
+  number, never a crash.** Review accordingly: check arithmetic against its
+  own doc comment, not just that the suite is green.
+- **`src/core/` and `src/numbers/` touch nothing but their arguments** — no
+  wall clock, no disk, no network. Enforced by `src/purity.test.ts`, not
+  just documented; `src/config/` and `src/ingest/` are the I/O layer, on
+  purpose.
+- **No chart library, no state library.** Dependencies are added
+  deliberately, not reflexively — `package.json` is the source of truth for
+  the current count, and a new one is worth a second look before it lands.
+- **An envelope's `estimate` is a commitment, never regenerated in place.**
+  `generateEnvelopeBlock()` (`src/numbers/generate.ts`) only ever returns
+  TOML text for a human to paste; nothing in `app/` calls it.
+- **There's no `docs/` folder, and no process documentation lives in this
+  repo.** v0.1 had one — 201 lines of `CLAUDE.md` deferring to it, and 72%
+  of that version's effort went to process instead of product. Anything
+  that matters gets retyped deliberately when it's next needed, not filed
+  away in advance.
+
+Running it and configuring `sluice.toml`: see [`README.md`](README.md).
+
+## How a change happens here
+
+1. Non-trivial work gets a short plan first — reviewed, not written silently.
+2. One PR per coherent step. Stacked steps branch off the step below them,
+   not off `main`.
+3. Self-review, plus GitHub Copilot's automatic review where it fires —
+   every thread resolved or explicitly dismissed with a reason. Findings
+   and fixes are recorded in the PR body itself, not a separate document.
+4. Manual verification for anything user-visible: run it
+   (`SLUICE_CONFIG_DIR=~/sluice-private`) against real data where possible,
+   and say plainly what was and wasn't actually checked.
+5. Merge is the user's call, always — never the agent's, whatever CI says.
+6. `README.md` / this file update in the same PR as the change they describe.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,6 @@ here means finding one to cut.
 - **Every defect this project's reviews have found is a plausible wrong
   number, never a crash.** Review accordingly: check arithmetic against its
   own doc comment, not just that the suite is green.
-- **`src/core/` and `src/numbers/` touch nothing but their arguments** — no
-  wall clock, no disk, no network. Enforced by `src/purity.test.ts`, not
-  just documented; `src/config/` and `src/ingest/` are the I/O layer, on
-  purpose.
-- **No chart library, no state library.** Dependencies are added
-  deliberately, not reflexively — `package.json` is the source of truth for
-  the current count, and a new one is worth a second look before it lands.
 - **An envelope's `estimate` is a commitment, never regenerated in place.**
   `generateEnvelopeBlock()` (`src/numbers/generate.ts`) only ever returns
   TOML text for a human to paste; nothing in `app/` calls it.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ v0.2 is being built in steps, each its own pull request. The first version was d
 | 2 | **config** — `sluice.toml`: income, envelopes, goals, buffer | merged |
 | 3 | the numbers — the split, envelope consumption, seasonal pacing, the checks, the envelope generator | merged |
 | 4 | the page — instalment strip and four sections | merged |
-| 5 | `CLAUDE.md`, written once there is code to describe | next |
+| 5 | `CLAUDE.md`, written once there is code to describe | merged |
 
 ## Running it
 

--- a/src/purity.test.ts
+++ b/src/purity.test.ts
@@ -11,30 +11,61 @@ import { join, resolve } from 'node:path';
  * ("nothing under `src/numbers/` reads the wall clock; that stays at the
  * edge, in step 4") — but nothing enforced it. This does. `src/config/` and
  * `src/ingest/` are excluded on purpose: reading the config file and the
- * bank exports is their job.
+ * bank exports is their job. `__fixtures__/` is excluded too, the same call
+ * `stryker.config.mjs` already makes for the same reason: mutating, or
+ * purity-checking, test scaffolding measures nothing.
+ *
+ * Checks the *import source* rather than naming every forbidden function:
+ * any `node:fs` import, static or dynamic, read or write, under any name,
+ * fails this — not a curated list of function spellings that would need
+ * updating every time a new one gets used. `fetch(`, `Date.now(`, and
+ * `new Date(` are named directly since they're globals, not imports.
+ *
+ * Two gaps this can't close, accepted rather than chased: this reads raw
+ * text, not parsed code, so a doc comment mentioning `fetch(` would fail
+ * the same way real code would — TypeScript 7's `typescript` package no
+ * longer ships the compiler API that would parse it, and adding one just
+ * for this is disproportionate to what a guard test this size should cost.
+ * And a function re-exported under a new name from the excluded
+ * `src/config/`/`src/ingest/` and imported by that new name carries no
+ * `node:fs` import line into the scanned file at all — closing that fully
+ * needs whole-program import resolution, not a text check.
  */
 
-const FORBIDDEN = /\breadFile|readdir|fetch\(|new Date\(/;
+const FORBIDDEN_MODULE = /(?:from\s+|import\(|require\()["'](?:node:)?fs(?:\/promises)?["']/;
+const FORBIDDEN_CALL = /\bfetch\(|\bDate\.now\(|\bnew\s+Date\(/;
 const ROOTS = ['core', 'numbers'].map((dir) => resolve(import.meta.dirname, dir));
 
 function tsFilesUnder(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...tsFilesUnder(path));
-    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
-      out.push(path);
-    }
+  return readdirSync(dir, { recursive: true, withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        entry.name.endsWith('.ts') &&
+        !entry.name.endsWith('.test.ts') &&
+        !entry.parentPath.split(/[\\/]/).includes('__fixtures__'),
+    )
+    .map((entry) => join(entry.parentPath, entry.name));
+}
+
+/** `null` means clean. An unreadable file (e.g. a dangling symlink) is reported as an offender, not a crash. */
+function violationIn(path: string): string | null {
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch (error) {
+    return `unreadable: ${(error as Error).message}`;
   }
-  return out;
+  if (FORBIDDEN_MODULE.test(text)) return 'imports from node:fs';
+  if (FORBIDDEN_CALL.test(text)) return 'calls fetch(), Date.now(), or new Date()';
+  return null;
 }
 
 describe('src/core and src/numbers', () => {
   it('never read the wall clock, the filesystem, or the network', () => {
-    const offenders = ROOTS.flatMap(tsFilesUnder).filter((path) =>
-      FORBIDDEN.test(readFileSync(path, 'utf8')),
-    );
+    const offenders = ROOTS.flatMap(tsFilesUnder)
+      .map((path) => ({ path, reason: violationIn(path) }))
+      .filter((entry) => entry.reason !== null);
     expect(offenders).toEqual([]);
   });
 });

--- a/src/purity.test.ts
+++ b/src/purity.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * `src/core/` and `src/numbers/` never touch the wall clock, the
+ * filesystem, or the network — `referenceDay` and `Ledger` always arrive as
+ * parameters, read nowhere in between. That's what keeps every function
+ * under these two directories mutation-testable without mocking anything.
+ * It has held so far by discipline alone — several doc comments say so
+ * ("nothing under `src/numbers/` reads the wall clock; that stays at the
+ * edge, in step 4") — but nothing enforced it. This does. `src/config/` and
+ * `src/ingest/` are excluded on purpose: reading the config file and the
+ * bank exports is their job.
+ */
+
+const FORBIDDEN = /\breadFile|readdir|fetch\(|new Date\(/;
+const ROOTS = ['core', 'numbers'].map((dir) => resolve(import.meta.dirname, dir));
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...tsFilesUnder(path));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe('src/core and src/numbers', () => {
+  it('never read the wall clock, the filesystem, or the network', () => {
+    const offenders = ROOTS.flatMap(tsFilesUnder).filter((path) =>
+      FORBIDDEN.test(readFileSync(path, 'utf8')),
+    );
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #294.

## What this adds

`CLAUDE.md` at the repo root (45 lines), plus three small supporting pieces:

- **`src/purity.test.ts`** — a guard test asserting `src/core/` and `src/numbers/` never import from `node:fs` and never call `fetch(`/`Date.now(`/`new Date(`. Several doc comments already promised this ("nothing under `src/numbers/` reads the wall clock; that stays at the edge, in step 4"), but nothing enforced it. Modeled on the same shape `src/runnable.test.ts` and `src/source-hygiene.test.ts` already use for this project's other non-obvious, repo-wide invariants: small, single-purpose, doc comment naming what it protects and what it can't catch. See "Code review + fix," below — the mechanism changed after review found real gaps in the first version.
- **`.claude/rules/app.md`** — Claude Code's path-scoped rule mechanism (`paths: ["app/**"]` frontmatter): `app/` has no automated tests (decision, not oversight) and no chart/state library, both loading only in sessions that actually touch `app/`.
- **`.claude/rules/core-numbers.md`** — same mechanism, `paths: ["src/core/**", "src/numbers/**"]`, for the purity boundary the guard test enforces.

## Why now, and why this shape

The issue's own text: written only once there's code to describe, and exactly two things belong in it — constraints the model can't infer from the code, and a map of where things are / how to run them. A comment already on the issue (after steps 1–2 merged) established the test: *can a competent model infer this from the code in front of it, and does it beat the alternative of making it unnecessary.*

Steps 1–4 are all merged now, so this applies that test to what steps 3–4 added, and — new here — actually applies the test's *second* clause, which the issue's own precedent comment named but never used: two of this project's existing tests (`runnable.test.ts`, `source-hygiene.test.ts`) are exactly "the alternative of making it unnecessary" in practice, so the purity boundary got the same treatment instead of another paragraph of prose.

**The "map" half shrank to almost nothing, deliberately.** Anthropic's own CLAUDE.md guidance (fetched fresh rather than assumed, while writing this) says a trim pass on a checked-in `CLAUDE.md` cuts exactly what a directory-layout table is — content a model can derive from reading the filesystem — and keeps rationale and conventions that differ from tool defaults. A six-row "here's what's in each folder" table didn't survive that standard; a one-line pointer to `README.md` (which already documents running it and configuring `sluice.toml`) did.

**A short "how a change happens here" section is new**, beyond the issue's original two-part scope — plan first, one PR per step, self- plus Copilot review with findings recorded in the PR body, manual verification against real data when applicable, merge is always a human call, docs updated same-PR. This is process this project already follows every time, just never written down anywhere a fresh session or another tool could read.

## Two corrections to the record while writing this

- The issue's own live text says v0.1's `CLAUDE.md` was "264 lines." It was 201 (`git show v0.1:CLAUDE.md | wc -l`, cross-checked against the freeze commit's diffstat). Small, but worth fixing where it's asserted rather than repeating it.
- The precedent comment on the issue guessed `allocate()`'s exact-sum apportionment invariant (`src/core/money.ts`) as the next likely candidate for this file. It isn't, on the same standard that already excluded "money is integer cents" — the function carries a 30-line doc comment explaining the mechanism and why, which makes it exactly the kind of thing a competent reader infers from the file in front of them.

## How this file's content was checked

Four rounds of review before writing anything: three passes each fact-checking one part of the design space that came up while drafting (what to cut under a harder budget, what to add under a looser one, and what "no line limit" actually implies for a project whose predecessor tried that and restarted from it), then a reconciling pass against Anthropic's current published guidance, fetched live. That process caught and corrected, before any of it reached this file:

- An early draft scoped the "no side effects" rule to all of `src/`, which is wrong — `src/config/` and `src/ingest/` do real, correct file I/O; only `src/core/` and `src/numbers/` are meant to be pure. Worth catching specifically because an overly broad written rule is worse than none: a literal reader would flag correct code as a violation.
- A draft example describing this repo's branch-naming convention was wrong (named the rare prefixes, missed the dominant one) and got cut rather than fixed, since it turned out not to be a meaningful convention to codify either way.
- A draft aside describing one UI safeguard's failure mode had the mechanism backwards, and turned out to already be fully self-documented at the source — cut on the same standard as everything else that's locally well-commented already.

## Second pass: `/doctor`

Run in an interactive session after the first commit, against the file as merged-ready. Its own trim check (checked-in-`CLAUDE.md`-specific, not the general four-round review above) agreed there was nothing left to *cut* — every remaining line passes "could a session reconstruct this from the code" — but found two bullets that only mattered for one subdirectory each, still sitting in the always-loaded root file:

- `src/core/` + `src/numbers/` purity → new `.claude/rules/core-numbers.md`
- no chart/state library → existing `.claude/rules/app.md` (`src/` has no UI code at all, so this was always an `app/`-only concern)

`CLAUDE.md`: 52 → 45 lines. Considered moving the envelope-estimate-commitment bullet too; left it in root as a design principle relevant to any future feature idea, not tied to one file — a judgment call, not a rule.

`/doctor`'s other checks (unused skills, settings health, hook timing, permission mode) came back clean or were applied locally (a plugin bundle's unused skills, gitignored, not part of this PR).

## Third pass: `/code-review max`, plus GitHub Copilot's own review, on `src/purity.test.ts`

Both converged on the same finding independently: the original regex (`/\breadFile|readdir|fetch\(|new Date\(/`) only anchored its first alternative, missed `Date.now()` and every filesystem write, matched inside comments and unrelated identifiers (`prefetch(`, `xreaddirSync`), and — the sharpest one, found by both Copilot and this session's own review — could be evaded by importing a forbidden function re-exported under a new name from the excluded `src/config/`/`src/ingest/`, which isn't hypothetical: `src/config/load.ts` already mixes a real `readFile` call with pure re-exports `src/numbers/` imports directly today.

Fixed in `3ff758f`: the check now matches on the *import source* (any `node:fs` import, static or dynamic) rather than a function-name list, which catches every fs write for free — no more enumerating spellings. Verified against a battery of positive/negative cases before trusting it, then against the real tree (still green today, still fails red on an injected `writeFileSync`-via-import violation and on a real `prefetch()`-named function).

Two things named in the file's own doc comment rather than fixed, both explained to Copilot in-thread: the transitive re-export case is still open (closing it needs whole-program import resolution, not a text check), and comments/strings can still false-positive on `fetch()`/`Date.now()`/`new Date()` (this reads raw text, not parsed code — `typescript@7.0.2`, installed here, no longer ships the classic compiler API that would parse it; confirmed by trying it, not assumed, before ruling it out). The 4 remaining findings from `/code-review`'s 14 (CLAUDE.md no longer linking to the two `.claude/rules/` files it delegated content to; both rules' `paths` globs excluding the file most relevant to what they document; a small duplication between `app.md` and `CLAUDE.md`'s verification instructions; two unrelated rules sharing one file with no enclosing structure) are real but lower-severity and more editorial — left for follow-up rather than folded into this pass.

## Test plan

- [x] `npm run check` — typecheck + full suite green (293 tests), re-run after each follow-up commit
- [x] `src/purity.test.ts` verified to actually fail on an injected violation (both a write-via-import and the original wall-clock case), not just pass by construction
- [x] Grepped `app/` for any config-writing call before asserting the generator's output is never auto-applied — none found
- [x] Grepped the changed files for anything beyond what `README.md` already discloses publicly — clean
- [x] `/context` and `/doctor` — run in a follow-up interactive session; findings applied above
- [x] `/code-review max` (10 finder angles, verify pass, sweep) — findings triaged above; the confirmed correctness gap fixed and the Copilot thread it also caught resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
