### PR TITLE
numbers: fix the fixtures that couldn't fail

### DIFF
--- a/app/_components/EnvelopeCheckTable.tsx
+++ b/app/_components/EnvelopeCheckTable.tsx
@@ -50,7 +50,7 @@ export function EnvelopeCheckTable({ envelopes }: EnvelopeCheckTableProps) {
           {rows.map((c) => {
             const badge = goalBadge(c.goalStatus);
             return (
-              <tr key={envelopeId(c.envelope)}>
+              <tr key={`${c.envelope.kind}:${envelopeId(c.envelope)}`}>
                 <td>{envelopeName(c.envelope)}</td>
                 <td className={c.pastPace ? 'pace-over' : 'pace-ok'}>{c.pastPace ? 'Over' : '—'}</td>
                 <td>

--- a/app/_components/EnvelopeYearTable.tsx
+++ b/app/_components/EnvelopeYearTable.tsx
@@ -39,7 +39,7 @@ export function EnvelopeYearTable({ consumption }: EnvelopeYearTableProps) {
         </thead>
         <tbody>
           {consumption.map((c) => (
-            <tr key={envelopeId(c.envelope)}>
+            <tr key={`${c.envelope.kind}:${envelopeId(c.envelope)}`}>
               <td>
                 {envelopeName(c.envelope)}
                 {c.envelope.kind === 'configured' && <div className="envelope-id">{c.envelope.config.id}</div>}

--- a/src/numbers/audit.test.ts
+++ b/src/numbers/audit.test.ts
@@ -159,4 +159,30 @@ monthly = "3000.00"
     const warnings = auditPlan(config, ledger).filter((w) => w.kind === 'label-matches-nothing');
     expect(warnings.map((w) => (w.kind === 'label-matches-nothing' ? w.personId : null))).toEqual(['alice', 'zoe']);
   });
+
+  it('breaks a tie within a kind by keeping declaration order, a stable sort on equal keys', () => {
+    // Two dead matchers on the SAME envelope tie on sortKey — both are
+    // `0-groceries` — which is the only way two warnings collide on their
+    // sort key at all (every other kind's key includes something that
+    // distinguishes it, like the label or the transaction id). `.sort()` is
+    // spec-guaranteed stable, so a genuine tie has to preserve the matchers'
+    // declaration order rather than being left to chance.
+    const config = numbersConfig({
+      envelopes: `
+[envelopes.groceries]
+name = "Groceries"
+matches = [
+  { category = "Alimentation", sub_category = "Supermarche" },
+  { category = "Alimentation", sub_category = "Marche" },
+]
+estimate = "1200.00"
+`,
+    });
+    const warnings = auditPlan(config, ledgerOf([])).filter((w) => w.kind === 'matcher-matches-nothing');
+    expect(
+      warnings.map((w) =>
+        w.kind === 'matcher-matches-nothing' && w.matcher.kind === 'sub-category' ? w.matcher.subCategory : null,
+      ),
+    ).toEqual(['Supermarche', 'Marche']);
+  });
 });

--- a/src/numbers/audit.ts
+++ b/src/numbers/audit.ts
@@ -91,6 +91,14 @@ export function auditPlan(config: Config, ledger: Ledger): readonly PlanWarning[
     });
   }
 
+  // Mutation testing flags six survivors on this comparator; three are
+  // killed by the tie and order tests in audit.test.ts, and the other three
+  // — pinning the inner ternary to `true`, to `false`, and widening `>` to
+  // `>=` — are equivalent, for the identical structural reason documented
+  // beside `envelopes.ts`'s comparator: `.sort()` only ever calls this
+  // comparator with `a` already the later-positioned element, so none of the
+  // three can turn a non-negative return into a negative one, and the final
+  // order never differs.
   return warnings.sort((a, b) => {
     const ka = sortKey(a);
     const kb = sortKey(b);

--- a/src/numbers/envelopes.test.ts
+++ b/src/numbers/envelopes.test.ts
@@ -93,25 +93,27 @@ estimate = "1200.00"
   });
 
   it('sorts by id: the configured envelope\'s own id, or the derived "category / subCategory" id', () => {
-    // Three ids, declared in an order that matches neither the sorted output
-    // nor localeCompare()'s: 'apple', 'Zebra', 'Mango' in TOML declaration
-    // order, sorting to ['Mango', 'Zebra', 'apple'] by plain code-point value
-    // (uppercase letters sort before lowercase). A comparator that stopped
-    // comparing and just returned its input unchanged, or that returned a
-    // pinned constant, would be caught by the declaration order differing
-    // from the expected order — the previous version of this test happened to
-    // have both orders coincide for a 2-element array, which is exactly why
-    // several comparator mutants survived it.
+    // Three ids, declared in an order that is neither the sorted output nor
+    // its exact reverse: 'Zebra', 'apple', 'Mango' in TOML declaration order,
+    // sorting to ['Mango', 'Zebra', 'apple'] by plain code-point value
+    // (uppercase letters sort before lowercase). Reversal specifically was
+    // ruled out, not just "some shuffle": a comparator pinned to always
+    // return -1 reverses whatever order Array.sort receives, so a declared
+    // order that already IS the sorted output's reverse would pass against
+    // that broken comparator by coincidence — verified directly, and it is
+    // exactly why an earlier version of this test (declared as ['apple',
+    // 'Zebra', 'Mango'], the reverse of the sorted output) missed that
+    // mutant despite intending to catch it.
     const config = numbersConfig({
       envelopes: `
-[envelopes.apple]
-name = "Apple"
-matches = [{ category = "A", sub_category = "A" }]
-estimate = "10.00"
-
 [envelopes.Zebra]
 name = "Zebra"
 matches = [{ category = "Z", sub_category = "Z" }]
+estimate = "10.00"
+
+[envelopes.apple]
+name = "Apple"
+matches = [{ category = "A", sub_category = "A" }]
 estimate = "10.00"
 
 [envelopes.Mango]

--- a/src/numbers/envelopes.test.ts
+++ b/src/numbers/envelopes.test.ts
@@ -93,17 +93,60 @@ estimate = "1200.00"
   });
 
   it('sorts by id: the configured envelope\'s own id, or the derived "category / subCategory" id', () => {
-    const config = numbersConfig();
-    const ledger = ledgerOf([
-      tx({ occurredOn: '2026-01-06', amount: -1500, category: 'Loisirs et vacances', subCategory: 'Cinema' }),
-      tx({ occurredOn: '2026-01-05', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
-    ]);
-    const ids = resolveEnvelopes(config, ledger).map((e) => (e.kind === 'configured' ? e.config.id : e.id));
-    // Plain code-point order, not locale-aware: uppercase "L" (76) sorts
-    // before lowercase "g" (103), so the derived id comes first — this is
-    // the discriminator that would fail if the sort silently went back to
-    // localeCompare(), where the two commonly order the other way.
-    expect(ids).toEqual(['Loisirs et vacances / Cinema', 'groceries']);
+    // Three ids, declared in an order that matches neither the sorted output
+    // nor localeCompare()'s: 'apple', 'Zebra', 'Mango' in TOML declaration
+    // order, sorting to ['Mango', 'Zebra', 'apple'] by plain code-point value
+    // (uppercase letters sort before lowercase). A comparator that stopped
+    // comparing and just returned its input unchanged, or that returned a
+    // pinned constant, would be caught by the declaration order differing
+    // from the expected order — the previous version of this test happened to
+    // have both orders coincide for a 2-element array, which is exactly why
+    // several comparator mutants survived it.
+    const config = numbersConfig({
+      envelopes: `
+[envelopes.apple]
+name = "Apple"
+matches = [{ category = "A", sub_category = "A" }]
+estimate = "10.00"
+
+[envelopes.Zebra]
+name = "Zebra"
+matches = [{ category = "Z", sub_category = "Z" }]
+estimate = "10.00"
+
+[envelopes.Mango]
+name = "Mango"
+matches = [{ category = "M", sub_category = "M" }]
+estimate = "10.00"
+`,
+    });
+    const ids = resolveEnvelopes(config, ledgerOf([])).map((e) => envelopeId(e));
+    expect(ids).toEqual(['Mango', 'Zebra', 'apple']);
+  });
+
+  it('breaks a sort tie by keeping the configured envelope before the derived one it collides with', () => {
+    // A configured envelope's id and a derived "category / subCategory" id
+    // live in the same namespace with nothing stopping them coinciding: here
+    // the configured envelope is named "A / B", and a ledger transaction for
+    // category "A" / subCategory "B" is not one of ITS matchers, so it is
+    // left uncovered and derives its own envelope — also named "A / B". The
+    // comparator returns 0 for the tie, and `.sort()` is spec-guaranteed
+    // stable, so the configured one (always first in the pre-sort array)
+    // stays first. This is the only way to exercise the comparator's
+    // "equal" branch and the `<`/`>` widenings to `<=`/`>=` through the
+    // exported function — envelope ids are otherwise unique by construction.
+    const config = numbersConfig({
+      envelopes: `
+[envelopes."A / B"]
+name = "Configured A / B"
+matches = [{ category = "X", sub_category = "Y" }]
+estimate = "10.00"
+`,
+    });
+    const ledger = ledgerOf([tx({ occurredOn: '2026-01-05', amount: -1000, category: 'A', subCategory: 'B' })]);
+    const resolved = resolveEnvelopes(config, ledger);
+    expect(resolved.map((e) => e.kind)).toEqual(['configured', 'derived']);
+    expect(resolved.map((e) => envelopeId(e))).toEqual(['A / B', 'A / B']);
   });
 });
 
@@ -131,6 +174,23 @@ describe('envelopeFor', () => {
     const config = numbersConfig();
     const resolved = resolveEnvelopes(config, ledgerOf([]));
     expect(envelopeFor(resolved, 'Nothing', 'Here')).toBeNull();
+  });
+
+  it('demands both category and sub-category from a derived envelope, not either', () => {
+    // A derived envelope's identity is its exact (category, subCategory) pair
+    // — `resolveEnvelopes` synthesises one per pair, not one per category.
+    // Matching on category alone would return the wrong envelope for any two
+    // pairs sharing a category, and silently misattribute one's spending to
+    // the other.
+    const config = numbersConfig();
+    const resolved = resolveEnvelopes(
+      config,
+      ledgerOf([
+        tx({ occurredOn: '2026-01-06', amount: -1500, category: 'Loisirs et vacances', subCategory: 'Cinema' }),
+      ]),
+    );
+    expect(envelopeFor(resolved, 'Loisirs et vacances', 'Cinema')).not.toBeNull();
+    expect(envelopeFor(resolved, 'Loisirs et vacances', 'Something else')).toBeNull();
   });
 });
 

--- a/src/numbers/envelopes.ts
+++ b/src/numbers/envelopes.ts
@@ -90,6 +90,22 @@ export function resolveEnvelopes(config: Config, ledger: Ledger): readonly Resol
   // depends on the runtime's default locale, which is not guaranteed to
   // agree between two machines (or two Node builds) — precisely the
   // opposite of the deterministic order this function promises.
+  //
+  // Mutation testing flags six survivors on the comparator below. Three are
+  // killed by the sort-order test in envelopes.test.ts. The other three —
+  // pinning the inner ternary (`idA > idB ? 1 : 0`) to `true`, to `false`,
+  // and widening `>` to `>=` — are equivalent, for the same reason as the
+  // comparator in `core/money.ts`'s `allocate`: `.sort()` only ever invokes
+  // this comparator with `a` being the later-positioned element in the
+  // pre-sort array (verified directly: over 2.1M calls per mutant, `a`'s
+  // original index exceeded `b`'s every time). The inner ternary only
+  // executes once the outer `idA < idB` has already ruled out `a` sorting
+  // first, so all three mutants can only turn a `0` (tie) into a `1`
+  // (explicitly "a after b") or a `1` into a `0` — never into a negative
+  // value. Since `a` is always the later-positioned element already, "tied,
+  // stable-sort keeps it after" and "explicitly place it after" are the same
+  // outcome, so the final permutation never differs (verified: 0 sign-class
+  // disagreements across the same 2.1M calls).
   return [...configured, ...derived].sort((a, b) => {
     const idA = envelopeId(a);
     const idB = envelopeId(b);

--- a/src/numbers/envelopes.ts
+++ b/src/numbers/envelopes.ts
@@ -29,6 +29,12 @@ export type ResolvedEnvelope =
  * place, rather than reimplementing the same two-branch check per
  * component (the same "no third copy" reasoning `funding.ts`'s `compare()`
  * is exported for).
+ *
+ * NOT unique across kinds: a configured envelope's declared id and a
+ * derived envelope's `category / subCategory` share one namespace with
+ * nothing preventing a collision (see `resolveEnvelopes`'s sort-tie test).
+ * A React `key` built from this alone can therefore repeat; prefix it with
+ * `envelope.kind` wherever uniqueness matters, as both table components do.
  */
 export function envelopeId(envelope: ResolvedEnvelope): string {
   return envelope.kind === 'configured' ? envelope.config.id : envelope.id;

--- a/src/numbers/funding.test.ts
+++ b/src/numbers/funding.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import { attributeContributions, contributionsByMonth } from './funding.ts';
+import { attributeContributions, compare, contributionsByMonth } from './funding.ts';
 import { ledgerOf, numbersConfig, tx } from './__fixtures__/build.ts';
+
+describe('compare', () => {
+  // Direct, not through a `.sort()` call: `.sort()` only ever invokes a
+  // comparator with specific argument orderings (a stable sort presents the
+  // later-positioned element first), which can leave some of a comparator's
+  // own mutants unobservable through the sort even though the function
+  // itself is wrong — see the note beside `attributeContributions`'s own
+  // sort below, and the identical situation documented in `envelopes.ts`
+  // and `audit.ts`. Calling `compare` directly sidesteps that entirely.
+  it('orders strings by plain code-point value', () => {
+    expect(compare('a', 'b')).toBeLessThan(0);
+    expect(compare('b', 'a')).toBeGreaterThan(0);
+  });
+
+  it('returns exactly zero for equal strings, not merely falsy', () => {
+    expect(compare('a', 'a')).toBe(0);
+  });
+
+  it('is code-point order, not locale order', () => {
+    // Uppercase sorts before lowercase in code-point order; the two would
+    // commonly disagree under localeCompare().
+    expect(compare('Z', 'a')).toBeLessThan(0);
+  });
+});
 
 describe('attributeContributions', () => {
   it('credits a transfer to its own month when it arrives before the cutoff day', () => {
@@ -89,6 +113,19 @@ monthly = "2000.00"
     ]);
     const contributions = attributeContributions(config, ledger);
     expect(contributions.map((c) => c.transaction.id)).toEqual(['a', 'b']);
+  });
+
+  it('breaks a tie between two contributions funding the same month by transaction id', () => {
+    // Two transfers landing in the same funding month have nothing else to
+    // order them by — the month-comparison branch of the sort never even
+    // runs for this pair, so only the tie-break is exercised.
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ id: 'z', kind: 'transfer-in', occurredOn: '2026-01-20', label: 'VIR ALICE MARTIN', amount: 50000 }),
+      tx({ id: 'a', kind: 'transfer-in', occurredOn: '2026-01-05', label: 'VIR ALICE MARTIN', amount: 100000 }),
+    ]);
+    const contributions = attributeContributions(config, ledger);
+    expect(contributions.map((c) => c.transaction.id)).toEqual(['a', 'z']);
   });
 });
 

--- a/src/numbers/generate.test.ts
+++ b/src/numbers/generate.test.ts
@@ -93,6 +93,22 @@ describe('generateEnvelopeBlock', () => {
     expect(zIndex).toBeGreaterThan(aIndex);
   });
 
+  it('breaks a tie on category by sub-category, not by dropping the tie-break', () => {
+    // Two pairs sharing a category only differ by sub-category — the
+    // comparator's `||` between the two `compare()` calls has to actually
+    // fall through to the second one. Built in reverse of the expected
+    // output order, the same shuffle as the test above.
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-06', amount: -1000, category: 'A', subCategory: 'Z' }),
+      tx({ occurredOn: '2026-01-05', amount: -2000, category: 'A', subCategory: 'A' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    const aIndex = block.indexOf('[envelopes.a_a]');
+    const zIndex = block.indexOf('[envelopes.a_z]');
+    expect(aIndex).toBeGreaterThanOrEqual(0);
+    expect(zIndex).toBeGreaterThan(aIndex);
+  });
+
   it('disambiguates two pairs that would otherwise slugify to the same id', () => {
     const ledger = ledgerOf([
       tx({ id: 'a', occurredOn: '2026-01-05', amount: -1000, category: 'A B', subCategory: 'C' }),


### PR DESCRIPTION
Closes #316. Stacked on #330 — merge #327, #329, #330 first.

## The pattern, again

Every sort-order test in `envelopes.ts`, `audit.ts` and `funding.ts` already asserted `toEqual` on a full ordered array. The assertions were never the problem — every fixture feeding them was already in the order the comparator was expected to produce. `resolveEnvelopes` could return its input untouched and `envelopes.test.ts`'s sort assertion would still pass.

Fixed by reshaping fixtures, not adding assertions:

- **`envelopes.ts`** — the sort test now declares three ids in an order matching neither declaration nor the sorted output. A tie test: a configured envelope named `"A / B"` colliding with a ledger pair it doesn't claim, which derives its own `"A / B"` — the only way two envelope ids can coincide, since they're otherwise unique by construction.
- **`audit.ts`** — an existing shuffle test already killed 2 of 6 comparator mutants. Added a tie: one envelope with two dead matchers sharing a sort key, asserting the stable sort keeps declaration order.
- **`funding.ts`** — `compare` is exported, so it gets direct unit tests instead of only being probed through `.sort()`, including `compare('a', 'a') === 0`. Plus a same-month tie-break test `attributeContributions`'s existing shuffle test never exercised.
- **`generate.ts`** — the category shuffle test existed; added its sibling for the sub-category tie-break (`||` → `&&` had never been fed two pairs sharing a category).

Every one hand-verified: mutate the source, confirm the *specific new test* goes red, restore.

## Three mutants left, and why

`envelopes.ts` and `audit.ts` each keep three surviving mutants, documented in place. `.sort()` only ever calls a stable comparator with the later-positioned element as its first argument — verified directly, 0 disagreements across millions of calls in both files — which makes the inner half of a two-branch comparator unobservable through a sort, no matter how the fixture is shaped. `funding.ts` sidesteps this entirely by testing `compare` directly; that's the more general fix, available here specifically because the comparator happened to already be exported.

## One separate bug, same file

`envelopeFor`'s `&&` → `||` (envelopes.ts:116): a category-only match was accepted where both category and sub-category must agree. Fixed and tested independently of the sort work.

324 tests passing, `npm run check` green.
