### PR TITLE
reconcile: close the card-matching and settlement-slot survivors

### DIFF
--- a/src/ingest/reconcile.test.ts
+++ b/src/ingest/reconcile.test.ts
@@ -284,17 +284,6 @@ describe('reconcileSettlements', () => {
     expect(report.checks[0]?.cardNumber).toBe(UNIDENTIFIED_CARD);
   });
 
-  it('reads the card number past surrounding whitespace in the label', () => {
-    const account = statementOf(
-      [{ ...charge('04/08/2026', '-180,00', '1111'), label: '  DEBIT DIFFERE N° ...1111  ' }],
-      '00000000001_01012024_31122024.ofx',
-      { ...WINDOW, balance: '+100.00' },
-    );
-
-    const report = reconcileSettlements(ledgerOf([account]));
-    expect(report.checks[0]?.cardNumber).toBe('1111');
-  });
-
   it('surfaces a settlement whose label does not name a card', () => {
     // The sub-category already proved it is a settlement. Dropping it for want
     // of a parseable label would recreate the worst failure here: an account

--- a/src/ingest/reconcile.test.ts
+++ b/src/ingest/reconcile.test.ts
@@ -137,6 +137,20 @@ describe('reconcileSettlements', () => {
     expect(report.mismatched).toBe(1);
   });
 
+  it('refuses in-flight for a genuinely future settlement too, with no account export', () => {
+    // The test above uses a settlement date safely in the past, which stays a
+    // mismatch under "hasAccount" inverted to include card sources — the date
+    // comparison alone happens to still say no. This one settles after the
+    // card's own data is current, which a real account WOULD have called
+    // in-flight; with no account at all, it has to stay a mismatch regardless.
+    const card = statementOf([buy('11/08/2026', '04/09/2026', '-7,00')],
+      'carte_1111_01012024_31122024.ofx', { ...WINDOW, balance: '-7.00' });
+
+    const report = reconcileSettlements(ledgerOf([card]));
+    expect(report.inFlight).toBe(0);
+    expect(report.mismatched).toBe(1);
+  });
+
   it('judges pending against when the data is current, not the range requested', () => {
     // Asking the bank for a whole calendar year in August returns a December
     // end date over data that stops today. Trusting that end date would place
@@ -239,6 +253,46 @@ describe('reconcileSettlements', () => {
     expect(report.checks.map((c) => c.cardNumber)).not.toContain('2026');
     expect(report.checks.map((c) => c.cardNumber)).toContain(UNIDENTIFIED_CARD);
     expect(report.mismatched).toBeGreaterThan(0);
+  });
+
+  it('does not treat non-whitespace before the digits as part of the ellipsis gap', () => {
+    // The pattern allows whitespace, and only whitespace, between "..." and
+    // the four digits — a label where something else sits in that gap must
+    // not be read as naming a card at all.
+    const account = statementOf(
+      [{ ...charge('04/08/2026', '-180,00', '1111'), label: 'DEBIT DIFFERE N° ...XX1111' }],
+      '00000000001_01012024_31122024.ofx',
+      { ...WINDOW, balance: '+100.00' },
+    );
+
+    const report = reconcileSettlements(ledgerOf([account]));
+    expect(report.checks[0]?.cardNumber).toBe(UNIDENTIFIED_CARD);
+  });
+
+  it('refuses a run of five digits rather than guessing the first four', () => {
+    // The lookahead exists so a run longer than four digits is refused as
+    // ambiguous, not silently truncated to its first four — the same
+    // "guessing is what produced the wrong answer" reasoning CARD_IN_LABEL
+    // is built on.
+    const account = statementOf(
+      [{ ...charge('04/08/2026', '-180,00', '1111'), label: 'DEBIT DIFFERE N° ...11111' }],
+      '00000000001_01012024_31122024.ofx',
+      { ...WINDOW, balance: '+100.00' },
+    );
+
+    const report = reconcileSettlements(ledgerOf([account]));
+    expect(report.checks[0]?.cardNumber).toBe(UNIDENTIFIED_CARD);
+  });
+
+  it('reads the card number past surrounding whitespace in the label', () => {
+    const account = statementOf(
+      [{ ...charge('04/08/2026', '-180,00', '1111'), label: '  DEBIT DIFFERE N° ...1111  ' }],
+      '00000000001_01012024_31122024.ofx',
+      { ...WINDOW, balance: '+100.00' },
+    );
+
+    const report = reconcileSettlements(ledgerOf([account]));
+    expect(report.checks[0]?.cardNumber).toBe('1111');
   });
 
   it('surfaces a settlement whose label does not name a card', () => {

--- a/src/ingest/reconcile.ts
+++ b/src/ingest/reconcile.ts
@@ -85,6 +85,11 @@ const CARD_IN_LABEL = /\.\.\.\s*(\d{4})(?!\d)/;
 export const UNIDENTIFIED_CARD = 'unidentified';
 
 function cardNumberOf(settlement: Transaction): string {
+  // `.trim()` is unreachable given today's ingest, not decorative: every
+  // `Transaction.label` is `row.csv.label` (ledger.ts), and csv.ts's own
+  // parser already trims it. Kept anyway — it costs nothing, and this
+  // function has no way to know the guarantee still holds the next time
+  // ledger.ts changes which side's label wins.
   return CARD_IN_LABEL.exec(settlement.label.trim())?.[1] ?? UNIDENTIFIED_CARD;
 }
 
@@ -123,6 +128,10 @@ export function reconcileSettlements(ledger: LedgerData): ReconciliationReport {
   // export stops in June, a July settlement is not "still to come" — it is a
   // charge the account file simply does not reach, and saying "in flight" would
   // book money as owed that was in fact paid months ago.
+  // `b > a` cannot be widened to `b >= a` observably: `Day` values are
+  // compared by value, not identity, so a tie leaves the reduce holding an
+  // equal string either way. Verified across ties, near-ties and empty
+  // input — no case where the two produce a different result.
   const dataCurrentTo = ledger.sources
     .map((s) => s.balanceAsOf)
     .reduce<Day | null>((a, b) => (a === null || b > a ? b : a), null);
@@ -145,6 +154,14 @@ export function reconcileSettlements(ledger: LedgerData): ReconciliationReport {
     readonly settlesOn: Day;
   }
   const slots = new Map<string, Slot>();
+  // The guard reads as "first slot for this key wins", but it cannot lose to
+  // a mutant that makes every call overwrite: `key` is derived from exactly
+  // `cardNumber` and `settlesOn`, so any two calls that produce the same key
+  // were passed the same two values, and the Slot they'd write is identical
+  // either way. Real card numbers never contain "|", so a collision between
+  // two DIFFERENT pairs is not constructible through this codebase's own
+  // data. Kept for readability — "first wins" is what the comment above it
+  // claims — not because a test can tell it apart from "last wins".
   const slotKey = (cardNumber: string, settlesOn: Day): string => {
     const key = `${cardNumber}|${settlesOn}`;
     if (!slots.has(key)) slots.set(key, { cardNumber, settlesOn });


### PR DESCRIPTION
Addresses `reconcile.ts` for #319 — the file the issue itself prioritized ("focused on reconcile.ts first, since the others are shallower"). Stacked on #333 — merge #327, #329, #330, #331, #332, #333 first.

The remaining ~54 survivors across `sources.ts`, `load.ts` and `join.ts` are follow-up #334, filed separately so this PR stays reviewable and so the cost of that remaining work is visible on its own.

## Five items, checked one at a time

Two turned out to be real gaps. Two turned out to be equivalent mutants once followed through to what they can actually change. One is equivalent for a reason worth stating precisely rather than leaving unexplained.

**Real gaps, closed:**

- **The card regex's two directions of loosening.** `\s*` → `\S*` let non-whitespace between `...` and the digits count as the gap — `...XX1111` now correctly stays unidentified rather than reading `1111`. `(?!\d)` → `(?!\D)` let a five-digit run be silently truncated to its first four — now refused as ambiguous, matching the file's own "guessing is what produced the wrong answer" reasoning.
- **`hasAccount`'s `===` → `!==`.** The existing "no account export" test used a settlement dated safely in the past, which stays a `mismatch` either way the comparison runs — the date check alone happens to agree regardless of `hasAccount`. Added a genuinely future settlement, which a real account *would* call in-flight; with no account at all it has to stay a mismatch no matter what the (mutated) comparison says.

**Equivalent, documented rather than chased:**

- **`!slots.has(key)` → `true`.** The composite key is derived from exactly the two fields the `Slot` stores, so any two calls landing on the same key were passed the same `cardNumber` and `settlesOn` — the `Slot` they'd write is identical either way. A collision between two *different* pairs would need a card number containing `|`, which nothing in this codebase's data can produce.
- **The latest-day reduce's `b > a` → `b >= a`.** `Day` values compare by value, not identity; a tie leaves the reduce holding an equal string regardless of which side "wins" the comparison. Verified across ties, near-ties and empty input.
- **`.trim()` in `cardNumberOf`.** Provably unreachable given today's ingest: every `Transaction.label` is `row.csv.label` (`ledger.ts`), and `csv.ts`'s own parser already trims it before the label ever reaches this function.

345 tests passing, `npm run check` green.
