### PR TITLE
ingest: pin the format-contract strings that were only tested by fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ three minutes.
 
 It prints a score per directory rather than one for the whole tree, because the
 weakest surface otherwise hides behind the strongest — the spread is currently
-about ten points (83–94%). The baseline and the triage of every surviving mutant live on
+about eleven points (83–94%). The baseline and the triage of every surviving mutant live on
 [#299](https://github.com/xavierbriand/sluice/issues/299); the gaps it found are
 tracked as their own issues rather than fixed inline, so the cost of each stays
 visible. No score threshold is enforced yet, deliberately: [#321](https://github.com/xavierbriand/sluice/issues/321)

--- a/src/ingest/__fixtures__/build.ts
+++ b/src/ingest/__fixtures__/build.ts
@@ -19,8 +19,10 @@ export interface FixtureRow {
   readonly operationType?: string;
   readonly notes?: string;
   readonly fitId?: string;
+  /** OFX only, ignored by `csvFixture`. */
+  readonly memo?: string;
   /** OFX only, ignored by `csvFixture`: tags to leave out of this transaction's block. */
-  readonly omit?: readonly ('TRNTYPE' | 'DTPOSTED' | 'TRNAMT' | 'FITID' | 'NAME')[];
+  readonly omit?: readonly ('TRNTYPE' | 'DTPOSTED' | 'TRNAMT' | 'FITID' | 'NAME' | 'MEMO')[];
 }
 
 export function csvFixture(rows: readonly FixtureRow[]): Uint8Array {
@@ -62,6 +64,8 @@ export interface OfxOptions {
   readonly balanceAsOf?: string; // YYYYMMDD
   readonly omitBalance?: boolean;
   readonly omitCurdef?: boolean;
+  /** Ignored when `omitCurdef` is set. Defaults to 'EUR', same as every real export seen so far. */
+  readonly currency?: string;
 }
 
 function ofxDate(french: string): string {
@@ -82,6 +86,7 @@ export function ofxFixture(rows: readonly FixtureRow[], options: OfxOptions = {}
     balanceAsOf = to,
     omitBalance = false,
     omitCurdef = false,
+    currency = 'EUR',
   } = options;
 
   const body = rows
@@ -94,6 +99,7 @@ export function ofxFixture(rows: readonly FixtureRow[], options: OfxOptions = {}
         !omit.has('TRNAMT') && `<TRNAMT>${ofxAmount(r.amount)}`,
         !omit.has('FITID') && `<FITID>${r.fitId ?? `FIT${i + 1}`}`,
         !omit.has('NAME') && `<NAME>${r.label ?? 'MERCHANT'}`,
+        !omit.has('MEMO') && `<MEMO>${r.memo ?? 'NOTE'}`,
         '</STMTTRN>',
       ];
       return lines.filter((l): l is string => l !== false).join('\r\n');
@@ -137,7 +143,7 @@ export function ofxFixture(rows: readonly FixtureRow[], options: OfxOptions = {}
     '<SEVERITY>INFO',
     '</STATUS>',
     '<STMTRS>',
-    ...(omitCurdef ? [] : ['<CURDEF>EUR']),
+    ...(omitCurdef ? [] : [`<CURDEF>${currency}`]),
     '<BANKACCTFROM>',
     `<ACCTID>${accountId}</ACCTID>`,
     '</BANKACCTFROM>',

--- a/src/ingest/csv.test.ts
+++ b/src/ingest/csv.test.ts
@@ -95,6 +95,10 @@ describe('parseCsv', () => {
     expect(() => parseCsv(Buffer.from('', 'latin1'), 'export.csv')).toThrow(/is empty/);
   });
 
+  it('names the file "export.csv" when no caller says otherwise', () => {
+    expect(() => parseCsv(Buffer.from('', 'latin1'))).toThrow(/export\.csv/);
+  });
+
   it('tolerates bare \n line endings, not just \r\n', () => {
     // Every fixture in the suite builds \r\n files, since that is what the bank
     // actually emits — so the /\r?\n/ split's tolerance for a bare \n had never

--- a/src/ingest/csv.ts
+++ b/src/ingest/csv.ts
@@ -52,6 +52,8 @@ export interface CsvRow {
   readonly line: number;
 }
 
+// Prose and `this.name` deliberately left surviving — see the comment on
+// DateParseError in src/core/dates.ts.
 export class CsvFormatError extends Error {
   constructor(message: string) {
     super(message);
@@ -93,6 +95,13 @@ export function parseCsv(bytes: Uint8Array, filename = 'export.csv'): CsvRow[] {
     }
   }
 
+  // The `?? ''` can never run: `columns.length !== CSV_COLUMNS.length` has
+  // already thrown above for the header, and every data row is checked
+  // against the same length below before `at` is ever called on it, so
+  // `CSV_COLUMNS.indexOf(name)` — always a valid index into `CSV_COLUMNS`,
+  // since `name` is drawn from that same tuple — is always a valid index
+  // into `cells` too. Exists only to satisfy `noUncheckedIndexedAccess`,
+  // same shape as `money.ts`'s documented `whole = '0'`.
   const at = (cells: string[], name: (typeof CSV_COLUMNS)[number]) =>
     cells[CSV_COLUMNS.indexOf(name)] ?? '';
 

--- a/src/ingest/csv.ts
+++ b/src/ingest/csv.ts
@@ -52,8 +52,7 @@ export interface CsvRow {
   readonly line: number;
 }
 
-// Prose and `this.name` deliberately left surviving — see the comment on
-// DateParseError in src/core/dates.ts.
+// Prose and `this.name` deliberately left surviving — see CLAUDE.md.
 export class CsvFormatError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/ingest/join.ts
+++ b/src/ingest/join.ts
@@ -23,6 +23,8 @@ export interface JoinedRow {
   readonly csv: CsvRow;
 }
 
+// Prose and `this.name` deliberately left surviving — see the comment on
+// DateParseError in src/core/dates.ts.
 export class JoinMismatchError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/ingest/join.ts
+++ b/src/ingest/join.ts
@@ -23,8 +23,7 @@ export interface JoinedRow {
   readonly csv: CsvRow;
 }
 
-// Prose and `this.name` deliberately left surviving — see the comment on
-// DateParseError in src/core/dates.ts.
+// Prose and `this.name` deliberately left surviving — see CLAUDE.md.
 export class JoinMismatchError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/ingest/ledger.ts
+++ b/src/ingest/ledger.ts
@@ -111,6 +111,8 @@ export function toTransactions(rows: readonly JoinedRow[], source: Source): Tran
   }));
 }
 
+// Prose and `this.name` deliberately left surviving — see the comment on
+// DateParseError in src/core/dates.ts.
 export class DuplicateTransactionError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/ingest/ledger.ts
+++ b/src/ingest/ledger.ts
@@ -111,8 +111,7 @@ export function toTransactions(rows: readonly JoinedRow[], source: Source): Tran
   }));
 }
 
