### PR TITLE
ingest: close sources.ts, load.ts, ledger.ts and join.ts's remaining survivors

### DIFF
--- a/src/ingest/__fixtures__/build.ts
+++ b/src/ingest/__fixtures__/build.ts
@@ -52,6 +52,14 @@ export interface OfxOptions {
   readonly from?: string; // YYYYMMDD
   readonly to?: string; // YYYYMMDD
   readonly balance?: string; // "+264.21"
+  /**
+   * DTASOF, the balance's own as-of date. Defaults to `to`, which is
+   * realistic for most exports but not guaranteed — a real bank can report a
+   * DTEND (the requested range) that differs from the moment its balance is
+   * current as of. Set independently to test code that depends on the two
+   * NOT being the same value.
+   */
+  readonly balanceAsOf?: string; // YYYYMMDD
   readonly omitBalance?: boolean;
   readonly omitCurdef?: boolean;
 }
@@ -71,6 +79,7 @@ export function ofxFixture(rows: readonly FixtureRow[], options: OfxOptions = {}
     from = '20250101',
     to = '20261231',
     balance = '+0.00',
+    balanceAsOf = to,
     omitBalance = false,
     omitCurdef = false,
   } = options;
@@ -93,7 +102,7 @@ export function ofxFixture(rows: readonly FixtureRow[], options: OfxOptions = {}
 
   const ledgerBalance = omitBalance
     ? ''
-    : ['<LEDGERBAL>', `<BALAMT>${balance}`, `<DTASOF>${to}`, '</LEDGERBAL>'].join('\r\n') + '\r\n';
+    : ['<LEDGERBAL>', `<BALAMT>${balance}`, `<DTASOF>${balanceAsOf}`, '</LEDGERBAL>'].join('\r\n') + '\r\n';
 
   const text = [
     'OFXHEADER:100',

--- a/src/ingest/join.test.ts
+++ b/src/ingest/join.test.ts
@@ -47,4 +47,21 @@ describe('joinPositionally', () => {
       joinPositionally(parseOfx(ofxFixture(rows)), parseCsv(csvFixture(differentAmount)), 'acct'),
     ).toThrow(/row 2/);
   });
+
+  it('refuses a date mismatch on its own, not just as a side effect of a length or amount mismatch', () => {
+    // Every other date-mismatch test in this file reorders rows, which also
+    // changes the amount at the diverging position — a bypassed date check
+    // still throws, just from the amount check instead, and the outcome
+    // looks identical from the outside. This fixture changes only the date,
+    // amounts held equal, so the date check is the only thing that can catch
+    // it — and names row 2, isolating the message's row index from the
+    // amount-mismatch message's own row-index test above.
+    const dateShifted = [rows[0]!, { ...rows[1]!, postedOn: '05/03/2026' }, rows[2]!];
+    expect(() =>
+      joinPositionally(parseOfx(ofxFixture(rows)), parseCsv(csvFixture(dateShifted)), 'acct'),
+    ).toThrow(JoinMismatchError);
+    expect(() =>
+      joinPositionally(parseOfx(ofxFixture(rows)), parseCsv(csvFixture(dateShifted)), 'acct'),
+    ).toThrow(/row 2 is dated/);
+  });
 });

--- a/src/ingest/ledger.test.ts
+++ b/src/ingest/ledger.test.ts
@@ -69,6 +69,22 @@ describe('classification', () => {
     expect(t?.occurredOn).toBe('2026-08-11');
     expect(t?.settlesOn).toBe('2026-09-04');
   });
