### PR TITLE
core: pin MONTH_NAMES and the default `where` values, close #328

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,11 @@ here means finding one to cut.
 - **An envelope's `estimate` is a commitment, never regenerated in place.**
   `generateEnvelopeBlock()` (`src/numbers/generate.ts`) only ever returns
   TOML text for a human to paste; nothing in `app/` calls it.
+- **Error-message prose and `this.name` on every custom `Error` subclass are
+  deliberately left as surviving mutants, not tested.** Nothing anywhere
+  asserts `err.name`; every catch site matches by `instanceof` or
+  `toThrow(SomeErrorClass)`. Applies project-wide — filed once as a decision
+  on #328 rather than re-argued per class.
 - **There's no `docs/` folder, and no process documentation lives in this
   repo.** v0.1 had one — 201 lines of `CLAUDE.md` deferring to it, and 72%
   of that version's effort went to process instead of product. Anything

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ three minutes.
 
 It prints a score per directory rather than one for the whole tree, because the
 weakest surface otherwise hides behind the strongest — the spread is currently
-thirteen points. The baseline and the triage of every surviving mutant live on
+about ten points (83–94%). The baseline and the triage of every surviving mutant live on
 [#299](https://github.com/xavierbriand/sluice/issues/299); the gaps it found are
 tracked as their own issues rather than fixed inline, so the cost of each stays
 visible. No score threshold is enforced yet, deliberately: [#321](https://github.com/xavierbriand/sluice/issues/321)

--- a/src/core/dates.test.ts
+++ b/src/core/dates.test.ts
@@ -191,7 +191,7 @@ describe('month arithmetic', () => {
     // MONTH_NAMES is rendered straight onto the page. A reordered or
     // corrupted entry would be a confident wrong month beside a correct
     // figure — one assertion over all twelve closes every entry at once.
-    const names = Array.from({ length: 12 }, (_, i) => formatMonthLong(makeMonth(2026, i + 1)));
+    const names = monthRange(makeMonth(2026, 1), makeMonth(2026, 12)).map(formatMonthLong);
     expect(names).toEqual([
       'Jan 2026', 'Feb 2026', 'Mar 2026', 'Apr 2026', 'May 2026', 'Jun 2026',
       'Jul 2026', 'Aug 2026', 'Sep 2026', 'Oct 2026', 'Nov 2026', 'Dec 2026',

--- a/src/core/dates.test.ts
+++ b/src/core/dates.test.ts
@@ -92,6 +92,12 @@ describe('parseFrenchDay', () => {
     // is asserted rather than left to chance.
     expect(parseFrenchDay('  14/08/2026  ')).toBe('2026-08-14');
   });
+
+  it('names the field "date" when no caller says otherwise', () => {
+    // Every real caller passes its own `where`; only the default had gone
+    // unpinned.
+    expect(() => parseFrenchDay('not-a-date')).toThrow(/\(date\)/);
+  });
 });
 
 describe('parseOfxDay', () => {
@@ -140,6 +146,10 @@ describe('parseOfxDay', () => {
     // return the 3rd west of UTC, turning a paid month into a missed one.
     expect(parseOfxDay('20260804')).toBe('2026-08-04');
   });
+
+  it('names the field "date" when no caller says otherwise', () => {
+    expect(() => parseOfxDay('not-a-date')).toThrow(/\(date\)/);
+  });
 });
 
 describe('month arithmetic', () => {
@@ -175,5 +185,16 @@ describe('month arithmetic', () => {
 
   it('formats a month for a chart label', () => {
     expect(formatMonthLong(makeMonth(2026, 8))).toBe('Aug 2026');
+  });
+
+  it('names every month, not just the ones spot-checked elsewhere', () => {
+    // MONTH_NAMES is rendered straight onto the page. A reordered or
+    // corrupted entry would be a confident wrong month beside a correct
+    // figure — one assertion over all twelve closes every entry at once.
+    const names = Array.from({ length: 12 }, (_, i) => formatMonthLong(makeMonth(2026, i + 1)));
+    expect(names).toEqual([
+      'Jan 2026', 'Feb 2026', 'Mar 2026', 'Apr 2026', 'May 2026', 'Jun 2026',
+      'Jul 2026', 'Aug 2026', 'Sep 2026', 'Oct 2026', 'Nov 2026', 'Dec 2026',
+    ]);
   });
 });

--- a/src/core/dates.ts
+++ b/src/core/dates.ts
@@ -27,6 +27,15 @@ const DAY = /^\d{4}-\d{2}-\d{2}$/;
 const FRENCH = /^(\d{2})\/(\d{2})\/(\d{4})$/;
 const OFX = /^(\d{4})(\d{2})(\d{2})/;
 
+// Error-message prose and `this.name` are left as permanent, deliberate
+// survivors across every error class in `src/` — ten of them, this one
+// included. Nothing anywhere asserts `err.name`; every catch site matches
+// with `instanceof` or `toThrow(SomeErrorClass)`. Mutating a sentence like
+// the one below only tests whether some assertion happens to regex a
+// fragment of it, which is the reason #323 excluded string mutation in
+// `src/config` in the first place — the same reasoning applies here, just
+// not worth a `Stryker disable` directive for every line it touches. Filed
+// as a decision on #328, not re-triaged per class.
 export class DateParseError extends Error {
   readonly raw: string;
   readonly where: string;

--- a/src/core/money.test.ts
+++ b/src/core/money.test.ts
@@ -73,6 +73,12 @@ describe('parseAmount', () => {
   it('names where the bad value came from', () => {
     expect(() => parseAmount('oops', 'export.csv:42 Debit')).toThrow(/export\.csv:42 Debit/);
   });
+
+  it('names the field "amount" when no caller says otherwise', () => {
+    // Every real caller passes its own `where`; only the default had gone
+    // unpinned.
+    expect(() => parseAmount('n/a')).toThrow(/\(amount\)/);
+  });
 });
 
 describe('sum', () => {

--- a/src/core/money.ts
+++ b/src/core/money.ts
@@ -14,6 +14,8 @@ export type Cents = number;
 
 const AMOUNT = /^[+-]?\d+(?:[.,]\d{1,2})?$/;
 
+// Prose and `this.name` deliberately left surviving — see the comment on
+// DateParseError in dates.ts.
 export class AmountParseError extends Error {
   readonly raw: string;
   readonly where: string;


### PR DESCRIPTION
## Summary

`src/core`'s mutation score was 87.95% with the newly-visible `StringLiteral` survivors (#324/#328's split from #323). This closes #328's half of that: the 22 `src/core` string survivors.

- **MONTH_NAMES** (`dates.ts`) — rendered straight onto the page by `formatMonthLong`, but no test asserted the full array. One test now checks all twelve months.
- **The `where = 'date'`/`'amount'` parameter defaults** (`parseFrenchDay`, `parseOfxDay`, `parseAmount`) — every real caller passes its own `where`; only the default value had never been exercised.
- **Error-message prose and `this.name`** — documented as a deliberate, permanent survivor rather than tested. Nothing anywhere asserts `err.name`; every catch site matches by `instanceof`/`toThrow(SomeErrorClass)`. The write-up lives on `DateParseError` in `dates.ts`, with a pointer from `AmountParseError`; it applies to all ten `this.name` sites in `src/`, not just these two — #324 will point ingest's six back at it rather than re-deciding the same thing.

## Verification

- `npm run check` — 364 tests pass (was 359).
- `npm run mutate` — `src/core` moved from 87.95% to 93.98% (28 → 13 survivors). Confirmed via `mutation.json`, not just the aggregate: every MONTH_NAMES entry and both `where` defaults are now `Killed`; the 13 remaining survivors are the pre-existing documented equivalents (the `allocate` comparator ties, the `EUR` `Intl.NumberFormat` constructor args, the `DAY` regex anchors) plus the two `this.name` decorations documented above.
- `README.md`'s mutation-spread line updated from "thirteen points" (already stale before this PR) to the current ~10-point spread.

Refs #299, #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)