### PR TITLE
ofx: cover the format contract

### DIFF
--- a/src/ingest/__fixtures__/build.ts
+++ b/src/ingest/__fixtures__/build.ts
@@ -19,6 +19,8 @@ export interface FixtureRow {
   readonly operationType?: string;
   readonly notes?: string;
   readonly fitId?: string;
+  /** OFX only, ignored by `csvFixture`: tags to leave out of this transaction's block. */
+  readonly omit?: readonly ('TRNTYPE' | 'DTPOSTED' | 'TRNAMT' | 'FITID' | 'NAME')[];
 }
 
 export function csvFixture(rows: readonly FixtureRow[]): Uint8Array {
@@ -51,6 +53,7 @@ export interface OfxOptions {
   readonly to?: string; // YYYYMMDD
   readonly balance?: string; // "+264.21"
   readonly omitBalance?: boolean;
+  readonly omitCurdef?: boolean;
 }
 
 function ofxDate(french: string): string {
@@ -69,20 +72,23 @@ export function ofxFixture(rows: readonly FixtureRow[], options: OfxOptions = {}
     to = '20261231',
     balance = '+0.00',
     omitBalance = false,
+    omitCurdef = false,
   } = options;
 
   const body = rows
-    .map((r, i) =>
-      [
+    .map((r, i) => {
+      const omit = new Set(r.omit ?? []);
+      const lines = [
         '<STMTTRN>',
-        `<TRNTYPE>${r.amount.startsWith('-') ? 'DEBIT' : 'CREDIT'}`,
-        `<DTPOSTED>${ofxDate(r.postedOn)}`,
-        `<TRNAMT>${ofxAmount(r.amount)}`,
-        `<FITID>${r.fitId ?? `FIT${i + 1}`}`,
-        `<NAME>${r.label ?? 'MERCHANT'}`,
+        !omit.has('TRNTYPE') && `<TRNTYPE>${r.amount.startsWith('-') ? 'DEBIT' : 'CREDIT'}`,
+        !omit.has('DTPOSTED') && `<DTPOSTED>${ofxDate(r.postedOn)}`,
+        !omit.has('TRNAMT') && `<TRNAMT>${ofxAmount(r.amount)}`,
+        !omit.has('FITID') && `<FITID>${r.fitId ?? `FIT${i + 1}`}`,
+        !omit.has('NAME') && `<NAME>${r.label ?? 'MERCHANT'}`,
         '</STMTTRN>',
-      ].join('\r\n'),
-    )
+      ];
+      return lines.filter((l): l is string => l !== false).join('\r\n');
+    })
     .join('\r\n');
 
   const ledgerBalance = omitBalance
@@ -122,7 +128,7 @@ export function ofxFixture(rows: readonly FixtureRow[], options: OfxOptions = {}
     '<SEVERITY>INFO',
     '</STATUS>',
     '<STMTRS>',
-    '<CURDEF>EUR',
+    ...(omitCurdef ? [] : ['<CURDEF>EUR']),
     '<BANKACCTFROM>',
     `<ACCTID>${accountId}</ACCTID>`,
     '</BANKACCTFROM>',

--- a/src/ingest/ofx.test.ts
+++ b/src/ingest/ofx.test.ts
@@ -43,7 +43,71 @@ describe('parseOfx', () => {
   });
 
   it('refuses a file that is not OFX at all', () => {
-    expect(() => parseOfx(Buffer.from('just some text', 'latin1'), 'x.ofx')).toThrow(OfxFormatError);
+    // The check this guards is one line away from redundant with the
+    // <LEDGERBAL> lookup below it — remove it and "just some text" still
+    // throws OfxFormatError, just from the balance check instead. What makes
+    // it worth keeping is the message: this one tells someone they pointed
+    // sluice at the wrong file; a LEDGERBAL complaint would send them looking
+    // for a balance in a file that was never OFX to begin with. Asserting the
+    // text, not just the error type, is what keeps that message load-bearing.
+    expect(() => parseOfx(Buffer.from('just some text', 'latin1'), 'x.ofx')).toThrow(
+      /is this an OFX export/,
+    );
+  });
+
+  it('names the missing tag and the right transaction when a required field is absent', () => {
+    // FITID, DTPOSTED and TRNAMT all go through the same `required()` guard,
+    // and none of the three had ever been omitted from a fixture — the throw
+    // this depends on had no test reaching it at all. Two transactions, the
+    // second one broken, so the message's index has to be right rather than
+    // merely present: transaction 1 is fine and transaction 2 is missing its
+    // id, so a message saying "transaction 1" would be exactly the kind of
+    // wrong number this project keeps finding.
+    const bad = ofxFixture(
+      [
+        { postedOn: '01/08/2026', amount: '-10,00' },
+        { postedOn: '02/08/2026', amount: '-20,00', omit: ['FITID'] },
+      ],
+      { to: '20260815' },
+    );
+    expect(() => parseOfx(bad, 'x.ofx')).toThrow(/x\.ofx transaction 2: <FITID> is missing/);
+  });
+
+  it('splits transactions on every <STMTTRN>, not just the first', () => {
+    // `text.split('<STMTTRN>')` is what turns the raw file into one block per
+    // transaction; a single-transaction fixture cannot tell it apart from
+    // reading the whole body as one block.
+    const statement = parseOfx(
+      ofxFixture(
+        [
+          { postedOn: '01/08/2026', amount: '-10,00', fitId: 'A' },
+          { postedOn: '02/08/2026', amount: '-20,00', fitId: 'B' },
+        ],
+        { to: '20260815' },
+      ),
+    );
+    expect(statement.transactions.map((t) => t.fitId)).toEqual(['A', 'B']);
+    expect(statement.transactions.map((t) => t.amount)).toEqual([-1000, -2000]);
+  });
+
+  it('treats an absent TRNTYPE or NAME as empty, not as missing', () => {
+    // Unlike FITID/DTPOSTED/TRNAMT, these two are read with `?? ''` rather
+    // than `required()` — a card statement's memo-only rows have been seen
+    // without a NAME. The `?? ''` fallbacks on both had no test reaching them.
+    const statement = parseOfx(
+      ofxFixture([{ postedOn: '01/08/2026', amount: '-10,00', omit: ['TRNTYPE', 'NAME'] }], {
+        to: '20260815',
+      }),
+    );
+    expect(statement.transactions[0]?.type).toBe('');
+    expect(statement.transactions[0]?.name).toBe('');
+  });
+
+  it('defaults the currency to EUR when CURDEF is absent', () => {
+    const statement = parseOfx(
+      ofxFixture([{ postedOn: '01/08/2026', amount: '-10,00' }], { to: '20260815', omitCurdef: true }),
+    );
+    expect(statement.currency).toBe('EUR');
   });
 
   it('accepts a statement with no transactions and still reads its balance', () => {


### PR DESCRIPTION
Closes #312. Stacked on #327 — merge that first.

`src/ingest/ofx.ts` scored 47.83%, the weakest file in the repo, with 36 items to triage (30 survived, 6 with no coverage at all). None of them were missing tests so much as missing the ability to *construct* the malformed input — the fixture builder had no way to omit a required tag or drop the currency default.

## The fixture, extended before the tests

`FixtureRow.omit` drops named tags from a transaction block; `OfxOptions.omitCurdef` drops `<CURDEF>` from the preamble. Both follow the `omitBalance` pattern already in the file rather than inventing a new one.

## What each new test closes, and how it was checked

Every one of these was hand-verified by reverting the guard or fallback in `ofx.ts` and confirming the *new* test — not the whole suite — goes red:

- **`refuses a file that is not OFX at all`** now asserts the message, not just the error type. The `<OFX>` guard is one line from redundant with the `<LEDGERBAL>` check below it — remove it and `just some text` still throws `OfxFormatError`, from the balance check instead. What isn't redundant is the message: *"is this an OFX export?"* sends someone looking in the right place; a LEDGERBAL complaint wouldn't.
- **The transaction-index bug this repo keeps finding.** FITID, DTPOSTED and TRNAMT all route through `required()`, and none had ever been omitted from a fixture. Covered with two transactions where the *second* is missing its id, asserting the message names transaction 2, not 1. This is the one that would have quietly hidden a real off-by-one — every OFX error message points at the wrong row if `${i + 1}` ever becomes `${i - 1}`, and nothing throws.
- **`text.split('<STMTTRN>')`** had never seen two transactions in one file.
- **TRNTYPE and NAME's `?? ''` fallbacks** — a card statement's memo-only rows have been seen without a NAME — had no test reaching either.
- **CURDEF's `?? 'EUR'` fallback**, same story.

313 tests passing, `npm run check` green.