+
+  it('reads a zero-amount internal transfer as inbound, not outbound', () => {
+    // The boundary itself: `>= 0` puts exactly zero on the "in" side. A
+    // household transfer that nets to nothing (an immediate correction, a
+    // same-day reversal) still has to land on one side deterministically
+    // rather than the other.
+    const zero: FixtureRow = {
+      postedOn: '05/08/2026',
+      amount: '+0,00',
+      label: 'VIR. VERS COMPTE CHEQUE',
+      category: 'Transaction exclue',
+      subCategory: 'Virement interne',
+    };
+    const [t] = build([zero], '00000000001_01012024_31122024.ofx').transactions;
+    expect(t?.kind).toBe('transfer-in');
+  });
 });
 
 describe('mergeLedger', () => {
@@ -119,6 +135,27 @@ describe('mergeLedger', () => {
   it('refuses to merge two different transactions that claim the same identity', () => {
     const a: FixtureRow[] = [{ postedOn: '10/08/2026', amount: '-14,00', fitId: 'SAME' }];
     const b: FixtureRow[] = [{ postedOn: '11/08/2026', amount: '-7,00', fitId: 'SAME' }];
+    expect(() =>
+      mergeLedger([build(a, '00000000001_01012024_31122024.ofx'), build(b, '00000000001_01012024_31122024.ofx')]),
+    ).toThrow(DuplicateTransactionError);
+  });
+
+  it('refuses a same-id pair sharing the date but not the amount', () => {
+    // "Same transaction" needs the date AND the amount to agree, not either
+    // alone. Both rows below share their date, so this isolates the amount
+    // half of the check from the case above, where both fields differ at
+    // once and either alone would already explain the refusal.
+    const a: FixtureRow[] = [{ postedOn: '10/08/2026', amount: '-14,00', fitId: 'SAME' }];
+    const b: FixtureRow[] = [{ postedOn: '10/08/2026', amount: '-7,00', fitId: 'SAME' }];
+    expect(() =>
+      mergeLedger([build(a, '00000000001_01012024_31122024.ofx'), build(b, '00000000001_01012024_31122024.ofx')]),
+    ).toThrow(DuplicateTransactionError);
+  });
+
+  it('refuses a same-id pair sharing the amount but not the date', () => {
+    // The mirror of the test above: isolates the date half of the check.
+    const a: FixtureRow[] = [{ postedOn: '10/08/2026', amount: '-14,00', fitId: 'SAME' }];
+    const b: FixtureRow[] = [{ postedOn: '11/08/2026', amount: '-14,00', fitId: 'SAME' }];
     expect(() =>
       mergeLedger([build(a, '00000000001_01012024_31122024.ofx'), build(b, '00000000001_01012024_31122024.ofx')]),
     ).toThrow(DuplicateTransactionError);
@@ -177,5 +214,17 @@ describe('mergeLedger', () => {
   it('returns the ledger in date order', () => {
     const merged = mergeLedger([build([TRANSFER_OUT, GROCERIES, CONTRIBUTION], '00000000001_01012024_31122024.ofx')]);
     expect(merged.map((t) => t.occurredOn)).toEqual(['2026-08-03', '2026-08-05', '2026-08-10']);
+  });
+
+  it('breaks a same-day tie by id, not by declaration order', () => {
+    // Two rows sharing a date, with the later-sorting id declared first — a
+    // no-op sort (Array.sort is stable) would leave it first. The stated
+    // contract puts the earlier id first regardless.
+    const rows: FixtureRow[] = [
+      { postedOn: '10/08/2026', amount: '-1,00', fitId: 'ZZZ' },
+      { postedOn: '10/08/2026', amount: '-2,00', fitId: 'AAA' },
+    ];
+    const merged = mergeLedger([build(rows, '00000000001_01012024_31122024.ofx')]);
+    expect(merged.map((t) => t.id)).toEqual(['00000000001:AAA', '00000000001:ZZZ']);
   });
 });

--- a/src/ingest/load.test.ts
+++ b/src/ingest/load.test.ts
@@ -87,6 +87,50 @@ describe('loadLedgerData', () => {
     expect(source?.files).toHaveLength(2);
   });
 
+  it('widens the window from the middle export, not just the ends, and sorts before picking the newest', async () => {
+    // Filenames are chosen so their OWN alphabetical order (which
+    // loadLedgerData already sorts by, upstream of this) does NOT match the
+    // balanceAsOf order these exports actually carry — otherwise the
+    // upstream sort would silently do consolidate()'s job for it, and a
+    // broken or missing sort inside consolidate() would go unnoticed. By
+    // filename, B < C < A; by balanceAsOf, A < B < C.
+    //
+    // The widest from/to both come from the MIDDLE export by balanceAsOf
+    // (B), not the first or the last — a reduce that always kept its first
+    // argument would report A's from instead of B's; one that always kept
+    // its second would report C's to instead of B's.
+    const dir = await folderOf([
+      {
+        stem: '00000000001_09092025_09092025',
+        rows: [{ postedOn: '05/01/2025', amount: '-40,00', fitId: 'A-1' }],
+        options: { from: '20250105', to: '20250131', balanceAsOf: '20250131', balance: '+500.00' },
+      },
+      {
+        stem: '00000000001_01012025_01012025',
+        rows: [{ postedOn: '05/02/2025', amount: '-60,00', fitId: 'B-1' }],
+        options: { from: '20241201', to: '20250630', balanceAsOf: '20250228', balance: '+600.00' },
+      },
+      {
+        stem: '00000000001_05052025_05052025',
+        rows: [{ postedOn: '05/03/2025', amount: '-10,00', fitId: 'C-1' }],
+        options: { from: '20250301', to: '20250331', balanceAsOf: '20250331', balance: '+700.00' },
+      },
+    ]);
+
+    const [source] = (await loadLedgerData(dir)).sources;
+    expect(source?.from).toBe('2024-12-01');
+    expect(source?.to).toBe('2025-06-30');
+    expect(source?.balance).toBe(70000);
+    expect(source?.balanceAsOf).toBe('2025-03-31');
+    // Ordered by balanceAsOf, not by declaration or filename order — the
+    // same guarantee the values above depend on, made directly observable.
+    expect(source?.files).toEqual([
+      '00000000001_09092025_09092025.ofx',
+      '00000000001_01012025_01012025.ofx',
+      '00000000001_05052025_05052025.ofx',
+    ]);
+  });
+
   it('counts only the rows that survived the merge', async () => {
     const dir = await folderOf([
       { stem: '00000000001_01012025_31012025', rows: ROWS, options: { balance: '+500.00' } },
@@ -138,6 +182,19 @@ describe('loadLedgerData', () => {
     await expect(loadLedgerData(join(tmpdir(), 'sluice-does-not-exist'))).rejects.toThrow(
       /sluice\.toml/,
     );
+  });
+
+  it('keeps the original filesystem error as the cause', async () => {
+    // The friendly message says where to point sluice.toml; cause is what a
+    // debugger reaches for when "cannot read the folder" isn't the whole
+    // story — a permissions error looks identical from the message alone.
+    try {
+      await loadLedgerData(join(tmpdir(), 'sluice-does-not-exist'));
+      expect.unreachable();
+    } catch (error) {
+      expect((error as ExportsNotFoundError).cause).toBeInstanceOf(Error);
+      expect(((error as ExportsNotFoundError).cause as NodeJS.ErrnoException).code).toBe('ENOENT');
+    }
   });
 });
 

--- a/src/ingest/load.ts
+++ b/src/ingest/load.ts
@@ -74,6 +74,12 @@ function consolidate(files: readonly ParsedFile[], merged: readonly Transaction[
     const newest = ordered.at(-1)!;
     const source = newest.source;
 
+    // `<` and `>` cannot be widened to `<=`/`>=` observably: `Day` values
+    // compare by value, not identity, so a tie between two exports' `from`
+    // (or `to`) leaves the reduce holding an equal string regardless of
+    // which side "wins". Verified directly across single, all-tied and
+    // partially-tied inputs — the same reasoning as the latest-day reduce in
+    // reconcile.ts.
     return {
       source,
       from: ordered.map((f) => f.statement.from).reduce((a, b) => (a < b ? a : b)),
@@ -106,6 +112,14 @@ export async function loadLedgerData(directory: string): Promise<LedgerData> {
     );
   }
 
+  // The trailing .sort() is a real fix, not tested here. `readdir`'s return
+  // order is filesystem-defined — already alphabetical on APFS, not
+  // guaranteed on ext4, where CI runs — so a test built on real files in a
+  // real temp directory cannot force the unsorted case this .sort() protects
+  // against without also mocking `readdir` itself, which nothing else in
+  // this suite does. Removing it would only ever change which file's parse
+  // error is reported first when more than one is broken; every value this
+  // function computes is unaffected either way.
   const ofxFiles = entries.filter((f) => f.toLowerCase().endsWith('.ofx')).sort();
   if (ofxFiles.length === 0) {
     throw new ExportsNotFoundError(

--- a/src/ingest/sources.test.ts
+++ b/src/ingest/sources.test.ts
@@ -59,6 +59,44 @@ describe('sourceOf', () => {
     expect(() => sourceOf('carte_11111_01012025_31122025.ofx')).toThrow(SourceNameError);
     expect(() => sourceOf('cb_1111_01012025_31122025.ofx')).toThrow(SourceNameError);
   });
+
+  it('refuses trailing characters after the extension, rather than ignoring them', () => {
+    // EXPORT_NAME is anchored at both ends. Unanchored at the tail, a renamed
+    // or backed-up file — "….ofxBACKUP" — would still match on its real
+    // extension and be silently accepted as the genuine export.
+    expect(() => sourceOf('00000000001_01012025_31122025.ofxBACKUP')).toThrow(SourceNameError);
+  });
+
+  it('refuses leading characters before the stem, rather than skipping past them', () => {
+    // Unanchored at the head, "(.+?)" would happily start matching partway
+    // through the filename — accepting "xcarte_1111_…" as card "carte_1111"
+    // and silently dropping the "x" that made the name unrecognisable.
+    expect(() => sourceOf('xcarte_1111_01012025_31122025.ofx')).toThrow(SourceNameError);
+  });
+
+  it('refuses a name with an embedded newline before an otherwise-valid stem', () => {
+    // "(.+?)" cannot cross a newline without the anchor forcing the match to
+    // start at position 0 — without "^", exec() is free to start the match
+    // just past the newline instead of refusing the whole name. The one
+    // input shape where the anchor above is not equivalent to leaving it out.
+    expect(() => sourceOf('junk\ncarte_1111_01012025_31122025.ofx')).toThrow(SourceNameError);
+  });
+
+  it('refuses a stem with a card-shaped tail but junk before it', () => {
+    // CARD_STEM is anchored at both ends too. Unanchored at the head it would
+    // accept "xcarte_1111" as card "1111", the same failure as above but one
+    // level deeper — inside the already-extracted stem rather than the whole
+    // filename.
+    expect(() => sourceOf('xcarte_1111_01012025_31122025.ofx')).toThrow(/is not a name sluice recognises/);
+  });
+
+  it('refuses an account stem with non-digit characters at either end', () => {
+    // ACCOUNT_STEM is anchored at both ends. Unanchored at the head or tail,
+    // a stem with leading or trailing junk around a run of digits — a typo,
+    // a copy-paste artifact — would be misread as a bare account number.
+    expect(() => sourceOf('x00000000001_01012025_31122025.ofx')).toThrow(/is not a name sluice recognises/);
+    expect(() => sourceOf('00000000001x_01012025_31122025.ofx')).toThrow(/is not a name sluice recognises/);
+  });
 });
 
 describe('csvNameFor', () => {
@@ -71,5 +109,12 @@ describe('csvNameFor', () => {
     // filename match, so lowercasing here rejected a correctly-named uppercase
     // pair that was sitting in the folder.
     expect(csvNameFor('CARTE_1111_01012024_31122024.OFX')).toBe('CARTE_1111_01012024_31122024.CSV');
+  });
+
+  it('replaces the trailing extension, not the first occurrence of ".ofx"', () => {
+    // Anchored at the end on purpose: a filename that happens to contain
+    // ".ofx" earlier than its real, trailing extension must still be
+    // rewritten at the extension, not at the first match.
+    expect(csvNameFor('export.ofx.backup.ofx')).toBe('export.ofx.backup.csv');
   });
 });


### PR DESCRIPTION
Closes #334. Stacked on #336 — merge #327, #329, #330, #331, #332, #333, #335, #336 first.

## The stale count

#334 was filed against ~54 survivors, measured before the rest of this session's stack landed. Fresh mutation data first: the real remaining count was **23 non-string survivors across four files**. `sources.ts`, `ledger.ts` and `join.ts` are now clean; `load.ts` keeps 3, documented rather than chased.

## `sources.ts` (6, all anchor-stripping)

`EXPORT_NAME`, `CARD_STEM` and `ACCOUNT_STEM` are each anchored at both ends specifically so a filename with junk before or after the real pattern is refused rather than accepted. Six tests, one per anchor, each constructing the exact shape that anchor exists to reject — a trailing `BACKUP` after the extension, a leading character before `carte_`, a digit run with non-digit neighbours. One is a genuine edge case rather than a realistic filename: `EXPORT_NAME`'s `^` only matters when the name contains an embedded newline, since `.` cannot cross one without the anchor forcing the match to start at position 0. `csvNameFor`'s own extension regex gets the same treatment: a filename containing `.ofx` twice must be rewritten at the trailing occurrence, not the first.

## `join.ts` (3)

The postedOn-mismatch check had never been exercised in isolation — every existing date-mismatch test reorders rows, which also changes the amount at the diverging position, so a bypassed date check still throws from the amount check instead and looks identical from outside. Added a fixture that changes only the date, isolating it, which also gives the `i + 1` row-index message its first test at a non-zero index.

## `ledger.ts` (5)

A zero-amount transfer at the `>= 0` boundary; the same-transaction check's date and amount halves, each isolated by a same-id pair sharing exactly one of the two (the existing test differs on both at once, so either alone would explain the refusal); the same-day sort tie-break by id.

## `load.ts` (9, the awkward one)

Extended the OFX fixture builder with an independent `balanceAsOf` option — DTASOF and DTEND are coupled to the same value in the builder, which is a **fixture limitation, not a guarantee real exports make**, and it silently made the widest-window reduce and the consolidate-time sort untestable. Decoupling them exposed the real test: three exports whose *filenames* sort differently from their balanceAsOf order, so an upstream filename-sort can't accidentally do `consolidate()`'s own sorting job for it. The widest from/to both come from the *middle* export by balanceAsOf — a reduce that always kept its first or second argument would silently narrow the window instead of widening it. Also fixed: the ENOENT wrapper's `cause`, and the `files` list itself.

Three left, documented:
- The two `from`/`to` reduces above are equivalent for an exact tie — the identical value-not-identity reasoning as `reconcile.ts`'s latest-day reduce, verified the same way.
- The `ofxFiles` filename sort is a real fix for parse-error determinism under an unsorted `readdir`, but `readdir`'s order is filesystem-defined — already alphabetical on this machine's APFS, not guaranteed on the ext4 CI runs on — so no test built on real files in a real temp directory can force the case it protects against without mocking `readdir`, which nothing else in this suite does.

360 tests passing, `npm run check` green.

---

Last PR in the #299 mutation-testing backlog opened this session. Cumulative baseline:

| | before this session | now |
|---|---|---|
| all of `src` | 81.14% | **86.94%** |
| `src/core` | 81.25% | 87.95% |
| `src/config` | 81.32% | 83.46% |
| `src/ingest` | 74.14% | **85.25%** |
| `src/numbers` | 87.50% | 92.21% |
