### PR TITLE
docs: point at where the mutation baseline lives

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ reports which mutations no test objects to. It sits outside `check` on purpose �
 `check` gates every push in about thirty seconds, where a mutation run is about
 three minutes.
 
+It prints a score per directory rather than one for the whole tree, because the
+weakest surface otherwise hides behind the strongest — the spread is currently
+thirteen points. The baseline and the triage of every surviving mutant live on
+[#299](https://github.com/xavierbriand/sluice/issues/299); the gaps it found are
+tracked as their own issues rather than fixed inline, so the cost of each stays
+visible. No score threshold is enforced yet, deliberately: [#321](https://github.com/xavierbriand/sluice/issues/321)
+holds the criteria for adopting one.
+
 sluice reads two things and holds nothing: a folder of bank exports, and one configuration file. There is no database and no import step — every run re-reads the files, because a stale render of a household's money is worse than a slow one.
 
 `SLUICE_CONFIG_DIR` points at the folder holding `sluice.toml`; the page refuses to render without it, with a message saying so, rather than guessing a path.


### PR DESCRIPTION
Follow-up to #323, now merged.

The README gained `npm run mutate` and a paragraph on what it is for. It did not say where to find what the tool reported, or why no threshold is enforced — the two things a reader who runs it and sees `src/ingest` at 74% will immediately want.

Adds six lines: the per-directory rationale, a pointer to the baseline and triage on #299, and a pointer to #321 for the threshold decision.

**Deliberately does not quote a score.** Three baselines were published on #299 before one stuck — 84.55%, 84.48%, 81.14% — and none of the drops were because the tests got worse; each time the instrument was hiding something from itself. A number embedded in the README would have been wrong twice already. The issues carry the figures and the reasoning; the README carries the pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)