### PR TITLE
config: settle the guard idiom, close the concrete holes

### DIFF
--- a/src/config/load.test.ts
+++ b/src/config/load.test.ts
@@ -63,6 +63,14 @@ describe('loadConfig', () => {
     );
   });
 
+  it('expands a bare ~ on its own, not just as a ~/ prefix', async () => {
+    // A different branch of expandHome() from the test above: `~/x` matches
+    // startsWith('~/'), but a bare `~` has nothing after the slash to match
+    // that pattern at all — it needs its own equality check.
+    const dir = await withConfig(configToml({ exports: '[exports]\ndirectory = "~"\n' }));
+    expect((await loadConfig(dir)).exportsDirectory).toBe(homedir());
+  });
+
   it('reads a file that starts with a byte-order mark', async () => {
     // Invisible in an editor, and it would otherwise become part of the first
     // key's name — so the file would be refused for a reason nobody could see.
@@ -74,6 +82,20 @@ describe('loadConfig', () => {
     const dir = await tempDir();
     await expect(loadConfig(dir)).rejects.toThrow(ConfigNotFoundError);
     await expect(loadConfig(dir)).rejects.toThrow(new RegExp(dir));
+  });
+
+  it('keeps the original filesystem error as the cause', async () => {
+    // The friendly message names the directory; `cause` is what a debugger
+    // reaches for when "no such file" isn't the whole story — a permissions
+    // error looks identical from the message alone.
+    const dir = await tempDir();
+    try {
+      await loadConfig(dir);
+      expect.unreachable();
+    } catch (error) {
+      expect((error as ConfigNotFoundError).cause).toBeInstanceOf(Error);
+      expect(((error as ConfigNotFoundError).cause as NodeJS.ErrnoException).code).toBe('ENOENT');
+    }
   });
 
   it('reports a bad plan as a config problem, not a missing file', async () => {

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -68,6 +68,12 @@ export async function loadConfig(directory: string): Promise<Config> {
 
   // A BOM is invisible in an editor and would otherwise become part of the first
   // key's name, so the file would be refused for a reason nobody could see.
+  //
+  // The `^` anchor is equivalent: `text` is one whole file's contents read
+  // fresh from disk, so a match can only ever be at position 0 — there is no
+  // constructible "BOM later in the file" case, since a stray U+FEFF midway
+  // through otherwise-valid TOML is not a byte-order mark at all, just a
+  // different bug. Left in for readability, not because a test needs it.
   const config = parseConfig(text.replace(/^﻿/, ''), path);
 
   const declared = expandHome(config.exportsDirectory);

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -708,11 +708,14 @@ estimate = "1200.00"
   });
 
   it('refuses a matcher with an extra key, even though category itself is fine', () => {
-    // If readMatcher's guard is bypassed despite the bogus key, it returns a
-    // usable matcher instead of null — this is the envelope's ONLY matcher,
-    // so "claims nothing" would never fire, and that second complaint is
-    // what actually distinguishes a bypassed guard from a working one; the
-    // bogus-key message alone is reported either way.
+    // Whether readMatcher's own guard fires here is not actually observable:
+    // readEnvelope captures its own "before" ahead of processing matches, so
+    // its OWN guard (schema.ts:257) re-catches the bogus-key problem and
+    // returns null regardless of what readMatcher did with its return value
+    // — readEnvelope's "claims nothing" check (schema.ts:259) sits AFTER
+    // that guard and is never reached either way. This test pins the correct
+    // end-to-end refusal; see the note on Problems in values.ts for why
+    // readMatcher's specific guard is not independently testable here.
     const bad = () =>
       parse({
         envelopes: `

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -163,6 +163,7 @@ describe('parseConfig — refusals that would otherwise be a wrong number', () =
     expect(bad).toThrow(/Nothing in sluice\.toml is a date/);
   });
 
+
   it('refuses a goal above its estimate', () => {
     const bad = () =>
       parse({
@@ -606,6 +607,22 @@ ${seasonal}
     expect(bad).not.toThrow(/gives neither/);
   });
 
+  it('gives both forms exactly one complaint, not one plus "months"/"weights" unknown', () => {
+    // readSeasonal marks "months" and "weights" read with r.skip() before
+    // r.done() runs, specifically so a legitimate key does not also get
+    // flagged as unrecognised just because this branch chose not to use it.
+    // Without that, "gives both" would arrive alongside two spurious "is not
+    // a key sluice knows" complaints about the very keys that triggered it.
+    let message = '';
+    try {
+      withSeasonal('seasonal = { months = [6], weights = [1,1,1,1,1,1,1,1,1,1,1,1] }');
+    } catch (error) {
+      message = (error as ConfigError).message;
+    }
+    expect(message).toMatch(/gives both/);
+    expect(message).toMatch(/has 1 problem:/);
+  });
+
   it('reports an unknown key alongside giving both forms', () => {
     const bad = () =>
       withSeasonal('seasonal = { months = [6], weights = [1,1,1,1,1,1,1,1,1,1,1,1], bogus = 1 }');
@@ -621,6 +638,176 @@ ${seasonal}
     // The months branch builds its own twelve zeros and returns before the
     // all-zero check, which guards only the weights branch.
     expect(() => withSeasonal('seasonal = { months = [] }')).toThrow(/List the months/);
+  });
+});
+
+describe('parseConfig — a good first field does not excuse a bad later one', () => {
+  // Six readers share one idiom: `if (X === null || problems.count !== before)
+  // return null;`. It looks redundant — X becomes null only via a `fail()` call
+  // that has already bumped `problems.count` — but every one of the six also
+  // calls `r.done()`, or reads a later field, or reads a nested table, between
+  // capturing `before` and this check. Any of those can add a problem while X
+  // itself parsed fine, and the `|| problems.count !== before` half is what
+  // catches that case. None of the six had a test where X succeeds and
+  // something else in the same table fails, so that half of the guard had
+  // never been exercised.
+
+  it("refuses a seasonal months table with an extra key, even though months itself is fine", () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries" }]
+estimate = "1200.00"
+seasonal = { months = [6], bogus = 1 }
+`,
+      });
+    expect(bad).toThrow(/seasonal\.bogus" is not a key sluice knows/);
+  });
+
+  it('refuses a bad weights shape, which nothing had exercised', () => {
+    expect(() =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries" }]
+estimate = "1200.00"
+seasonal = { weights = "not a list" }
+`,
+      }),
+    ).toThrow(/must be a list of whole numbers/);
+  });
+
+  it('refuses a seasonal weights table with an extra key, even though weights itself is fine', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries" }]
+estimate = "1200.00"
+seasonal = { weights = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], bogus = 1 }
+`,
+      });
+    expect(bad).toThrow(/seasonal\.bogus" is not a key sluice knows/);
+  });
+
+  it('refuses a matcher with a bad category type, which nothing had exercised', () => {
+    expect(() =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = 5 }]
+estimate = "1200.00"
+`,
+      }),
+    ).toThrow(/must be text/);
+  });
+
+  it('refuses a matcher with an extra key, even though category itself is fine', () => {
+    // If readMatcher's guard is bypassed despite the bogus key, it returns a
+    // usable matcher instead of null — this is the envelope's ONLY matcher,
+    // so "claims nothing" would never fire, and that second complaint is
+    // what actually distinguishes a bypassed guard from a working one; the
+    // bogus-key message alone is reported either way.
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries", bogus = 1 }]
+estimate = "1200.00"
+`,
+      });
+    expect(bad).toThrow(/matches\[0\]\.bogus" is not a key sluice knows/);
+  });
+
+  it('refuses an envelope with no matches key at all, not just an empty one', () => {
+    // Absent and empty are different refusals with different messages — "matches
+    // is empty" already had a test; a wholly absent key had not, and it is the
+    // one that would crash instead of refusing gracefully if the fallback that
+    // guards against it were ever removed.
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+estimate = "1200.00"
+`,
+      });
+    expect(bad).toThrow(/"envelopes\.food\.matches" is missing/);
+  });
+
+  it('refuses an envelope with a good name but a malformed estimate', () => {
+    const bad = () =>
+      parse({
+        envelopes: `
+[envelopes.food]
+name = "Food"
+matches = [{ category = "Groceries" }]
+estimate = "not an amount"
+`,
+      });
+    expect(bad).toThrow(/not an amount/);
+  });
+
+  it('refuses an income source with a good label but a malformed amount', () => {
+    const bad = () =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+[[people.alice.income]]
+label = "Salary"
+monthly = "not an amount"
+`,
+      });
+    expect(bad).toThrow(/not an amount/);
+  });
+
+  it('refuses an income source with a bad label type, which nothing had exercised', () => {
+    expect(() =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+[[people.alice.income]]
+label = 5
+monthly = "3200.00"
+`,
+      }),
+    ).toThrow(/must be text/);
+  });
+
+  it("refuses a person with a good name whose income entry is itself malformed", () => {
+    // Not the same case as the income-source test above, even though the
+    // fixture looks similar: that one exercises readIncome's own guard from
+    // inside readIncome. This one exercises readPerson's guard, catching a
+    // problem a NESTED reader added to the shared `problems` object while
+    // the person's own `name` parsed fine — a different call site, a
+    // different survivor, and the malformed amount has to be on a field
+    // readPerson itself never touches directly, or the name check alone
+    // could coincidentally cover it. `annual` on a second income entry does
+    // that: the first entry is fine, so income.length > 0 by the time
+    // readPerson's guard runs, isolating the failure to the second entry's
+    // own readIncome call rather than to anything readPerson reads itself.
+    const bad = () =>
+      parse({
+        people: `
+[people.alice]
+name = "Alice"
+[[people.alice.income]]
+label = "Salary"
+monthly = "3200.00"
+[[people.alice.income]]
+label = "Bonus"
+annual = "not an amount"
+`,
+      });
+    expect(bad).toThrow(/not an amount/);
   });
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -152,6 +152,7 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
   if (hasMonths) {
     const months = r.integerArray('months');
     r.done();
+    // See the comment on Problems in values.ts for why this is not the redundant disjunction it looks like.
     if (months === null || problems.count !== before) return null;
     if (months.length === 0) {
       problems.add(`"${r.where}.months" is empty. List the months the money falls in.`);
@@ -172,6 +173,7 @@ function readSeasonal(r: Reader, problems: Problems): SeasonalWeights | null {
 
   const weights = r.integerArray('weights');
   r.done();
+  // See the comment on Problems in values.ts.
   if (weights === null || problems.count !== before) return null;
 
   if (weights.length !== 12) {
@@ -208,6 +210,7 @@ function readMatcher(r: Reader, problems: Problems): EnvelopeMatcher | null {
   const subCategory = r.optionalString('sub_category');
   const declaredSub = r.has('sub_category');
   r.done();
+  // See the comment on Problems in values.ts.
   if (category === null || problems.count !== before) return null;
 
   if (!declaredSub) return { kind: 'category', category };
@@ -237,6 +240,11 @@ function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig
   const before = problems.count;
   const name = r.string('name');
   const matchReaders = r.tableArray('matches');
+  // `?? []`, not `matchReaders!`: matchReaders is null whenever the
+  // "matches" key is absent or malformed, and this line runs before
+  // readEnvelope's own guard below, so the fallback is what stands between a
+  // missing key and a crash trying to .map() over null. The guard still
+  // catches the missing-key problem a moment later, via problems.count.
   const matches = (matchReaders ?? [])
     .map((m) => readMatcher(m, problems))
     .filter((m): m is EnvelopeMatcher => m !== null);
@@ -245,6 +253,7 @@ function readEnvelope(id: string, r: Reader, problems: Problems): EnvelopeConfig
   const seasonalReader = r.optionalTable('seasonal');
   const seasonal = seasonalReader === null ? null : readSeasonal(seasonalReader, problems);
   r.done();
+  // See the comment on Problems in values.ts.
   if (name === null || problems.count !== before) return null;
 
   if (matches.length === 0) {
@@ -305,6 +314,7 @@ function readIncome(r: Reader, problems: Problems): IncomeSource | null {
   const monthly = r.optionalMoney('monthly');
   const annual = r.optionalMoney('annual');
   r.done();
+  // See the comment on Problems in values.ts.
   if (label === null || problems.count !== before) return null;
 
   if (declaredMonthly && declaredAnnual) {
@@ -345,6 +355,7 @@ function readPerson(id: string, r: Reader, problems: Problems): Person | null {
     .map((entry) => readIncome(entry, problems))
     .filter((entry): entry is IncomeSource => entry !== null);
   r.done();
+  // See the comment on Problems in values.ts.
   if (name === null || problems.count !== before) return null;
 
   if (income.length === 0) {
@@ -357,6 +368,13 @@ function readPerson(id: string, r: Reader, problems: Problems): Person | null {
   }
 
   const labels: string[] = [];
+  // Unlike matches' fallback above, this `?? []` is unreachable rather than
+  // load-bearing: rawLabels is null only when "transfer_labels" is malformed
+  // (stringArray calls fail()), and that fail() runs before readPerson's own
+  // guard, which already returned null by the time this loop is reached.
+  // Verified: replacing it with a `!` assertion still passes every test.
+  // Kept as `?? []` anyway — cheaper to read as "defensive" than to prove
+  // unreachable again the next time this function is touched.
   for (const [i, raw] of (declaredLabels ? (rawLabels ?? []) : []).entries()) {
     const label = normaliseLabel(raw);
     if (label === '') {

--- a/src/config/values.ts
+++ b/src/config/values.ts
@@ -29,8 +29,9 @@ import { parseAmount, AmountParseError, type Cents } from '../core/money.ts';
  */
 /**
  * Six places in schema.ts read `if (X === null || problems.count !== before)
- * return null;` — one per reader function, right after its first required
- * field. It looks like the two halves are redundant with each other: every
+ * return null;`, right after each's first required field, across five reader
+ * functions — readSeasonal has two, one per branch of its months/weights
+ * choice. It looks like the two halves are redundant with each other: every
  * accessor that returns null has already called `add()` (directly, via
  * `fail()`, or via `take()`'s date-refusal branch) within that same call, so
  * `X === null` implies `problems.count !== before` in every case — proven by

--- a/src/config/values.ts
+++ b/src/config/values.ts
@@ -27,6 +27,47 @@ import { parseAmount, AmountParseError, type Cents } from '../core/money.ts';
  * while and rendered nowhere, which is how it was found: structure nothing reads
  * is structure that will drift away from the thing it claims to describe.
  */
+/**
+ * Six places in schema.ts read `if (X === null || problems.count !== before)
+ * return null;` — one per reader function, right after its first required
+ * field. It looks like the two halves are redundant with each other: every
+ * accessor that returns null has already called `add()` (directly, via
+ * `fail()`, or via `take()`'s date-refusal branch) within that same call, so
+ * `X === null` implies `problems.count !== before` in every case — proven by
+ * reading every accessor in this file, not assumed.
+ *
+ * It is NOT redundant to keep, for two separate reasons:
+ *
+ * 1. **Type narrowing.** Every one of the six reads more of the table after
+ *    this line and uses the first field as non-null (`months.length`,
+ *    `category` embedded in a returned object, ...). Dropping the `X ===
+ *    null` half compiles to a runtime-correct but type-UNSAFE function:
+ *    TypeScript cannot see that `problems.count !== before` implies `X` is
+ *    non-null, and refuses to narrow it. Verified directly — removing it
+ *    produces `'X' is possibly 'null'` at every later use.
+ * 2. **The right half is not redundant with the left, in principle.** Every one
+ *    of the six reads more fields, or calls `done()`, or calls a nested
+ *    reader, between capturing `before` and this check — and any of those
+ *    can add a problem while the FIRST field parsed fine. `X === null`
+ *    alone would miss that case entirely.
+ *
+ * In practice, verified by mutating every half of all six checks and running
+ * the suite: only two of the resulting 24 mutants are killed today (both on
+ * `readSeasonal`, both because bypassing them lets `null` reach a `.length`
+ * read one line later and crash). The other 22 are not observable through
+ * `parseConfig`'s public surface as it stands — every one of the six reader
+ * functions is either itself called from within another reader's own
+ * before/after window (so the outer guard re-catches whatever the inner one
+ * would have), or its return value only ever reaches a check
+ * (`checkEnvelopesDoNotOverlap`, `checkLabelsDoNotCollide`) that inspects a
+ * field the corruption does not touch, before the same top-level
+ * `problems.count > 0` throw fires regardless. That is a fact about today's
+ * call graph, not a proof the right half is pointless: it is what keeps a
+ * later refactor — flattening the nesting, or adding a check that inspects
+ * the corrupted field — from silently reopening a hole. Kept for that
+ * reason, not chased with more fixtures to force the remaining 22 mutants to
+ * die.
+ */
 export class Problems {
   private readonly items: string[] = [];
 


### PR DESCRIPTION
Closes #317. Stacked on #331 — merge #327, #329, #330, #331 first.

## The issue's central claim didn't survive checking

`src/config` moved from 81.32% to **83.46%** — but the interesting part isn't the number.

**"Roughly 15 sites" was 6.** The other 9 were mutant survivors, mistaken for sites when the issue was filed.

**"The two operands are redundant with each other" is provably wrong in general.** Every one of the six sites reads more fields, calls `r.done()`, or calls a nested reader between capturing `before` and the check — any of which can add a problem while the *first* field parsed fine. That's exactly what `problems.count !== before` exists to catch, and `X === null` alone would miss it.

**What the issue's first proposed remedy — "drop the redundant `X === null` operand" — would actually have done: broken the build.** Verified directly: removing it produces `'X' is possibly 'null'` at every later use. TypeScript needs that check to narrow `X` from `T | null` to `T` for the rest of the function. The runtime redundancy (when it exists) is incidental to a type-safety requirement, not evidence the code can be simplified.

## What's actually true, verified rather than assumed

Mutated all 24 comparator-half variants across the six sites and ran the suite for each. Two are killed — both on `readSeasonal`, because bypassing them lets `null` reach a `.length` read one line later and crash. **The other 22 are not observable through `parseConfig`'s public surface as it stands.** Each of the six reader functions is either nested inside another reader's own before/after window (the outer guard re-catches whatever the inner one would have — `readMatcher` under `readEnvelope`, `readIncome` under `readPerson`), or its return value only reaches a check that inspects a field the corruption never touches, before the same top-level `problems.count > 0` throw fires regardless.

That's a fact about today's call graph, not proof the guard is pointless. It's what stops a later refactor — flattening the nesting, or adding a check that inspects the corrupted field — from silently reopening a hole. Documented once, centrally, on `Problems` in `values.ts`, rather than claiming a fix I couldn't verify or deleting code on a redundancy argument that doesn't hold.

## Four concrete holes

- **Timeouts on the pairwise overlap loops** — already covered by real assertions (`reports every overlapping pair`, `reports every colliding pair of labels`). Nothing to add; a loop-bound mutant hangs for any nonempty input regardless of assertion quality, which is why Stryker's "detected" doesn't mean "undertested" here.
- **`matches ?? []`** — a genuine gap. No test omitted an envelope's `matches` key entirely; removing the fallback crashes instead of refusing gracefully. Fixed, hand-verified.
- **`rawLabels ?? []`** — the mirror image. Provably unreachable: `readPerson`'s own guard already returns null before this line whenever `rawLabels` could be null. Verified by replacing it with a `!` assertion — every test still passes. Documented, not deleted, for the same defense-in-depth reason as the idiom above.
- **The `REFUSED` branch in `namedTables`** — turned out to already have a real test killing it. The issue's NoCoverage read was stale; confirmed by hand-removing the guard and watching the *existing* test go red.
- **`r.skip('months')` / `r.skip('weights')`** — genuine gaps, both fixed. Neither had a test checking that giving both forms produces exactly one complaint, not one plus two spurious "unknown key" ones.

## `load.ts`'s three, not itemised in the issue

A bare `~` (as opposed to `~/`) had no test. The ENOENT wrapper's `cause` was never asserted — the one that lets a debugger tell "no such file" from "permission denied," which look identical from the message alone. The BOM regex's `^` anchor is equivalent (text is always one whole file read fresh from disk, so a mid-file match is not constructible) and documented as such.

337 tests passing, `npm run check` green.

## Cumulative baseline after this stack

| | before this session | now |
|---|---|---|
| all of `src` | 81.14% | **84.97%** |
| `src/core` | 81.25% | 87.95% |
| `src/config` | 81.32% | 83.46% |
| `src/ingest` | 74.14% | 79.89% |
| `src/numbers` | 87.50% | 90.22% |