-// Prose and `this.name` deliberately left surviving — see the comment on
-// DateParseError in src/core/dates.ts.
+// Prose and `this.name` deliberately left surviving — see CLAUDE.md.
 export class DuplicateTransactionError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/ingest/load.ts
+++ b/src/ingest/load.ts
@@ -31,6 +31,8 @@ export interface Ledger extends LedgerData {
   readonly reconciliation: ReconciliationReport;
 }
 
+// Prose and `this.name` deliberately left surviving — see the comment on
+// DateParseError in src/core/dates.ts.
 export class ExportsNotFoundError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);

--- a/src/ingest/load.ts
+++ b/src/ingest/load.ts
@@ -31,8 +31,7 @@ export interface Ledger extends LedgerData {
   readonly reconciliation: ReconciliationReport;
 }
 
-// Prose and `this.name` deliberately left surviving — see the comment on
-// DateParseError in src/core/dates.ts.
+// Prose and `this.name` deliberately left surviving — see CLAUDE.md.
 export class ExportsNotFoundError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);

--- a/src/ingest/ofx.test.ts
+++ b/src/ingest/ofx.test.ts
@@ -90,17 +90,34 @@ describe('parseOfx', () => {
     expect(statement.transactions.map((t) => t.amount)).toEqual([-1000, -2000]);
   });
 
