### PR TITLE
app: bring app/_lib into the tested and mutated surface, close #322

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ here means finding one to cut.
   asserts `err.name`; every catch site matches by `instanceof` or
   `toThrow(SomeErrorClass)`. Applies project-wide — filed once as a decision
   on #328 rather than re-argued per class.
+- **`app/_lib/` is unit- and mutation-tested like `src/`; the rest of `app/`
+  (components, routes) isn't.** `app/_lib/today.ts` is the product's only
+  clock and `chart.ts` feeds what the axes show — both can produce the wrong
+  number this project's reviews keep finding. `telemetry.ts` sits in
+  `app/_lib` too but is deliberately excluded from the same guarantee: every
+  error in it is swallowed, so it structurally can't produce one (see the
+  comment at the top of that file).
 - **There's no `docs/` folder, and no process documentation lives in this
   repo.** v0.1 had one — 201 lines of `CLAUDE.md` deferring to it, and 72%
   of that version's effort went to process instead of product. Anything

--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ reports which mutations no test objects to. It sits outside `check` on purpose �
 three minutes.
 
 It prints a score per directory rather than one for the whole tree, because the
-weakest surface otherwise hides behind the strongest — the spread is currently
-about eleven points (83–94%). The baseline and the triage of every surviving mutant live on
+weakest surface otherwise hides behind the strongest — the spread across `src/`
+is currently about eleven points (83–94%). `app/_lib/` joined the measured
+surface in [#322](https://github.com/xavierbriand/sluice/issues/322) and holds a
+much lower score by design, not by neglect: it includes `telemetry.ts`, whose
+errors are deliberately swallowed and so cannot produce the kind of wrong number
+this project's mutation testing exists to catch — see `CLAUDE.md`. The baseline
+and the triage of every surviving mutant live on
 [#299](https://github.com/xavierbriand/sluice/issues/299); the gaps it found are
 tracked as their own issues rather than fixed inline, so the cost of each stays
 visible. No score threshold is enforced yet, deliberately: [#321](https://github.com/xavierbriand/sluice/issues/321)

--- a/app/_lib/chart.test.ts
+++ b/app/_lib/chart.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { niceMax } from './chart.ts';
+
+describe('niceMax', () => {
+  it('floors non-positive values to 1, not 0 or a negative tick', () => {
+    expect(niceMax(0)).toBe(1);
+    expect(niceMax(-5)).toBe(1);
+  });
+
+  it('rounds up to the nearest 1 × a power of ten', () => {
+    expect(niceMax(1)).toBe(1);
+    expect(niceMax(100)).toBe(100);
+  });
+
+  it('rounds up to the nearest 2 × a power of ten', () => {
+    expect(niceMax(150)).toBe(200);
+  });
+
+  it('rounds up to the nearest 5 × a power of ten', () => {
+    expect(niceMax(3)).toBe(5);
+    expect(niceMax(45)).toBe(50);
+  });
+
+  it('rounds up to the nearest 10 × a power of ten, the top of the step list', () => {
+    expect(niceMax(7)).toBe(10);
+    expect(niceMax(999)).toBe(1000);
+  });
+
+  it('leaves an exact step untouched, rather than rounding up past it', () => {
+    expect(niceMax(500)).toBe(500);
+    expect(niceMax(2000)).toBe(2000);
+  });
+});

--- a/app/_lib/chart.ts
+++ b/app/_lib/chart.ts
@@ -7,6 +7,13 @@ export function niceMax(value: number): number {
   if (value <= 0) return 1;
   const magnitude = 10 ** Math.floor(Math.log10(value));
   const steps = [1, 2, 5, 10];
+  // `?? 10` can never run: by construction of `magnitude`,
+  // `10 * magnitude > value` always holds (that is what `Math.floor` on the
+  // log means), so `steps` — which ends in `10` — always finds a match
+  // before `.find` runs out. Verified by sweep, including exact powers of
+  // ten where floating-point `Math.log10` could in principle round the
+  // wrong way: zero fallback hits across every exponent -10..15 crossed
+  // with 10,000 multiples, plus every exact power of ten up to 10^20.
   const step = steps.find((s) => s * magnitude >= value) ?? 10;
   return step * magnitude;
 }

--- a/app/_lib/telemetry.ts
+++ b/app/_lib/telemetry.ts
@@ -1,6 +1,18 @@
 import { randomBytes } from 'node:crypto';
 
 /**
+ * Deliberately untested, unlike the rest of `app/_lib/` — see CLAUDE.md.
+ * `CLAUDE.md` names this project's whole defect class in one line: a
+ * plausible wrong number, never a crash. Nothing in this file can produce
+ * one — every error is swallowed (`.catch(() => {})` below), the call never
+ * blocks a render, and the only consumer of its output is an optional
+ * external collector the page itself never reads. Mutation-testing it would
+ * mean writing `fetch`-mocking and module-reimport machinery to chase a
+ * score for bugs that, if they existed, wouldn't be this project's kind of
+ * bug — measuring process rather than product, the thing the README says
+ * v0.1 over-invested in. Left inside the `mutate` glob anyway, so its low
+ * score is visible rather than quietly excluded.
+ *
  * Spans for the reserved `service.name=sluice` workload
  * `observability/README.md` already describes, over the identical transport
  * `observability/hooks/session-outcome.ts` uses: raw OTLP/HTTP JSON over

--- a/app/_lib/today.test.ts
+++ b/app/_lib/today.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { todayAsDay } from './today.ts';
+
+describe('todayAsDay', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads the date the wall clock is currently on', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 22));
+    expect(todayAsDay()).toBe('2026-08-22');
+  });
+
+  it('pads a single-digit month and day, not just double-digit ones', () => {
+    // Every other date this project's fixtures use happens to be two digits
+    // on both sides. A dropped `+ 1` on the month or a swapped `padStart`
+    // argument would only show up on the days this test picks.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 3));
+    expect(todayAsDay()).toBe('2026-01-03');
+  });
+});

--- a/scripts/mutation-summary.mjs
+++ b/scripts/mutation-summary.mjs
@@ -56,7 +56,7 @@ for (const [file, entry] of Object.entries(report.files)) {
 }
 
 const rows = [['scope', 'valid', 'score', 'covered', 'survived', 'no cov', 'timeout']];
-for (const [name, counts] of [['all of src', total], ...[...byDir].sort()]) {
+for (const [name, counts] of [['all files', total], ...[...byDir].sort()]) {
   const c = /** @type {Record<string, number>} */ (counts);
   const { detected, valid, covered } = score(c);
   rows.push([

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -37,12 +37,20 @@ export default {
   // not `__fixtures__/`. Both exclusions are restated here because the positive
   // glob is `src/**/*.ts` rather than the default's, so nothing is inherited.
   // Fixtures are test scaffolding — mutating them measures nothing.
+  //
+  // `app/_lib/**/*.ts` is included too, and the rest of `app/` (components,
+  // routes) deliberately is not — see CLAUDE.md for the reasoning. This is
+  // the first surface outside `src/` this file mutates, so its own score
+  // shows up as its own row in the report rather than folding into an
+  // aggregate that would hide it either way.
   mutate: [
     'src/**/*.ts',
     '!src/**/*.test.ts',
     '!src/**/*.spec.ts',
     '!src/**/__tests__/**',
     '!src/**/__fixtures__/**',
+    'app/_lib/**/*.ts',
+    '!app/_lib/**/*.test.ts',
   ],
 
   // Stryker rewrites tsconfig.json when copying into the sandbox, to fix up

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'app/_lib/**/*.test.ts'],
     environment: 'node',
   },
 });


### PR DESCRIPTION
## Summary

Closes #322. Decision: test `today.ts` and `chart.ts` for real; leave `telemetry.ts` in the *measured* surface but not the *tested* one, deliberately.

`CLAUDE.md` states this project's whole defect class in one line: "a plausible wrong number, never a crash." `today.ts` feeds every figure on the page and `chart.ts` feeds what the axes show — both are squarely that class, and `today.ts` is the product's only clock. `telemetry.ts` structurally can't produce a wrong number: every error is swallowed, the call is fire-and-forget, and its output goes to an optional collector the page never reads. Writing fetch-mocking and module-reimport machinery to chase its score would be measuring process, which is exactly what the README says v0.1 over-invested in. It stays in the `mutate` glob anyway — visible at a low score by design, not silently excluded — with a comment recording why.

**Changes:**
- `vitest.config.ts` / `stryker.config.mjs`: widen to `app/_lib/**` (not the rest of `app/`).
- `app/_lib/today.test.ts`, `app/_lib/chart.test.ts`: new, colocated like `src/`'s convention.
- `app/_lib/telemetry.ts`: decision comment at the top.
- `CLAUDE.md`: new bullet recording the `app/_lib`-vs-rest-of-`app/` boundary (rule 6: doc updates land in the same PR).
- `scripts/mutation-summary.mjs`: the total row was hardcoded `"all of src"`; relabelled `"all files"` now that the glob reaches outside `src/`.
- `README.md`: the mutation-spread line was already stale before this PR; corrected and scoped to `src/`, with `app/_lib`'s by-design-lower score called out separately.

## Verification

- `npm run check` — 368 tests pass (27 files, up from 25).
- `npm run build` — first `.test.ts` files ever placed under `app/`; confirmed Next produces no route from them.
- `npm run mutate` — `today.ts` and `chart.ts` both score **100%** (4/4 and 14/14 killed). `telemetry.ts` is 43/43 `NoCoverage`, exactly the deliberate-and-visible outcome the decision above describes, confirmed via `mutation.json` per-file breakdown, not the aggregate.
- The `chart.ts` `?? 10` fallback's unreachability (documented in a comment) was verified by sweep before deciding not to write a test for it: zero fallback hits across exponents -10..15 × 10,000 multiples, plus every exact power of ten to 10^20 (checking float-precision edge cases in `Math.log10`).

Refs #299, #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)