### PR TITLE
numbers: land on the boundaries the issue named — and one it didn't

### DIFF
--- a/src/numbers/checks.test.ts
+++ b/src/numbers/checks.test.ts
@@ -114,6 +114,17 @@ describe('checkPlan — plannedTotal, trailingYearActual, drift', () => {
     expect(result.plannedTotal).toBe(120000);
     expect(result.drift).toBe(30000);
   });
+
+  it('excludes a non-movement transaction inside the trailing window', () => {
+    // The window and the kind check are two separate conditions on the same
+    // filter — a transfer landing inside the date range still has to be
+    // excluded, on kind alone, not just on date.
+    const result = check({}, [
+      { occurredOn: '2026-06-01', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' },
+      { kind: 'transfer-in', occurredOn: '2026-06-05', amount: 500000 },
+    ], '2026-06-15');
+    expect(result.trailingYearActual).toBe(3000);
+  });
 });
 
 describe('checkPlan — worstObservedMonth and bufferSufficient', () => {

--- a/src/numbers/consumption.test.ts
+++ b/src/numbers/consumption.test.ts
@@ -91,4 +91,17 @@ seasonal = { months = [7] }
     const consumption = computeConsumption(ledger, resolved, '2026-06-01' as Day);
     expect(consumption.map((c) => c.envelope)).toEqual(resolved);
   });
+
+  it('counts a transaction dated exactly on referenceDay as year-to-date', () => {
+    // referenceDay is "today" for the whole page. A transaction posted today
+    // has to count — excluding it would make the figure lag by a day for
+    // anyone checking their spending the same day it happened.
+    const config = numbersConfig();
+    const ledger = ledgerOf([
+      tx({ occurredOn: '2026-03-15', amount: -3000, category: 'Alimentation', subCategory: 'Supermarche' }),
+    ]);
+    const resolved = resolveEnvelopes(config, ledger);
+    const [c] = computeConsumption(ledger, resolved, '2026-03-15' as Day);
+    expect(c?.yearToDateSpent).toBe(3000);
+  });
 });

--- a/src/numbers/timeline.ts
+++ b/src/numbers/timeline.ts
@@ -32,12 +32,13 @@ export function monthlySpendTimeline(ledger: Ledger): readonly MonthlySpend[] {
   // Equivalent, not dead: bypassing this leaves `months` empty, so `first`
   // and `last` below are `undefined` (past the `!`, which is compile-time
   // only). `monthRange(undefined, undefined)`'s loop condition,
-  // `m <= undefined`, is false for any `m` — JS resolves any comparison
-  // against `undefined` to false — so the loop body never runs and it
-  // returns `[]` regardless. Verified directly: removing this guard changes
-  // nothing observable for any ledger with zero movements. Kept because it
-  // states the case explicitly rather than relying on a comparison quirk
-  // three lines away from the type-unsafe `!` that depends on it.
+  // `m <= undefined`, is false for any `m` — a relational comparison
+  // coerces `undefined` to `NaN`, and every relational comparison against
+  // `NaN` is false — so the loop body never runs and it returns `[]`
+  // regardless. Verified directly: removing this guard changes nothing
+  // observable for any ledger with zero movements. Kept because it states
+  // the case explicitly rather than relying on a comparison quirk three
+  // lines away from the type-unsafe `!` that depends on it.
   if (movements.length === 0) return [];
 
   const byMonth = new Map<Month, Transaction[]>();

--- a/src/numbers/timeline.ts
+++ b/src/numbers/timeline.ts
@@ -29,6 +29,15 @@ export interface MonthlySpend {
  */
 export function monthlySpendTimeline(ledger: Ledger): readonly MonthlySpend[] {
   const movements = ledger.transactions.filter((t) => t.kind === 'movement');
+  // Equivalent, not dead: bypassing this leaves `months` empty, so `first`
+  // and `last` below are `undefined` (past the `!`, which is compile-time
+  // only). `monthRange(undefined, undefined)`'s loop condition,
+  // `m <= undefined`, is false for any `m` — JS resolves any comparison
+  // against `undefined` to false — so the loop body never runs and it
+  // returns `[]` regardless. Verified directly: removing this guard changes
+  // nothing observable for any ledger with zero movements. Kept because it
+  // states the case explicitly rather than relying on a comparison quirk
+  // three lines away from the type-unsafe `!` that depends on it.
   if (movements.length === 0) return [];
 
   const byMonth = new Map<Month, Transaction[]>();


### PR DESCRIPTION
Closes #320. Stacked on #335 — merge #327, #329, #330, #331, #332, #333, #335 first. Last PR in this stack.

Two real gaps, one correction to the issue's own diagnosis — matching the pattern the rest of this stack has followed.

## `consumption.ts` — as filed

A transaction dated exactly `referenceDay` must count toward year-to-date spending. `referenceDay` is "today" for the whole page; excluding today's own spending would make the figure lag by a day for anyone checking mid-day. No fixture placed one there. Added, verified: weakening `<=` to `<` fails the new test specifically.

## `checks.ts` — not the case the issue named

The issue's proposed remedy was "one dated exactly `windowStart`" — but that boundary is *already* tested precisely, by an existing fixture labelled `window-start` at exactly 12 months back. The actual surviving mutant, checked against the report directly, is the `kind === 'movement'` half of the same filter, pinned to `true`. No test had a non-movement transaction landing inside the trailing-year window — a transfer sitting in-range could be silently counted as spending. Added.

## `timeline.ts` — also not the case the issue's prose suggested

"The remaining one" isn't a date-boundary mutant at all — it's the empty-ledger early return, unrelated to any edge. Verified equivalent rather than chased: `monthRange(undefined, undefined)`'s loop condition is `m <= undefined`, which JS resolves to `false` for any `m`, so the loop body never runs and `[]` comes back regardless of whether the guard fires. No ledger with zero movements can distinguish it. Documented in place — the guard's value is stating the case explicitly next to the type-unsafe `!` that depends on it, not runtime behavior a test can pin.

347 tests passing, `npm run check` green.

---

This is the last PR in the #316–#320 stack. Cumulative baseline once the whole stack merges:

| | before this session | now |
|---|---|---|
| all of `src` | 81.14% | **~85%** (final number after merge) |
| `src/core` | 81.25% | 87.95% |
| `src/config` | 81.32% | 83.46% |
| `src/ingest` | 74.14% | ~80% (reconcile.ts done; #334 tracks the rest) |
| `src/numbers` | 87.50% | 90%+ |