-  it('treats an absent TRNTYPE or NAME as empty, not as missing', () => {
-    // Unlike FITID/DTPOSTED/TRNAMT, these two are read with `?? ''` rather
-    // than `required()` — a card statement's memo-only rows have been seen
-    // without a NAME. The `?? ''` fallbacks on both had no test reaching them.
+  it('treats an absent TRNTYPE, NAME or MEMO as empty, not as missing', () => {
+    // Unlike FITID/DTPOSTED/TRNAMT, these are read with `?? ''` rather than
+    // `required()` — a card statement's memo-only rows have been seen without
+    // a NAME. The `?? ''` fallbacks had no test reaching them.
     const statement = parseOfx(
-      ofxFixture([{ postedOn: '01/08/2026', amount: '-10,00', omit: ['TRNTYPE', 'NAME'] }], {
+      ofxFixture([{ postedOn: '01/08/2026', amount: '-10,00', omit: ['TRNTYPE', 'NAME', 'MEMO'] }], {
         to: '20260815',
       }),
     );
     expect(statement.transactions[0]?.type).toBe('');
     expect(statement.transactions[0]?.name).toBe('');
+    expect(statement.transactions[0]?.memo).toBe('');
+  });
+
+  it('reads TRNTYPE, NAME and MEMO when they are present, not just their fallback', () => {
+    // The omit test above proves the `?? ''` fallback works; it cannot prove
+    // the tag lookup itself is right, because a corrupted tag name (`'TRNTYPE'`
+    // read as garbage) falls back to the same `''` and passes it too. A
+    // present, distinctive value is the only thing that tells the two apart.
+    // No fixture had ever set a `<MEMO>` at all before this.
+    const statement = parseOfx(
+      ofxFixture([{ postedOn: '01/08/2026', amount: '-10,00', label: 'COTISATION', memo: 'ANNUAL FEE' }], {
+        to: '20260815',
+      }),
+    );
+    expect(statement.transactions[0]?.type).toBe('DEBIT');
+    expect(statement.transactions[0]?.name).toBe('COTISATION');
+    expect(statement.transactions[0]?.memo).toBe('ANNUAL FEE');
   });
 
   it('defaults the currency to EUR when CURDEF is absent', () => {
@@ -108,6 +125,20 @@ describe('parseOfx', () => {
       ofxFixture([{ postedOn: '01/08/2026', amount: '-10,00' }], { to: '20260815', omitCurdef: true }),
     );
     expect(statement.currency).toBe('EUR');
+  });
+
+  it('reads a non-default currency from CURDEF, not just the EUR fallback', () => {
+    // Every other fixture's CURDEF happens to be 'EUR', which is also the
+    // fallback value — so a corrupted `'CURDEF'` tag name would silently take
+    // the same fallback and no test would have noticed.
+    const statement = parseOfx(
+      ofxFixture([{ postedOn: '01/08/2026', amount: '-10,00' }], { to: '20260815', currency: 'USD' }),
+    );
+    expect(statement.currency).toBe('USD');
+  });
+
+  it('names the file "export.ofx" when no caller says otherwise', () => {
+    expect(() => parseOfx(Buffer.from('just some text', 'latin1'))).toThrow(/export\.ofx/);
   });
 
   it('accepts a statement with no transactions and still reads its balance', () => {

--- a/src/ingest/ofx.ts
+++ b/src/ingest/ofx.ts
@@ -48,6 +48,8 @@ export interface OfxStatement {
   readonly transactions: readonly OfxTransaction[];
 }
 
+// Prose and `this.name` deliberately left surviving — see the comment on
+// DateParseError in src/core/dates.ts.
 export class OfxFormatError extends Error {
   constructor(message: string) {
     super(message);
@@ -78,6 +80,12 @@ export function parseOfx(bytes: Uint8Array, filename = 'export.ofx'): OfxStateme
     throw new OfxFormatError(`${filename}: no <OFX> element — is this an OFX export?`);
   }
 
+  // `preamble`'s default can never run: `String.prototype.split` always
+  // returns at least one element, so destructuring the first one out of the
+  // result never falls through to a default. It exists only to satisfy
+  // `noUncheckedIndexedAccess` — the same shape as `money.ts`'s documented
+  // `whole = '0'`. The split token itself, `'<STMTTRN>'`, is a real
+  // format-contract string and is tested below.
   const [preamble = '', ...txBlocks] = text.split('<STMTTRN>');
 
   const transactions = txBlocks.map((block, i) => {

--- a/src/ingest/ofx.ts
+++ b/src/ingest/ofx.ts
@@ -48,8 +48,7 @@ export interface OfxStatement {
   readonly transactions: readonly OfxTransaction[];
 }
 
-// Prose and `this.name` deliberately left surviving — see the comment on
-// DateParseError in src/core/dates.ts.
+// Prose and `this.name` deliberately left surviving — see CLAUDE.md.
 export class OfxFormatError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/ingest/sources.ts
+++ b/src/ingest/sources.ts
@@ -24,8 +24,7 @@ export type Source =
   | { readonly kind: 'account'; readonly id: string }
   | { readonly kind: 'card'; readonly id: string; readonly cardNumber: string };
 
-// Prose and `this.name` deliberately left surviving — see the comment on
-// DateParseError in src/core/dates.ts.
+// Prose and `this.name` deliberately left surviving — see CLAUDE.md.
 export class SourceNameError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/ingest/sources.ts
+++ b/src/ingest/sources.ts
@@ -24,6 +24,8 @@ export type Source =
   | { readonly kind: 'account'; readonly id: string }
   | { readonly kind: 'card'; readonly id: string; readonly cardNumber: string };
 
+// Prose and `this.name` deliberately left surviving — see the comment on
+// DateParseError in src/core/dates.ts.
 export class SourceNameError extends Error {
   constructor(message: string) {
     super(message);
@@ -49,6 +51,13 @@ export function sourceOf(filename: string): Source {
     );
   }
 
+  // Both `?? ''` fallbacks below are dead code, not gaps: `m[1]` and
+  // `card[1]` come from `(.+?)` and `(\d{4})`, neither marked optional with
+  // a trailing `?`, so whenever the surrounding regex matches at all the
+  // group has matched too and is a defined string. TypeScript can't express
+  // "this capture group is mandatory," hence `noUncheckedIndexedAccess`
+  // forcing the fallback — but the runtime value can't miss. Same shape as
+  // `money.ts`'s documented `whole = '0'`.
   const stem = (m[1] ?? '').toLowerCase();
   const card = CARD_STEM.exec(stem);
   if (card) return { kind: 'card', id: stem, cardNumber: card[1] ?? '' };


### PR DESCRIPTION
## Summary

Closes #324. Before writing any test, re-checked every claim in the issue against the current mutation report rather than trusting it — the same discipline that caught #312/#314/#316 being mis-diagnosed earlier in this backlog.

**Real gaps, fixed:**
- TRNTYPE, NAME, MEMO, CURDEF: the `?? fallback` path was tested (an omitted tag falls back correctly), but the *tag-name lookup itself* wasn't — a corrupted `'TRNTYPE'`/`'NAME'`/`'CURDEF'` literal silently takes the same fallback value and no existing test would notice. MEMO was worse: no fixture had ever set a `<MEMO>` tag at all, so the field was untested in both directions.
- The `filename = 'export.ofx'`/`'export.csv'` parameter defaults — same shape as #328's `where` defaults, same one-line fix.

**Two of #324's "priority" items turn out to be equivalent mutants, not gaps** (confirmed against `mutation.json`'s `NoCoverage` status, and independently by reasoning about the invariants):
- `csv.ts`'s `cells[...] ?? ''` — the column count is already validated equal above every call site, so the fallback can never execute.
- `sources.ts`'s two `?? ''` capture-group fallbacks — both regex groups are mandatory (no trailing `?`), so when the surrounding match succeeds the group is always a defined string.

Documented in place, same treatment as `money.ts`'s already-documented `whole = '0'`.

**Decision, not configured away:** left the ~39 prose survivors across ingest undocumented by exclusion — #323's own review found the per-file `StringLiteral` exclusion over-suppresses, and ingest's prose lines sit next to real contract lines rather than isolated the way `schema.ts`/`values.ts` are. `this.name` across all six ingest error classes points back at #328's write-up instead of re-deciding the same question six times.

## Verification

- `npm run check` — 364 tests pass.
- `npm run mutate` — `src/ingest` moved from 85.25% to 86.78% (73 → 65 survivors). Confirmed via `mutation.json`: every targeted tag-identity and filename-default mutant is now `Killed`; the three "equivalent" defaults are still `NoCoverage`, which is the expected signature of dead code rather than a regression.
- `README.md`'s mutation-spread line updated to this branch's own measurement.

Refs #299, #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)