### PR TITLE
generate: close the id-collision and slug gaps

### DIFF
--- a/src/numbers/generate.test.ts
+++ b/src/numbers/generate.test.ts
@@ -36,6 +36,18 @@ describe('generateEnvelopeBlock', () => {
     expect(block).toContain('estimate = "40.00"');
   });
 
+  it('ignores a pair whose only spending falls in a different year entirely', () => {
+    // Every other year-filter test still has SOME spending in the target
+    // year for the same pair, so the filter's role there is to trim an
+    // amount, not to decide whether the envelope exists at all. This pair
+    // has nothing in 2026, so it must not appear in the block at all.
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2025-03-05', amount: -5000, category: 'Loisirs et vacances', subCategory: 'Cinema' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    expect(block).not.toContain('loisirs_et_vacances_cinema');
+  });
+
   it('derives the seasonal shape from the SAME year, not the year before', () => {
     const ledger = ledgerOf([
       tx({ occurredOn: '2025-06-05', amount: -99999, category: 'Alimentation', subCategory: 'Supermarche' }),
@@ -117,6 +129,37 @@ describe('generateEnvelopeBlock', () => {
     const block = generateEnvelopeBlock(ledger, null, 2026);
     expect(block).toContain('[envelopes.a_b_c]');
     expect(block).toContain('[envelopes.a_b_c_2]');
+  });
+
+  it('keeps disambiguating past the second collision, _2 and _3 both', () => {
+    // A single collision cannot tell +suffix from -suffix: both put the
+    // second pair at _2. Only a THIRD pair sharing the same base can, since
+    // -1 would put it at _1 (colliding with the un-suffixed original)
+    // instead of _3.
+    const ledger = ledgerOf([
+      tx({ id: 'a', occurredOn: '2026-01-05', amount: -1000, category: 'A B', subCategory: 'C' }),
+      tx({ id: 'b', occurredOn: '2026-01-06', amount: -2000, category: 'A', subCategory: 'B C' }),
+      tx({ id: 'c', occurredOn: '2026-01-07', amount: -3000, category: 'A B C', subCategory: '' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    expect(block).toContain('[envelopes.a_b_c]');
+    expect(block).toContain('[envelopes.a_b_c_2]');
+    expect(block).toContain('[envelopes.a_b_c_3]');
+  });
+
+  it('collapses a run of punctuation to one underscore, not one per character', () => {
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-01-05', amount: -1000, category: 'Loisirs!!!vacances', subCategory: 'Cinema' }),
+    ]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    expect(block).toContain('[envelopes.loisirs_vacances_cinema]');
+    expect(block).not.toContain('loisirs___vacances');
+  });
+
+  it('falls back to "envelope" for a pair that slugs to nothing at all', () => {
+    const ledger = ledgerOf([tx({ occurredOn: '2026-01-05', amount: -1000, category: '!!!', subCategory: '???' })]);
+    const block = generateEnvelopeBlock(ledger, null, 2026);
+    expect(block).toContain('[envelopes.envelope]');
   });
 
   it('says so when there is nothing new to configure', () => {

--- a/src/numbers/generate.ts
+++ b/src/numbers/generate.ts
@@ -121,6 +121,13 @@ function slugify(text: string): string {
     .replace(/[\u0300-\u036f]/g, '') // combining diacritical marks, once NFD has split them off
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '_')
+    // The trailing "+" on each half of this regex is equivalent, not
+    // decorative: the line above already collapses every run of non-alnum
+    // characters, including any run of literal underscores, into exactly
+    // one "_" — so by the time this line runs, a leading or trailing run
+    // can never be longer than one character. Verified across 200k
+    // randomised inputs: max observed run length 1. "+" matches the intent
+    // ("any run") even though "^_|_$" would behave identically today.
     .replace(/^_+|_+$/g, '');
   return base === '' ? 'envelope' : base;
 }


### PR DESCRIPTION
Closes #318. Stacked on #332 — merge #327, #329, #330, #331, #332 first.

Four remedies, all from the issue's own list, all hand-verified by mutating the source and confirming the specific new test goes red — not the suite in aggregate.

- **The `_2`/`_3` gap.** A single collision can't tell `suffix += 1` from `-= 1` — both land the second pair at `_2`. A third pair sharing the same base can: `-1` would collide it at `_1` instead of landing on `_3`. Added.
- **Two regex survivors on the punctuation-collapsing quantifier** (`Loisirs!!!vacances` now asserted to slug as `loisirs_vacances_cinema`, not `loisirs___vacances_cinema`), and the **empty-slug fallback** for a category that slugs to nothing at all (`!!!` / `???`).
- **The year filter's `||` → `&&`**, plus both operand-pinned-false variants. The existing "worked by hand" estimate test has an other-year row, but it always shares same-year spending on the same pair too — never isolates the case where a pair's *only* spending is in the wrong year. Added a fixture where it's the only spending, asserting the pair doesn't appear in the output at all.

## Two of the four trim-regex survivors turned out to be equivalent

`/^_+|_+$/`'s `+` quantifiers can never see a run longer than one character — the line above it already collapses every run of non-alnum characters, *including runs of literal underscores*, down to a single `_`. Verified across 200k randomised inputs before writing that down, not after.

## The timeout stays a timeout

The empty-body `while` loop mutant hangs given any collision at all, including in the mutated tests — that's the correct, unavoidable behaviour for that specific mutation, not something a better test converts into a real assertion. Same shape as the pairwise-loop-bound timeouts closed in #317.

341 tests passing, `npm run check` green.
